### PR TITLE
Use existing content name

### DIFF
--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -106,6 +106,12 @@ func storeObjectUpdate(store cache.Store, obj interface{}, className string) (bo
 // GetSnapshotContentNameForSnapshot returns SnapshotContent.Name for the create VolumeSnapshotContent.
 // The name must be unique.
 func GetSnapshotContentNameForSnapshot(snapshot *crdv1.VolumeSnapshot) string {
+	// If VolumeSnapshot object has SnapshotContentName, use it directly.
+	// This might be the case for static provisioning.
+	if len(snapshot.Spec.SnapshotContentName) > 0 {
+		return snapshot.Spec.SnapshotContentName
+	}
+	// Construct SnapshotContentName for dynamic provisioning.
 	return "snapcontent-" + string(snapshot.UID)
 }
 


### PR DESCRIPTION
If content name is already in snapshot object, just use it.
This may be the case for static provisioning. Otherwise construct
new name for content for dynamic provisioning.