### PR TITLE
Revert "add pvcLister to snapshot controller"

### DIFF
--- a/cmd/csi-snapshotter/main.go
+++ b/cmd/csi-snapshotter/main.go
@@ -37,7 +37,6 @@ import (
 	snapshotscheme "github.com/kubernetes-csi/external-snapshotter/pkg/client/clientset/versioned/scheme"
 	informers "github.com/kubernetes-csi/external-snapshotter/pkg/client/informers/externalversions"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
-	coreinformers "k8s.io/client-go/informers"
 )
 
 const (
@@ -96,7 +95,6 @@ func main() {
 	}
 
 	factory := informers.NewSharedInformerFactory(snapClient, *resyncPeriod)
-	coreFactory := coreinformers.NewSharedInformerFactory(kubeClient, *resyncPeriod)
 
 	// Create CRD resource
 	aeclientset, err := apiextensionsclient.NewForConfig(config)
@@ -167,7 +165,6 @@ func main() {
 		factory.Volumesnapshot().V1alpha1().VolumeSnapshots(),
 		factory.Volumesnapshot().V1alpha1().VolumeSnapshotContents(),
 		factory.Volumesnapshot().V1alpha1().VolumeSnapshotClasses(),
-		coreFactory.Core().V1().PersistentVolumeClaims(),
 		*createSnapshotContentRetryCount,
 		*createSnapshotContentInterval,
 		csiConn,

--- a/pkg/controller/framework_test.go
+++ b/pkg/controller/framework_test.go
@@ -46,11 +46,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
-	coreinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	kubefake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
-	corelisters "k8s.io/client-go/listers/core/v1"
 	core "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
@@ -722,8 +720,6 @@ func newTestController(kubeClient kubernetes.Interface, clientset clientset.Inte
 		informerFactory = informers.NewSharedInformerFactory(clientset, NoResyncPeriodFunc())
 	}
 
-	coreFactory := coreinformers.NewSharedInformerFactory(kubeClient, NoResyncPeriodFunc())
-
 	// Construct controller
 	csiConnection := &fakeCSIConnection{
 		t:           t,
@@ -739,7 +735,6 @@ func newTestController(kubeClient kubernetes.Interface, clientset clientset.Inte
 		informerFactory.Volumesnapshot().V1alpha1().VolumeSnapshots(),
 		informerFactory.Volumesnapshot().V1alpha1().VolumeSnapshotContents(),
 		informerFactory.Volumesnapshot().V1alpha1().VolumeSnapshotClasses(),
-		coreFactory.Core().V1().PersistentVolumeClaims(),
 		3,
 		5*time.Millisecond,
 		csiConnection,
@@ -1057,14 +1052,9 @@ func runSyncTests(t *testing.T, tests []controllerTest, snapshotClasses []*crdv1
 				reactor.contents[content.Name] = content
 			}
 		}
-
-		pvcIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
 		for _, claim := range test.initialClaims {
 			reactor.claims[claim.Name] = claim
-			pvcIndexer.Add(claim)
 		}
-		ctrl.pvcLister = corelisters.NewPersistentVolumeClaimLister(pvcIndexer)
-
 		for _, volume := range test.initialVolumes {
 			reactor.volumes[volume.Name] = volume
 		}

--- a/pkg/controller/snapshot_controller.go
+++ b/pkg/controller/snapshot_controller.go
@@ -947,9 +947,9 @@ func (ctrl *csiSnapshotController) getClaimFromVolumeSnapshot(snapshot *crdv1.Vo
 		return nil, fmt.Errorf("the snapshot source does not have the right APIGroup. Expected empty string, Got %s", *(snapshot.Spec.Source.APIGroup))
 	}
 
-	pvc, err := ctrl.pvcLister.PersistentVolumeClaims(snapshot.Namespace).Get(pvcName)
+	pvc, err := ctrl.client.CoreV1().PersistentVolumeClaims(snapshot.Namespace).Get(pvcName, metav1.GetOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve PVC %s from the lister: %q", pvcName, err)
+		return nil, fmt.Errorf("failed to retrieve PVC %s from the API server: %q", pvcName, err)
 	}
 
 	return pvc, nil

--- a/pkg/controller/snapshot_create_test.go
+++ b/pkg/controller/snapshot_create_test.go
@@ -255,7 +255,7 @@ func TestCreateSnapshotSync(t *testing.T) {
 			initialContents:   nocontents,
 			expectedContents:  nocontents,
 			initialSnapshots:  newSnapshotArray("snap7-4", classGold, "", "snapuid7-4", "claim7-4", false, nil, nil, nil),
-			expectedSnapshots: newSnapshotArray("snap7-4", classGold, "", "snapuid7-4", "claim7-4", false, newVolumeError("Failed to create snapshot: failed to get input parameters to create snapshot snap7-4: \"failed to retrieve PVC claim7-4 from the lister: \\\"persistentvolumeclaim \\\\\\\"claim7-4\\\\\\\" not found\\\"\""), nil, nil),
+			expectedSnapshots: newSnapshotArray("snap7-4", classGold, "", "snapuid7-4", "claim7-4", false, newVolumeError("Failed to create snapshot: failed to get input parameters to create snapshot snap7-4: \"failed to retrieve PVC claim7-4 from the API server: \\\"cannot find claim claim7-4\\\"\""), nil, nil),
 			initialVolumes:    newVolumeArray("volume7-4", "pv-uid7-4", "pv-handle7-4", "1Gi", "pvc-uid7-4", "claim7-4", v1.VolumeBound, v1.PersistentVolumeReclaimDelete, classEmpty),
 			expectedEvents:    []string{"Warning SnapshotCreationFailed"},
 			errors:            noerrors,


### PR DESCRIPTION
Reverts kubernetes-csi/external-snapshotter#72

PR #72 caused a hang when creating a snapshot.  As a result, the snapshot was never created.  Need to revert it.