### PR TITLE
Handle the CSI driver in VolumeSnapshotContent does not match case

### DIFF
--- a/pkg/controller/framework_test.go
+++ b/pkg/controller/framework_test.go
@@ -34,6 +34,7 @@ import (
 	crdv1 "github.com/kubernetes-csi/external-snapshotter/pkg/apis/volumesnapshot/v1alpha1"
 	clientset "github.com/kubernetes-csi/external-snapshotter/pkg/client/clientset/versioned"
 	"github.com/kubernetes-csi/external-snapshotter/pkg/client/clientset/versioned/fake"
+	snapshotscheme "github.com/kubernetes-csi/external-snapshotter/pkg/client/clientset/versioned/scheme"
 	informers "github.com/kubernetes-csi/external-snapshotter/pkg/client/informers/externalversions"
 	storagelisters "github.com/kubernetes-csi/external-snapshotter/pkg/client/listers/volumesnapshot/v1alpha1"
 	"k8s.io/api/core/v1"
@@ -48,6 +49,7 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
 	kubefake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/kubernetes/scheme"
 	core "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
@@ -786,6 +788,14 @@ func newContentArray(name, className, snapshotHandle, volumeUID, volumeName, bou
 	}
 }
 
+func newContentWithUnmatchDriverArray(name, className, snapshotHandle, volumeUID, volumeName, boundToSnapshotUID, boundToSnapshotName string, size *int64, creationTime *int64) []*crdv1.VolumeSnapshotContent {
+	content := newContent(name, className, snapshotHandle, volumeUID, volumeName, boundToSnapshotUID, boundToSnapshotName, size, creationTime)
+	content.Spec.VolumeSnapshotSource.CSI.Driver = "fake"
+	return []*crdv1.VolumeSnapshotContent{
+		content,
+	}
+}
+
 func newSnapshot(name, className, boundToContent, snapshotUID, claimName string, ready bool, err *storagev1beta1.VolumeError, creationTime *metav1.Time, size *resource.Quantity) *crdv1.VolumeSnapshot {
 	snapshot := crdv1.VolumeSnapshot{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1005,6 +1015,7 @@ func evaluateTestResults(ctrl *csiSnapshotController, reactor *snapshotReactor, 
 //    controllerTest.testCall *once*.
 // 3. Compare resulting contents and snapshots with expected contents and snapshots.
 func runSyncTests(t *testing.T, tests []controllerTest, snapshotClasses []*crdv1.VolumeSnapshotClass) {
+	snapshotscheme.AddToScheme(scheme.Scheme)
 	for _, test := range tests {
 		glog.V(4).Infof("starting test %q", test.name)
 
@@ -1023,8 +1034,10 @@ func runSyncTests(t *testing.T, tests []controllerTest, snapshotClasses []*crdv1
 			reactor.snapshots[snapshot.Name] = snapshot
 		}
 		for _, content := range test.initialContents {
-			ctrl.contentStore.Add(content)
-			reactor.contents[content.Name] = content
+			if ctrl.isDriverMatch(test.initialContents[0]) {
+				ctrl.contentStore.Add(content)
+				reactor.contents[content.Name] = content
+			}
 		}
 		for _, claim := range test.initialClaims {
 			reactor.claims[claim.Name] = claim

--- a/pkg/controller/snapshot_ready_test.go
+++ b/pkg/controller/snapshot_ready_test.go
@@ -232,6 +232,26 @@ func TestSync(t *testing.T) {
 			errors:            noerrors,
 			test:              testSyncSnapshot,
 		},
+		{
+			name:              "3-5 - snapshot bound to content in which the driver does not match",
+			initialContents:   newContentWithUnmatchDriverArray("content3-5", validSecretClass, "sid3-5", "vuid3-5", "volume3-5", "", "snap3-5", nil, nil),
+			expectedContents:  nocontents,
+			initialSnapshots:  newSnapshotArray("snap3-5", validSecretClass, "content3-5", "snapuid3-5", "claim3-5", false, nil, nil, nil),
+			expectedSnapshots: newSnapshotArray("snap3-5", validSecretClass, "content3-5", "snapuid3-5", "claim3-5", false, newVolumeError("VolumeSnapshotContent is missing"), nil, nil),
+			expectedEvents:    []string{"Warning SnapshotContentMissing"},
+			errors:            noerrors,
+			test:              testSyncSnapshotError,
+		},
+		{
+			name:              "3-6 - snapshot bound to content in which the snapshot uid does not match",
+			initialContents:   newContentArray("content3-4", validSecretClass, "sid3-4", "vuid3-4", "volume3-4", "snapuid3-4-x", "snap3-6", nil, nil),
+			expectedContents:  newContentArray("content3-4", validSecretClass, "sid3-4", "vuid3-4", "volume3-4", "snapuid3-4-x", "snap3-6", nil, nil),
+			initialSnapshots:  newSnapshotArray("snap3-5", validSecretClass, "content3-5", "snapuid3-5", "claim3-5", false, nil, nil, nil),
+			expectedSnapshots: newSnapshotArray("snap3-5", validSecretClass, "content3-5", "snapuid3-5", "claim3-5", false, newVolumeError("VolumeSnapshotContent is missing"), nil, nil),
+			expectedEvents:    []string{"Warning SnapshotContentMissing"},
+			errors:            noerrors,
+			test:              testSyncSnapshotError,
+		},
 	}
 
 	runSyncTests(t, tests, snapshotClasses)


### PR DESCRIPTION
In VolumeSnapshotContent, if the CSI driver does not match the plugin's,
the controller should skip this content instead of always processing it.
This PR also add a few tests related to snapshot and content static
binding.

During binding, if content specify its bound snapshot uid and it
does not match the snapshot's uid, the content object and also the
physical snapshot will be deleted. In this case, the controller will
treat the content as an orphan content because its snapshot object does
not exist (deleted) any more.