### PR TITLE
Remove unnecessary verbs for endpoints

### DIFF
--- a/deploy/kubernetes/setup-csi-snapshotter.yaml
+++ b/deploy/kubernetes/setup-csi-snapshotter.yaml
@@ -31,7 +31,7 @@ rules:
     verbs: ["list", "watch", "create", "update", "patch"]
   - apiGroups: [""]
     resources: ["endpoints"]
-    verbs: ["list", "watch", "create", "update", "delete", "get"]
+    verbs: ["update", "get"]
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "list"]


### PR DESCRIPTION
This PR removes unnecessary verbs for "endpoints" resource in the deployment yaml file.