### PR TITLE
Use distroless as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine
+FROM gcr.io/distroless/static:latest
 LABEL maintainers="Kubernetes Authors"
 LABEL description="CSI External Snapshotter"
 


### PR DESCRIPTION
Reason: k8s core components move its base images to distroless/static. See kubernetes/kubernetes#70249 (comment) for details.

