### PR TITLE
Add new reserved prefixed parameter keys

### DIFF
--- a/pkg/controller/csi_handler.go
+++ b/pkg/controller/csi_handler.go
@@ -65,7 +65,11 @@ func (handler *csiHandler) CreateSnapshot(snapshot *crdv1.VolumeSnapshot, volume
 	if err != nil {
 		return "", "", 0, 0, false, err
 	}
-	return handler.csiConnection.CreateSnapshot(ctx, snapshotName, volume, parameters, snapshotterCredentials)
+	newParameters, err := removePrefixedParameters(parameters)
+	if err != nil {
+		return "", "", 0, 0, false, fmt.Errorf("failed to remove CSI Parameters of prefixed keys: %v", err)
+	}
+	return handler.csiConnection.CreateSnapshot(ctx, snapshotName, volume, newParameters, snapshotterCredentials)
 }
 
 func (handler *csiHandler) DeleteSnapshot(content *crdv1.VolumeSnapshotContent, snapshotterCredentials map[string]string) error {

--- a/pkg/controller/snapshot_controller.go
+++ b/pkg/controller/snapshot_controller.go
@@ -542,11 +542,11 @@ func (ctrl *csiSnapshotController) getCreateSnapshotInput(snapshot *crdv1.Volume
 	contentName := GetSnapshotContentNameForSnapshot(snapshot)
 
 	// Resolve snapshotting secret credentials.
-	snapshotterSecretRef, err := GetSecretReference(class.Parameters, contentName, snapshot)
+	snapshotterSecretRef, err := getSecretReference(class.Parameters, contentName, snapshot)
 	if err != nil {
 		return nil, nil, "", nil, err
 	}
-	snapshotterCredentials, err := GetCredentials(ctrl.client, snapshotterSecretRef)
+	snapshotterCredentials, err := getCredentials(ctrl.client, snapshotterSecretRef)
 	if err != nil {
 		return nil, nil, "", nil, err
 	}
@@ -710,11 +710,11 @@ func (ctrl *csiSnapshotController) deleteSnapshotContentOperation(content *crdv1
 		if snapshotClass, err := ctrl.classLister.Get(*snapshotClassName); err == nil {
 			// Resolve snapshotting secret credentials.
 			// No VolumeSnapshot is provided when resolving delete secret names, since the VolumeSnapshot may or may not exist at delete time.
-			snapshotterSecretRef, err := GetSecretReference(snapshotClass.Parameters, content.Name, nil)
+			snapshotterSecretRef, err := getSecretReference(snapshotClass.Parameters, content.Name, nil)
 			if err != nil {
 				return err
 			}
-			snapshotterCredentials, err = GetCredentials(ctrl.client, snapshotterSecretRef)
+			snapshotterCredentials, err = getCredentials(ctrl.client, snapshotterSecretRef)
 			if err != nil {
 				return err
 			}

--- a/pkg/controller/snapshot_create_test.go
+++ b/pkg/controller/snapshot_create_test.go
@@ -230,7 +230,7 @@ func TestCreateSnapshotSync(t *testing.T) {
 			initialContents:   nocontents,
 			expectedContents:  nocontents,
 			initialSnapshots:  newSnapshotArray("snap7-2", invalidSecretClass, "", "snapuid7-2", "claim7-2", false, nil, nil, nil),
-			expectedSnapshots: newSnapshotArray("snap7-2", invalidSecretClass, "", "snapuid7-2", "claim7-2", false, newVolumeError("Failed to create snapshot: failed to get input parameters to create snapshot snap7-2: \"csiSnapshotterSecretName and csiSnapshotterSecretNamespace parameters must be specified together\""), nil, nil),
+			expectedSnapshots: newSnapshotArray("snap7-2", invalidSecretClass, "", "snapuid7-2", "claim7-2", false, newVolumeError("Failed to create snapshot: failed to get input parameters to create snapshot snap7-2: \"failed to get name and namespace template from params: either name and namespace for Snapshotter secrets specified, Both must be specified\""), nil, nil),
 			initialClaims:     newClaimArray("claim7-2", "pvc-uid7-2", "1Gi", "volume7-2", v1.ClaimBound, &classEmpty),
 			initialVolumes:    newVolumeArray("volume7-2", "pv-uid7-2", "pv-handle7-2", "1Gi", "pvc-uid7-2", "claim7-2", v1.VolumeBound, v1.PersistentVolumeReclaimDelete, classEmpty),
 			expectedEvents:    []string{"Warning SnapshotCreationFailed"},


### PR DESCRIPTION
This PR adds new reserved prefixed parameter keys which are stripped
out of parameter list, and adds deprecation notice for old keys and
keep their behavior the same.

```
csiParameterPrefix = "csi.storage.k8s.io/"
prefixedSnapshotterSecretNameKey      = csiParameterPrefix + "snapshotter-secret-name"
prefixedSnapshotterSecretNamespaceKey = csiParameterPrefix + "snapshotter-secret-namespace"
```

This fix is modeled after a similar fix in external-provisioner: https://github.com/kubernetes-csi/external-provisioner/pull/178 

/assign @davidz627 @jingxu97 @saad-ali @msau42