### PR TITLE
Fix #89: Increase probe timeout

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -754,7 +754,6 @@
     "github.com/kubernetes-csi/csi-test/driver",
     "google.golang.org/grpc",
     "google.golang.org/grpc/codes",
-    "google.golang.org/grpc/connectivity",
     "google.golang.org/grpc/status",
     "k8s.io/api/core/v1",
     "k8s.io/api/storage/v1",

--- a/cmd/csi-snapshotter/main.go
+++ b/cmd/csi-snapshotter/main.go
@@ -126,6 +126,12 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Check it's ready
+	if err = waitForDriverReady(csiConn, *connectionTimeout); err != nil {
+		glog.Error(err.Error())
+		os.Exit(1)
+	}
+
 	// Pass a context with a timeout
 	ctx, cancel := context.WithTimeout(context.Background(), csiTimeout)
 	defer cancel()
@@ -139,12 +145,6 @@ func main() {
 		}
 	}
 	glog.V(2).Infof("CSI driver name: %q", *snapshotter)
-
-	// Check it's ready
-	if err = waitForDriverReady(csiConn, *connectionTimeout); err != nil {
-		glog.Error(err.Error())
-		os.Exit(1)
-	}
 
 	// Find out if the driver supports create/delete snapshot.
 	supportsCreateSnapshot, err := csiConn.SupportsControllerCreateSnapshot(ctx)
@@ -206,7 +206,7 @@ func waitForDriverReady(csiConn connection.CSIConnection, timeout time.Duration)
 	finish := now.Add(timeout)
 	var err error
 	for {
-		ctx, cancel := context.WithTimeout(context.Background(), csiTimeout)
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
 		defer cancel()
 		err = csiConn.Probe(ctx)
 		if err == nil {


### PR DESCRIPTION
The Probe timeout is set to 1 second, which is insufficient for most
plugins that want to do a thorough health check.

Change the timeout to the default of 1 minute, like we did in the
external-attacher.