### PR TITLE
Rename Ready to ReadyToUse

### DIFF
--- a/pkg/apis/volumesnapshot/v1alpha1/types.go
+++ b/pkg/apis/volumesnapshot/v1alpha1/types.go
@@ -96,12 +96,12 @@ type VolumeSnapshotStatus struct {
 	// +optional
 	RestoreSize *resource.Quantity `json:"restoreSize" protobuf:"bytes,2,opt,name=restoreSize"`
 
-	// Ready is set to true only if the snapshot is ready to use (e.g., finish uploading if
+	// ReadyToUse is set to true only if the snapshot is ready to use (e.g., finish uploading if
 	// there is an uploading phase) and also VolumeSnapshot and its VolumeSnapshotContent
-	// bind correctly with each other. If any of the above condition is not true, Ready is
+	// bind correctly with each other. If any of the above condition is not true, ReadyToUse is
 	// set to false
 	// +optional
-	Ready bool `json:"ready" protobuf:"varint,3,opt,name=ready"`
+	ReadyToUse bool `json:"readyToUse" protobuf:"varint,3,opt,name=readyToUse"`
 
 	// The last error encountered during create snapshot operation, if any.
 	// This field must only be set by the entity completing the create snapshot

--- a/pkg/controller/framework_test.go
+++ b/pkg/controller/framework_test.go
@@ -815,7 +815,7 @@ func newSnapshot(name, className, boundToContent, snapshotUID, claimName string,
 		},
 		Status: crdv1.VolumeSnapshotStatus{
 			CreationTime: creationTime,
-			Ready:        ready,
+			ReadyToUse:   ready,
 			Error:        err,
 			RestoreSize:  size,
 		},

--- a/pkg/controller/snapshot_controller.go
+++ b/pkg/controller/snapshot_controller.go
@@ -154,7 +154,7 @@ func (ctrl *csiSnapshotController) syncContent(content *crdv1.VolumeSnapshotCont
 func (ctrl *csiSnapshotController) syncSnapshot(snapshot *crdv1.VolumeSnapshot) error {
 	glog.V(5).Infof("synchonizing VolumeSnapshot[%s]: %s", snapshotKey(snapshot), getSnapshotStatusForLogging(snapshot))
 
-	if !snapshot.Status.Ready {
+	if !snapshot.Status.ReadyToUse {
 		return ctrl.syncUnreadySnapshot(snapshot)
 	} else {
 		return ctrl.syncReadySnapshot(snapshot)
@@ -379,7 +379,7 @@ func (ctrl *csiSnapshotController) updateSnapshotErrorStatusWithEvent(snapshot *
 	}
 	snapshotClone.Status.Error = statusError
 
-	snapshotClone.Status.Ready = false
+	snapshotClone.Status.ReadyToUse = false
 	newSnapshot, err := ctrl.clientset.VolumesnapshotV1alpha1().VolumeSnapshots(snapshotClone.Namespace).Update(snapshotClone)
 	if err != nil {
 		glog.V(4).Infof("updating VolumeSnapshot[%s] error status failed %v", snapshotKey(snapshot), err)
@@ -399,7 +399,7 @@ func (ctrl *csiSnapshotController) updateSnapshotErrorStatusWithEvent(snapshot *
 
 // Stateless functions
 func getSnapshotStatusForLogging(snapshot *crdv1.VolumeSnapshot) string {
-	return fmt.Sprintf("bound to: %q, Completed: %v", snapshot.Spec.SnapshotContentName, snapshot.Status.Ready)
+	return fmt.Sprintf("bound to: %q, Completed: %v", snapshot.Spec.SnapshotContentName, snapshot.Status.ReadyToUse)
 }
 
 func IsSnapshotBound(snapshot *crdv1.VolumeSnapshot, content *crdv1.VolumeSnapshotContent) bool {
@@ -721,7 +721,7 @@ func (ctrl *csiSnapshotController) updateSnapshotStatus(snapshot *crdv1.VolumeSn
 	snapshotClone := snapshot.DeepCopy()
 	if readyToUse {
 		if bound {
-			status.Ready = true
+			status.ReadyToUse = true
 			// Remove the error if checking snapshot is already bound and ready
 			status.Error = nil
 			change = true


### PR DESCRIPTION
This PR renames Ready to ReadyToUse in VolumeSnapshot Status
to be consistent with the name in CSI spec.

This should be added to the release note.