### PR TITLE
Update dependencies to k8s 1.13.1 from the release-1.0 branch

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,51 +2,66 @@
 
 
 [[projects]]
+  digest = "1:93147eb1d6f08d39f2c0efe3d29ee043bda72be7a8b3b367eb08c72c18524638"
   name = "github.com/container-storage-interface/spec"
   packages = ["lib/go/csi"]
+  pruneopts = ""
   revision = "ed0bb0e1557548aa028307f48728767cfe8f6345"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:0deddd908b6b4b768cfc272c16ee61e7088a60f7fe2f06c547bd3d8e1f8b8e77"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
+  pruneopts = ""
   revision = "8991bc29aa16c548c550c7ff78260e27b9ab7c73"
   version = "v1.1.1"
 
 [[projects]]
+  digest = "1:4216202f4088a73e2982df875e2f0d1401137bbc248e57391e70547af167a18a"
   name = "github.com/evanphx/json-patch"
   packages = ["."]
+  pruneopts = ""
   revision = "72bf35d0ff611848c1dc9df0f976c81192392fa5"
   version = "v4.1.0"
 
 [[projects]]
+  digest = "1:6e73003ecd35f4487a5e88270d3ca0a81bc80dc88053ac7e4dcfec5fba30d918"
   name = "github.com/gogo/protobuf"
   packages = [
     "proto",
-    "sortkeys"
+    "sortkeys",
   ]
+  pruneopts = ""
   revision = "636bf0302bc95575d69441b25a2603156ffdddf1"
   version = "v1.1.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:107b233e45174dbab5b1324201d092ea9448e58243ab9f039e4c0f332e121e3a"
   name = "github.com/golang/glog"
   packages = ["."]
+  pruneopts = ""
   revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
 
 [[projects]]
   branch = "master"
+  digest = "1:aa2251148505e561bfa8cd6b69a319b37761da57b0b25529c4af08389559e3b9"
   name = "github.com/golang/groupcache"
   packages = ["lru"]
+  pruneopts = ""
   revision = "c65c006176ff7ff98bb916961c7abbc6b0afc0aa"
 
 [[projects]]
+  digest = "1:73a7106c799f98af4f3da7552906efc6a2570329f4cd2d2f5fb8f9d6c053ff2f"
   name = "github.com/golang/mock"
   packages = ["gomock"]
+  pruneopts = ""
   revision = "c34cdb4725f4c3844d095133c6e40e448b86589b"
   version = "v1.1.1"
 
 [[projects]]
+  digest = "1:3dd078fda7500c341bc26cfbc6c6a34614f295a2457149fc1045cab767cbcf18"
   name = "github.com/golang/protobuf"
   packages = [
     "descriptor",
@@ -56,116 +71,148 @@
     "ptypes/any",
     "ptypes/duration",
     "ptypes/timestamp",
-    "ptypes/wrappers"
+    "ptypes/wrappers",
   ]
+  pruneopts = ""
   revision = "aa810b61a9c79d51363740d207bb46cf8e620ed5"
   version = "v1.2.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:1e5b1e14524ed08301977b7b8e10c719ed853cbf3f24ecb66fae783a46f207a6"
   name = "github.com/google/btree"
   packages = ["."]
+  pruneopts = ""
   revision = "4030bb1f1f0c35b30ca7009e9ebd06849dd45306"
 
 [[projects]]
   branch = "master"
+  digest = "1:754f77e9c839b24778a4b64422236d38515301d2baeb63113aa3edc42e6af692"
   name = "github.com/google/gofuzz"
   packages = ["."]
+  pruneopts = ""
   revision = "24818f796faf91cd76ec7bddd72458fbced7a6c1"
 
 [[projects]]
+  digest = "1:16b2837c8b3cf045fa2cdc82af0cf78b19582701394484ae76b2c3bc3c99ad73"
   name = "github.com/googleapis/gnostic"
   packages = [
     "OpenAPIv2",
     "compiler",
-    "extensions"
+    "extensions",
   ]
+  pruneopts = ""
   revision = "7c663266750e7d82587642f65e60bc4083f1f84e"
   version = "v0.2.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:5e345eb75d8bfb2b91cfbfe02a82a79c0b2ea55cf06c5a4d180a9321f36973b4"
   name = "github.com/gregjones/httpcache"
   packages = [
     ".",
-    "diskcache"
+    "diskcache",
   ]
+  pruneopts = ""
   revision = "c63ab54fda8f77302f8d414e19933f2b6026a089"
 
 [[projects]]
+  digest = "1:3313a63031ae281e5f6fd7b0bbca733dfa04d2429df86519e3b4d4c016ccb836"
   name = "github.com/hashicorp/golang-lru"
   packages = [
     ".",
-    "simplelru"
+    "simplelru",
   ]
+  pruneopts = ""
   revision = "20f1fb78b0740ba8c3cb143a61e86ba5c8669768"
   version = "v0.5.0"
 
 [[projects]]
+  digest = "1:7ab38c15bd21e056e3115c8b526d201eaf74e0308da9370997c6b3c187115d36"
   name = "github.com/imdario/mergo"
   packages = ["."]
+  pruneopts = ""
   revision = "9f23e2d6bd2a77f959b2bf6acdbefd708a83a4a4"
   version = "v0.3.6"
 
 [[projects]]
+  digest = "1:b79fc583e4dc7055ed86742e22164ac41bf8c0940722dbcb600f1a3ace1a8cb5"
   name = "github.com/json-iterator/go"
   packages = ["."]
+  pruneopts = ""
   revision = "1624edc4454b8682399def8740d46db5e4362ba4"
   version = "v1.1.5"
 
 [[projects]]
+  digest = "1:7769b409ad23ac05a4537f61c7e8861b276bd004607abc7e9d26ba406d2f0ace"
   name = "github.com/kubernetes-csi/csi-lib-utils"
   packages = ["protosanitizer"]
+  pruneopts = ""
   revision = "1628ab5351eafa4fc89a96862a08a891e601e03a"
   version = "v0.1.0"
 
 [[projects]]
+  digest = "1:79848f850d0d15b2413a7285441a7fd13ed8a901ebe57d59f1e49759c103b930"
   name = "github.com/kubernetes-csi/csi-test"
   packages = [
     "driver",
-    "utils"
+    "utils",
   ]
+  pruneopts = ""
   revision = "619da6853e10bef67ddcc8f1c2b68b73154bf11d"
   version = "v1.0.0-rc2"
 
 [[projects]]
+  digest = "1:0c0ff2a89c1bb0d01887e1dac043ad7efbf3ec77482ef058ac423d13497e16fd"
   name = "github.com/modern-go/concurrent"
   packages = ["."]
+  pruneopts = ""
   revision = "bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94"
   version = "1.0.3"
 
 [[projects]]
+  digest = "1:e32bdbdb7c377a07a9a46378290059822efdce5c8d96fe71940d87cb4f918855"
   name = "github.com/modern-go/reflect2"
   packages = ["."]
+  pruneopts = ""
   revision = "4b7aa43c6742a2c18fdef89dd197aaae7dac7ccd"
   version = "1.0.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:c24598ffeadd2762552269271b3b1510df2d83ee6696c1e543a0ff653af494bc"
   name = "github.com/petar/GoLLRB"
   packages = ["llrb"]
+  pruneopts = ""
   revision = "53be0d36a84c2a886ca057d34b6aa4468df9ccb4"
 
 [[projects]]
+  digest = "1:b46305723171710475f2dd37547edd57b67b9de9f2a6267cafdd98331fd6897f"
   name = "github.com/peterbourgon/diskv"
   packages = ["."]
+  pruneopts = ""
   revision = "5f041e8faa004a95c88a202771f4cc3e991971e6"
   version = "v2.0.1"
 
 [[projects]]
+  digest = "1:cbaf13cdbfef0e4734ed8a7504f57fe893d471d62a35b982bf6fb3f036449a66"
   name = "github.com/spf13/pflag"
   packages = ["."]
+  pruneopts = ""
   revision = "298182f68c66c05229eb03ac171abe6e309ee79a"
   version = "v1.0.3"
 
 [[projects]]
   branch = "master"
+  digest = "1:f7be435e0ca22e2cd62b2d2542081a231685837170a87a3662abb7cdf9f3f1cd"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
+  pruneopts = ""
   revision = "3d3f9f413869b949e48070b5bc593aa22cc2b8f2"
 
 [[projects]]
   branch = "master"
+  digest = "1:4ac199b027ed34460ec4e0a92c882156f561e78cd046fef095e50f867462435a"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -175,29 +222,35 @@
     "http2/hpack",
     "idna",
     "internal/timeseries",
-    "trace"
+    "trace",
   ]
+  pruneopts = ""
   revision = "adae6a3d119ae4890b46832a2e88a95adc62b8e7"
 
 [[projects]]
   branch = "master"
+  digest = "1:51d339a1d79f5c617fba14414aefb7dfd184b8ba0ddbb9f95251430b67c8aab8"
   name = "golang.org/x/oauth2"
   packages = [
     ".",
-    "internal"
+    "internal",
   ]
+  pruneopts = ""
   revision = "f42d05182288abf10faef86d16c0d07b8d40ea2d"
 
 [[projects]]
   branch = "master"
+  digest = "1:0ad2730a94694f9968449f91f0311788b58b2822ff5eff299202e02f538c6027"
   name = "golang.org/x/sys"
   packages = [
     "unix",
-    "windows"
+    "windows",
   ]
+  pruneopts = ""
   revision = "ec83556a53fe16b65c452a104ea9d1e86a671852"
 
 [[projects]]
+  digest = "1:5acd3512b047305d49e8763eef7ba423901e85d5dd2fd1e71778a0ea8de10bd4"
   name = "golang.org/x/text"
   packages = [
     "collate",
@@ -213,29 +266,35 @@
     "unicode/bidi",
     "unicode/cldr",
     "unicode/norm",
-    "unicode/rangetable"
+    "unicode/rangetable",
   ]
+  pruneopts = ""
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:14cb1d4240bcbbf1386ae763957e04e2765ec4e4ce7bb2769d05fa6faccd774e"
   name = "golang.org/x/time"
   packages = ["rate"]
+  pruneopts = ""
   revision = "85acf8d2951cb2a3bde7632f9ff273ef0379bcbd"
 
 [[projects]]
   branch = "master"
+  digest = "1:f17543c60083ff4f8fae5ee3e5d51bcd6fece074fd39a49cfd0f29573039dd17"
   name = "golang.org/x/tools"
   packages = [
     "go/ast/astutil",
     "imports",
     "internal/fastwalk",
-    "internal/gopathwalk"
+    "internal/gopathwalk",
   ]
+  pruneopts = ""
   revision = "89e258047f9bd4255fae0d48139e1d5ff0a7b8dd"
 
 [[projects]]
+  digest = "1:77d3cff3a451d50be4b52db9c7766c0d8570ba47593f0c9dc72173adb208e788"
   name = "google.golang.org/appengine"
   packages = [
     "internal",
@@ -244,18 +303,22 @@
     "internal/log",
     "internal/remote_api",
     "internal/urlfetch",
-    "urlfetch"
+    "urlfetch",
   ]
+  pruneopts = ""
   revision = "4a4468ece617fc8205e99368fa2200e9d1fad421"
   version = "v1.3.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:212d4045ef941b209a154001718705dc723bd77e0200fcea36d15ec87ed49dec"
   name = "google.golang.org/genproto"
   packages = ["googleapis/rpc/status"]
+  pruneopts = ""
   revision = "b5d43981345bdb2c233eb4bf3277847b48c6fdc6"
 
 [[projects]]
+  digest = "1:1293087271e314cfa2b3decededba2ecba0ff327e7b7809e00f73f616449191c"
   name = "google.golang.org/grpc"
   packages = [
     ".",
@@ -285,24 +348,30 @@
     "resolver/passthrough",
     "stats",
     "status",
-    "tap"
+    "tap",
   ]
+  pruneopts = ""
   revision = "2e463a05d100327ca47ac218281906921038fd95"
   version = "v1.16.0"
 
 [[projects]]
+  digest = "1:75fb3fcfc73a8c723efde7777b40e8e8ff9babf30d8c56160d01beffea8a95a6"
   name = "gopkg.in/inf.v0"
   packages = ["."]
+  pruneopts = ""
   revision = "d2d2541c53f18d2a059457998ce2876cc8e67cbf"
   version = "v0.9.1"
 
 [[projects]]
+  digest = "1:f0620375dd1f6251d9973b5f2596228cc8042e887cd7f827e4220bc1ce8c30e2"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
+  pruneopts = ""
   revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
   version = "v2.2.1"
 
 [[projects]]
+  digest = "1:be67264067c68b1f601bfc4a6c102b1380ed0743147381de81ed11da88d2e246"
   name = "k8s.io/api"
   packages = [
     "admissionregistration/v1alpha1",
@@ -336,24 +405,28 @@
     "settings/v1alpha1",
     "storage/v1",
     "storage/v1alpha1",
-    "storage/v1beta1"
+    "storage/v1beta1",
   ]
-  revision = "d01564359763a39d310efc27866b63d4f5c92f1d"
-  version = "kubernetes-1.13.0-beta.1"
+  pruneopts = ""
+  revision = "05914d821849570fba9eacfb29466f2d8d3cd229"
+  version = "kubernetes-1.13.1"
 
 [[projects]]
+  digest = "1:2133e488e6db5701ef295c39cbc0836855c02af677e8707e539ebf605a4211ca"
   name = "k8s.io/apiextensions-apiserver"
   packages = [
     "pkg/apis/apiextensions",
     "pkg/apis/apiextensions/v1beta1",
     "pkg/client/clientset/clientset",
     "pkg/client/clientset/clientset/scheme",
-    "pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
+    "pkg/client/clientset/clientset/typed/apiextensions/v1beta1",
   ]
-  revision = "e1ae69ff7b8b6c135578c1892f3781c55d75c69e"
-  version = "kubernetes-1.13.0-beta.1"
+  pruneopts = ""
+  revision = "0fe22c71c47604641d9aa352c785b7912c200562"
+  version = "kubernetes-1.13.1"
 
 [[projects]]
+  digest = "1:66b0292f815d508d11ed5fe94fdeb0bcc5a988703a08e73bf3cb3a415de676cf"
   name = "k8s.io/apimachinery"
   packages = [
     "pkg/api/errors",
@@ -398,12 +471,14 @@
     "pkg/version",
     "pkg/watch",
     "third_party/forked/golang/json",
-    "third_party/forked/golang/reflect"
+    "third_party/forked/golang/reflect",
   ]
-  revision = "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
-  version = "kubernetes-1.13.0-beta.1"
+  pruneopts = ""
+  revision = "2b1284ed4c93a43499e781493253e2ac5959c4fd"
+  version = "kubernetes-1.13.1"
 
 [[projects]]
+  digest = "1:d603c9957fa66c90792d45fe0205d484da2ea364a01069c20890f2640b4a0fd5"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
@@ -501,12 +576,14 @@
     "util/homedir",
     "util/integer",
     "util/retry",
-    "util/workqueue"
+    "util/workqueue",
   ]
-  revision = "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
-  version = "kubernetes-1.13.0-beta.1"
+  pruneopts = ""
+  revision = "8d9ed539ba3134352c586810e749e58df4e94e4f"
+  version = "kubernetes-1.13.1"
 
 [[projects]]
+  digest = "1:d809e6c8dfa3448ae10f5624eff4ed1ebdc906755e7cea294c44e8b7ac0b077a"
   name = "k8s.io/code-generator"
   packages = [
     "cmd/client-gen",
@@ -527,13 +604,15 @@
     "cmd/lister-gen",
     "cmd/lister-gen/args",
     "cmd/lister-gen/generators",
-    "pkg/util"
+    "pkg/util",
   ]
+  pruneopts = ""
   revision = "c2090bec4d9b1fb25de3812f868accc2bc9ecbae"
-  version = "kubernetes-1.13.0-beta.1"
+  version = "kubernetes-1.13.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:0cc7d194e005097afad585545a3049ac7b5d1e3a1bfa86aa6bf6f2fb0e0a5063"
   name = "k8s.io/gengo"
   packages = [
     "args",
@@ -543,41 +622,104 @@
     "generator",
     "namer",
     "parser",
-    "types"
+    "types",
   ]
+  pruneopts = ""
   revision = "fd15ee9cc2f77baa4f31e59e6acbf21146455073"
 
 [[projects]]
+  digest = "1:4f5eb833037cc0ba0bf8fe9cae6be9df62c19dd1c869415275c708daa8ccfda5"
   name = "k8s.io/klog"
   packages = ["."]
+  pruneopts = ""
   revision = "a5bc97fbc634d635061f3146511332c7e313a55a"
   version = "v0.1.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:e5d4ca90c0f3862515c98454bb37d4d340f4ceeca60ac3e0a5cb5857360aed7c"
   name = "k8s.io/kube-openapi"
   packages = ["pkg/util/proto"]
+  pruneopts = ""
   revision = "0317810137be915b9cf888946c6e115c1bfac693"
 
 [[projects]]
+  digest = "1:6061aa42761235df375f20fa4a1aa6d1845cba3687575f3adb2ef3f3bc540af5"
   name = "k8s.io/kubernetes"
   packages = [
     "pkg/util/goroutinemap",
     "pkg/util/goroutinemap/exponentialbackoff",
-    "pkg/util/slice"
+    "pkg/util/slice",
   ]
+  pruneopts = ""
   revision = "17c77c7898218073f14c8d573582e8d2313dc740"
   version = "v1.12.2"
 
 [[projects]]
+  digest = "1:321081b4a44256715f2b68411d8eda9a17f17ebfe6f0cc61d2cc52d11c08acfa"
   name = "sigs.k8s.io/yaml"
   packages = ["."]
+  pruneopts = ""
   revision = "fd68e9863619f6ec2fdd8625fe1f02e7c877e480"
   version = "v1.1.0"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "1ffccc02a34124d103d58b579a8e5b8aec657e279f0bfbaaeb3eeeed9c146182"
+  input-imports = [
+    "github.com/container-storage-interface/spec/lib/go/csi",
+    "github.com/golang/glog",
+    "github.com/golang/mock/gomock",
+    "github.com/golang/protobuf/ptypes",
+    "github.com/golang/protobuf/ptypes/timestamp",
+    "github.com/kubernetes-csi/csi-lib-utils/protosanitizer",
+    "github.com/kubernetes-csi/csi-test/driver",
+    "google.golang.org/grpc",
+    "google.golang.org/grpc/codes",
+    "google.golang.org/grpc/connectivity",
+    "google.golang.org/grpc/status",
+    "k8s.io/api/core/v1",
+    "k8s.io/api/storage/v1",
+    "k8s.io/api/storage/v1beta1",
+    "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1",
+    "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset",
+    "k8s.io/apimachinery/pkg/api/errors",
+    "k8s.io/apimachinery/pkg/api/meta",
+    "k8s.io/apimachinery/pkg/api/resource",
+    "k8s.io/apimachinery/pkg/apis/meta/v1",
+    "k8s.io/apimachinery/pkg/labels",
+    "k8s.io/apimachinery/pkg/runtime",
+    "k8s.io/apimachinery/pkg/runtime/schema",
+    "k8s.io/apimachinery/pkg/runtime/serializer",
+    "k8s.io/apimachinery/pkg/types",
+    "k8s.io/apimachinery/pkg/util/diff",
+    "k8s.io/apimachinery/pkg/util/runtime",
+    "k8s.io/apimachinery/pkg/util/sets",
+    "k8s.io/apimachinery/pkg/util/validation",
+    "k8s.io/apimachinery/pkg/util/wait",
+    "k8s.io/apimachinery/pkg/watch",
+    "k8s.io/client-go/discovery",
+    "k8s.io/client-go/discovery/fake",
+    "k8s.io/client-go/kubernetes",
+    "k8s.io/client-go/kubernetes/fake",
+    "k8s.io/client-go/kubernetes/scheme",
+    "k8s.io/client-go/kubernetes/typed/core/v1",
+    "k8s.io/client-go/rest",
+    "k8s.io/client-go/testing",
+    "k8s.io/client-go/tools/cache",
+    "k8s.io/client-go/tools/clientcmd",
+    "k8s.io/client-go/tools/record",
+    "k8s.io/client-go/tools/reference",
+    "k8s.io/client-go/util/flowcontrol",
+    "k8s.io/client-go/util/workqueue",
+    "k8s.io/code-generator/cmd/client-gen",
+    "k8s.io/code-generator/cmd/deepcopy-gen",
+    "k8s.io/code-generator/cmd/defaulter-gen",
+    "k8s.io/code-generator/cmd/informer-gen",
+    "k8s.io/code-generator/cmd/lister-gen",
+    "k8s.io/kubernetes/pkg/util/goroutinemap",
+    "k8s.io/kubernetes/pkg/util/goroutinemap/exponentialbackoff",
+    "k8s.io/kubernetes/pkg/util/slice",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -31,15 +31,15 @@ required = [
 
 [[constraint]]
   name = "k8s.io/api"
-  version = "kubernetes-1.13.0-beta.1"
+  version = "kubernetes-1.13.1"
 
 [[constraint]]
   name = "k8s.io/apimachinery"
-  version = "kubernetes-1.13.0-beta.1"
+  version = "kubernetes-1.13.1"
 
 [[constraint]]
   name = "k8s.io/client-go"
-  version = "kubernetes-1.13.0-beta.1"
+  version = "kubernetes-1.13.1"
 
 [[override]]
   name = "github.com/json-iterator/go"
@@ -47,11 +47,11 @@ required = [
 
 [[constraint]]
   name = "k8s.io/code-generator"
-  version = "kubernetes-1.13.0-beta.1"
+  version = "kubernetes-1.13.1"
 
 [[constraint]]
   name = "k8s.io/apiextensions-apiserver"
-  version = "kubernetes-1.13.0-beta.1"
+  version = "kubernetes-1.13.1"
 
 [[constraint]]
   name = "github.com/kubernetes-csi/csi-lib-utils"

--- a/vendor/k8s.io/api/Godeps/Godeps.json
+++ b/vendor/k8s.io/api/Godeps/Godeps.json
@@ -28,7 +28,7 @@
 		},
 		{
 			"ImportPath": "github.com/json-iterator/go",
-			"Rev": "f2b4162afba35581b6d4a50d3b8f34e33c144682"
+			"Rev": "ab8a2e0c74be9d3be70b3184d9acc634935ded82"
 		},
 		{
 			"ImportPath": "github.com/modern-go/concurrent",
@@ -96,151 +96,151 @@
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/api/apitesting",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/api/apitesting/fuzzer",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/api/apitesting/roundtrip",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/api/equality",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/api/meta",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/api/resource",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/apis/meta/fuzzer",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/apis/meta/v1",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/apis/meta/v1beta1",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/conversion",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/conversion/queryparams",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/fields",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/labels",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/runtime",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/runtime/schema",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer/json",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer/protobuf",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer/recognizer",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer/versioning",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/selection",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/types",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/diff",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/errors",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/framer",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/intstr",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/json",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/naming",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/net",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/runtime",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/sets",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/validation",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/validation/field",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/yaml",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/watch",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/third_party/forked/golang/reflect",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/klog",

--- a/vendor/k8s.io/apiextensions-apiserver/Godeps/Godeps.json
+++ b/vendor/k8s.io/apiextensions-apiserver/Godeps/Godeps.json
@@ -564,7 +564,7 @@
 		},
 		{
 			"ImportPath": "github.com/json-iterator/go",
-			"Rev": "f2b4162afba35581b6d4a50d3b8f34e33c144682"
+			"Rev": "ab8a2e0c74be9d3be70b3184d9acc634935ded82"
 		},
 		{
 			"ImportPath": "github.com/mailru/easyjson/buffer",
@@ -940,1371 +940,1371 @@
 		},
 		{
 			"ImportPath": "k8s.io/api/admission/v1beta1",
-			"Rev": "d01564359763a39d310efc27866b63d4f5c92f1d"
+			"Rev": "05914d821849570fba9eacfb29466f2d8d3cd229"
 		},
 		{
 			"ImportPath": "k8s.io/api/admissionregistration/v1alpha1",
-			"Rev": "d01564359763a39d310efc27866b63d4f5c92f1d"
+			"Rev": "05914d821849570fba9eacfb29466f2d8d3cd229"
 		},
 		{
 			"ImportPath": "k8s.io/api/admissionregistration/v1beta1",
-			"Rev": "d01564359763a39d310efc27866b63d4f5c92f1d"
+			"Rev": "05914d821849570fba9eacfb29466f2d8d3cd229"
 		},
 		{
 			"ImportPath": "k8s.io/api/apps/v1",
-			"Rev": "d01564359763a39d310efc27866b63d4f5c92f1d"
+			"Rev": "05914d821849570fba9eacfb29466f2d8d3cd229"
 		},
 		{
 			"ImportPath": "k8s.io/api/apps/v1beta1",
-			"Rev": "d01564359763a39d310efc27866b63d4f5c92f1d"
+			"Rev": "05914d821849570fba9eacfb29466f2d8d3cd229"
 		},
 		{
 			"ImportPath": "k8s.io/api/apps/v1beta2",
-			"Rev": "d01564359763a39d310efc27866b63d4f5c92f1d"
+			"Rev": "05914d821849570fba9eacfb29466f2d8d3cd229"
 		},
 		{
 			"ImportPath": "k8s.io/api/auditregistration/v1alpha1",
-			"Rev": "d01564359763a39d310efc27866b63d4f5c92f1d"
+			"Rev": "05914d821849570fba9eacfb29466f2d8d3cd229"
 		},
 		{
 			"ImportPath": "k8s.io/api/authentication/v1",
-			"Rev": "d01564359763a39d310efc27866b63d4f5c92f1d"
+			"Rev": "05914d821849570fba9eacfb29466f2d8d3cd229"
 		},
 		{
 			"ImportPath": "k8s.io/api/authentication/v1beta1",
-			"Rev": "d01564359763a39d310efc27866b63d4f5c92f1d"
+			"Rev": "05914d821849570fba9eacfb29466f2d8d3cd229"
 		},
 		{
 			"ImportPath": "k8s.io/api/authorization/v1",
-			"Rev": "d01564359763a39d310efc27866b63d4f5c92f1d"
+			"Rev": "05914d821849570fba9eacfb29466f2d8d3cd229"
 		},
 		{
 			"ImportPath": "k8s.io/api/authorization/v1beta1",
-			"Rev": "d01564359763a39d310efc27866b63d4f5c92f1d"
+			"Rev": "05914d821849570fba9eacfb29466f2d8d3cd229"
 		},
 		{
 			"ImportPath": "k8s.io/api/autoscaling/v1",
-			"Rev": "d01564359763a39d310efc27866b63d4f5c92f1d"
+			"Rev": "05914d821849570fba9eacfb29466f2d8d3cd229"
 		},
 		{
 			"ImportPath": "k8s.io/api/autoscaling/v2beta1",
-			"Rev": "d01564359763a39d310efc27866b63d4f5c92f1d"
+			"Rev": "05914d821849570fba9eacfb29466f2d8d3cd229"
 		},
 		{
 			"ImportPath": "k8s.io/api/autoscaling/v2beta2",
-			"Rev": "d01564359763a39d310efc27866b63d4f5c92f1d"
+			"Rev": "05914d821849570fba9eacfb29466f2d8d3cd229"
 		},
 		{
 			"ImportPath": "k8s.io/api/batch/v1",
-			"Rev": "d01564359763a39d310efc27866b63d4f5c92f1d"
+			"Rev": "05914d821849570fba9eacfb29466f2d8d3cd229"
 		},
 		{
 			"ImportPath": "k8s.io/api/batch/v1beta1",
-			"Rev": "d01564359763a39d310efc27866b63d4f5c92f1d"
+			"Rev": "05914d821849570fba9eacfb29466f2d8d3cd229"
 		},
 		{
 			"ImportPath": "k8s.io/api/batch/v2alpha1",
-			"Rev": "d01564359763a39d310efc27866b63d4f5c92f1d"
+			"Rev": "05914d821849570fba9eacfb29466f2d8d3cd229"
 		},
 		{
 			"ImportPath": "k8s.io/api/certificates/v1beta1",
-			"Rev": "d01564359763a39d310efc27866b63d4f5c92f1d"
+			"Rev": "05914d821849570fba9eacfb29466f2d8d3cd229"
 		},
 		{
 			"ImportPath": "k8s.io/api/coordination/v1beta1",
-			"Rev": "d01564359763a39d310efc27866b63d4f5c92f1d"
+			"Rev": "05914d821849570fba9eacfb29466f2d8d3cd229"
 		},
 		{
 			"ImportPath": "k8s.io/api/core/v1",
-			"Rev": "d01564359763a39d310efc27866b63d4f5c92f1d"
+			"Rev": "05914d821849570fba9eacfb29466f2d8d3cd229"
 		},
 		{
 			"ImportPath": "k8s.io/api/events/v1beta1",
-			"Rev": "d01564359763a39d310efc27866b63d4f5c92f1d"
+			"Rev": "05914d821849570fba9eacfb29466f2d8d3cd229"
 		},
 		{
 			"ImportPath": "k8s.io/api/extensions/v1beta1",
-			"Rev": "d01564359763a39d310efc27866b63d4f5c92f1d"
+			"Rev": "05914d821849570fba9eacfb29466f2d8d3cd229"
 		},
 		{
 			"ImportPath": "k8s.io/api/networking/v1",
-			"Rev": "d01564359763a39d310efc27866b63d4f5c92f1d"
+			"Rev": "05914d821849570fba9eacfb29466f2d8d3cd229"
 		},
 		{
 			"ImportPath": "k8s.io/api/policy/v1beta1",
-			"Rev": "d01564359763a39d310efc27866b63d4f5c92f1d"
+			"Rev": "05914d821849570fba9eacfb29466f2d8d3cd229"
 		},
 		{
 			"ImportPath": "k8s.io/api/rbac/v1",
-			"Rev": "d01564359763a39d310efc27866b63d4f5c92f1d"
+			"Rev": "05914d821849570fba9eacfb29466f2d8d3cd229"
 		},
 		{
 			"ImportPath": "k8s.io/api/rbac/v1alpha1",
-			"Rev": "d01564359763a39d310efc27866b63d4f5c92f1d"
+			"Rev": "05914d821849570fba9eacfb29466f2d8d3cd229"
 		},
 		{
 			"ImportPath": "k8s.io/api/rbac/v1beta1",
-			"Rev": "d01564359763a39d310efc27866b63d4f5c92f1d"
+			"Rev": "05914d821849570fba9eacfb29466f2d8d3cd229"
 		},
 		{
 			"ImportPath": "k8s.io/api/scheduling/v1alpha1",
-			"Rev": "d01564359763a39d310efc27866b63d4f5c92f1d"
+			"Rev": "05914d821849570fba9eacfb29466f2d8d3cd229"
 		},
 		{
 			"ImportPath": "k8s.io/api/scheduling/v1beta1",
-			"Rev": "d01564359763a39d310efc27866b63d4f5c92f1d"
+			"Rev": "05914d821849570fba9eacfb29466f2d8d3cd229"
 		},
 		{
 			"ImportPath": "k8s.io/api/settings/v1alpha1",
-			"Rev": "d01564359763a39d310efc27866b63d4f5c92f1d"
+			"Rev": "05914d821849570fba9eacfb29466f2d8d3cd229"
 		},
 		{
 			"ImportPath": "k8s.io/api/storage/v1",
-			"Rev": "d01564359763a39d310efc27866b63d4f5c92f1d"
+			"Rev": "05914d821849570fba9eacfb29466f2d8d3cd229"
 		},
 		{
 			"ImportPath": "k8s.io/api/storage/v1alpha1",
-			"Rev": "d01564359763a39d310efc27866b63d4f5c92f1d"
+			"Rev": "05914d821849570fba9eacfb29466f2d8d3cd229"
 		},
 		{
 			"ImportPath": "k8s.io/api/storage/v1beta1",
-			"Rev": "d01564359763a39d310efc27866b63d4f5c92f1d"
+			"Rev": "05914d821849570fba9eacfb29466f2d8d3cd229"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/api/apitesting",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/api/apitesting/fuzzer",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/api/apitesting/roundtrip",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/api/equality",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/api/errors",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/api/meta",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/api/meta/table",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/api/resource",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/api/validation",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/api/validation/path",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/apis/meta/fuzzer",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/apis/meta/internalversion",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/apis/meta/v1",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/apis/meta/v1/validation",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/apis/meta/v1beta1",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/conversion",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/conversion/queryparams",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/fields",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/labels",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/runtime",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/runtime/schema",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer/json",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer/protobuf",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer/recognizer",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer/streaming",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer/versioning",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/selection",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/types",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/cache",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/clock",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/diff",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/duration",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/errors",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/framer",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/intstr",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/json",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/mergepatch",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/naming",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/net",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/rand",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/runtime",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/sets",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/strategicpatch",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/uuid",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/validation",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/validation/field",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/wait",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/waitgroup",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/yaml",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/version",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/watch",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/third_party/forked/golang/json",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/third_party/forked/golang/reflect",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/admission",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/admission/configuration",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/admission/initializer",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/admission/metrics",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/admission/plugin/initialization",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/admission/plugin/webhook/config",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/admission/plugin/webhook/config/apis/webhookadmission",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/admission/plugin/webhook/config/apis/webhookadmission/v1alpha1",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/admission/plugin/webhook/errors",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/admission/plugin/webhook/generic",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/admission/plugin/webhook/mutating",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/admission/plugin/webhook/namespace",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/admission/plugin/webhook/request",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/admission/plugin/webhook/rules",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/admission/plugin/webhook/util",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/admission/plugin/webhook/validating",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/apis/apiserver",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/apis/apiserver/install",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/apis/apiserver/v1alpha1",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/apis/audit",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/apis/audit/install",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/apis/audit/v1",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/apis/audit/v1alpha1",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/apis/audit/v1beta1",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/apis/audit/validation",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/audit",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/audit/event",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/audit/policy",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/audit/util",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/authentication/authenticator",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/authentication/authenticatorfactory",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/authentication/group",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/authentication/request/anonymous",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/authentication/request/bearertoken",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/authentication/request/headerrequest",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/authentication/request/union",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/authentication/request/websocket",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/authentication/request/x509",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/authentication/serviceaccount",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/authentication/token/cache",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/authentication/token/tokenfile",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/authentication/user",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/authorization/authorizer",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/authorization/authorizerfactory",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/authorization/path",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/authorization/union",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/endpoints",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/endpoints/discovery",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/endpoints/filters",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/endpoints/handlers",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/endpoints/handlers/negotiation",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/endpoints/handlers/responsewriters",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/endpoints/metrics",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/endpoints/openapi",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/endpoints/request",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/features",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/registry/generic",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/registry/generic/registry",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/registry/generic/testing",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/registry/rest",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/registry/rest/resttest",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/server",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/server/filters",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/server/healthz",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/server/httplog",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/server/mux",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/server/options",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/server/resourceconfig",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/server/routes",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/server/routes/data/swagger",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/server/storage",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/storage",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/storage/cacher",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/storage/errors",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/storage/etcd",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/storage/etcd/etcdtest",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/storage/etcd/metrics",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/storage/etcd/testing",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/storage/etcd/testing/testingcert",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/storage/etcd3",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/storage/names",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/storage/storagebackend",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/storage/storagebackend/factory",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/storage/testing",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/storage/value",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/util/dryrun",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/util/feature",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/util/feature/testing",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/util/flag",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/util/flushwriter",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/util/logs",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/util/openapi",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/util/proxy",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/util/trace",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/util/webhook",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/util/wsstream",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/plugin/pkg/audit/buffered",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/plugin/pkg/audit/dynamic",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/plugin/pkg/audit/dynamic/enforced",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/plugin/pkg/audit/log",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/plugin/pkg/audit/truncate",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/plugin/pkg/audit/webhook",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/plugin/pkg/authenticator/token/webhook",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/plugin/pkg/authorizer/webhook",
-			"Rev": "6b360527ed84a1a6bb3883faef76c71cc17499ba"
+			"Rev": "3ccfe8365421eb08e334b195786a2973460741d8"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/discovery",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/discovery/fake",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/dynamic",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/admissionregistration",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/admissionregistration/v1alpha1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/admissionregistration/v1beta1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/apps",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/apps/v1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/apps/v1beta1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/apps/v1beta2",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/auditregistration",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/auditregistration/v1alpha1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/autoscaling",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/autoscaling/v1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/autoscaling/v2beta1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/autoscaling/v2beta2",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/batch",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/batch/v1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/batch/v1beta1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/batch/v2alpha1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/certificates",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/certificates/v1beta1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/coordination",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/coordination/v1beta1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/core",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/core/v1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/events",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/events/v1beta1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/extensions",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/extensions/v1beta1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/internalinterfaces",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/networking",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/networking/v1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/policy",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/policy/v1beta1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/rbac",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/rbac/v1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/rbac/v1alpha1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/rbac/v1beta1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/scheduling",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/scheduling/v1alpha1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/scheduling/v1beta1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/settings",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/settings/v1alpha1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/storage",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/storage/v1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/storage/v1alpha1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/informers/storage/v1beta1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/scheme",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/admissionregistration/v1alpha1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/apps/v1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/apps/v1beta1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/apps/v1beta2",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/auditregistration/v1alpha1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/authentication/v1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/authentication/v1beta1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/authorization/v1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/authorization/v1beta1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/autoscaling/v1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/autoscaling/v2beta1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/autoscaling/v2beta2",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/batch/v1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/batch/v1beta1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/batch/v2alpha1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/certificates/v1beta1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/coordination/v1beta1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/core/v1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/events/v1beta1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/extensions/v1beta1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/networking/v1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/policy/v1beta1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/rbac/v1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/rbac/v1alpha1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/rbac/v1beta1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/scheduling/v1alpha1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/scheduling/v1beta1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/settings/v1alpha1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/storage/v1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/storage/v1alpha1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/storage/v1beta1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/admissionregistration/v1alpha1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/admissionregistration/v1beta1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/apps/v1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/apps/v1beta1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/apps/v1beta2",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/auditregistration/v1alpha1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/autoscaling/v1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/autoscaling/v2beta1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/autoscaling/v2beta2",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/batch/v1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/batch/v1beta1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/batch/v2alpha1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/certificates/v1beta1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/coordination/v1beta1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/core/v1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/events/v1beta1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/extensions/v1beta1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/networking/v1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/policy/v1beta1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/rbac/v1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/rbac/v1alpha1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/rbac/v1beta1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/scheduling/v1alpha1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/scheduling/v1beta1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/settings/v1alpha1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/storage/v1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/storage/v1alpha1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/storage/v1beta1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/clientauthentication",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/clientauthentication/v1alpha1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/clientauthentication/v1beta1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/version",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/plugin/pkg/client/auth/exec",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/rest",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/rest/watch",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/restmapper",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/scale",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/scale/scheme",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/scale/scheme/appsint",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/scale/scheme/appsv1beta1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/scale/scheme/appsv1beta2",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/scale/scheme/autoscalingv1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/scale/scheme/extensionsint",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/scale/scheme/extensionsv1beta1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/testing",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/third_party/forked/golang/template",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/auth",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/cache",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/clientcmd",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/clientcmd/api",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/clientcmd/api/latest",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/clientcmd/api/v1",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/metrics",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/pager",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/record",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/reference",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/transport",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/util/buffer",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/util/cert",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/util/connrotation",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/util/flowcontrol",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/util/homedir",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/util/integer",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/util/jsonpath",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/util/retry",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/util/workqueue",
-			"Rev": "46a8dc78ec29761d6cb89a9eb50ddde947c84030"
+			"Rev": "8d9ed539ba3134352c586810e749e58df4e94e4f"
 		},
 		{
 			"ImportPath": "k8s.io/klog",

--- a/vendor/k8s.io/apiextensions-apiserver/OWNERS
+++ b/vendor/k8s.io/apiextensions-apiserver/OWNERS
@@ -3,6 +3,7 @@ reviewers:
 - sttts
 - enisoc
 - mbohlool
+- yue9944882
 approvers:
 - deads2k
 - lavalamp

--- a/vendor/k8s.io/apimachinery/Godeps/Godeps.json
+++ b/vendor/k8s.io/apimachinery/Godeps/Godeps.json
@@ -84,7 +84,7 @@
 		},
 		{
 			"ImportPath": "github.com/json-iterator/go",
-			"Rev": "f2b4162afba35581b6d4a50d3b8f34e33c144682"
+			"Rev": "ab8a2e0c74be9d3be70b3184d9acc634935ded82"
 		},
 		{
 			"ImportPath": "github.com/modern-go/concurrent",

--- a/vendor/k8s.io/client-go/.travis.yml
+++ b/vendor/k8s.io/client-go/.travis.yml
@@ -3,8 +3,7 @@ language: go
 go_import_path: k8s.io/client-go
 
 go:
-  - 1.11.1
+  - 1.11.2
 
 script:
-  - if [ "$TRAVIS_BRANCH" != "master" ]; then godep restore; fi
-  - go build ./...
+- go build ./...

--- a/vendor/k8s.io/client-go/CHANGELOG.md
+++ b/vendor/k8s.io/client-go/CHANGELOG.md
@@ -5,6 +5,114 @@ https://github.com/kubernetes/test-infra/issues/5843.
 Changes in `k8s.io/api` and `k8s.io/apimachinery` are mentioned here
 because `k8s.io/client-go` depends on them.
 
+# v10.0.0
+
+**Breaking Changes:**
+
+* Action required: client-go will no longer have bootstrap
+(`k8s.io/client-go/tools/bootstrap`) related code. Any reference to it will
+break. Please redirect all references to `k8s.io/bootstrap` instead.
+([#67356](https://github.com/kubernetes/kubernetes/pull/67356))
+
+* The methods `NewSelfSignedCACert` and `NewSignedCert` now use `crypto.Signer`
+interface instead of `rsa.PrivateKey` for certificate creation. This is done
+to allow different kind of private keys (for example: ecdsa).
+([#69329](https://github.com/kubernetes/kubernetes/pull/69329))
+
+* `GetScale` and `UpdateScale` methods have been added for `apps/v1` clients
+and with this, no-verb scale clients have been removed.
+([#70437](https://github.com/kubernetes/kubernetes/pull/70437))
+
+* `k8s.io/client-go/util/cert/triple` package has been removed.
+([#70966](https://github.com/kubernetes/kubernetes/pull/70966))
+
+**New Features:**
+
+* `unfinished_work_microseconds` is added to the workqueue metrics.
+It can be used to detect stuck worker threads (kube-controller-manager runs many workqueues.).
+([#70884](https://github.com/kubernetes/kubernetes/pull/70884))
+
+* A method `GetPorts` is added to expose the ports that were forwarded.
+This can be used to retrieve the locally-bound port in cases where the input was port 0.
+([#67513](https://github.com/kubernetes/kubernetes/pull/67513))
+
+* Dynamic listers and informers, that work with `runtime.Unstructured` objects,
+are added. These are useful for writing generic, non-generated controllers.
+([68748](https://github.com/kubernetes/kubernetes/pull/68748))
+
+* The dynamic fake client now supports JSONPatch.
+([#69330](https://github.com/kubernetes/kubernetes/pull/69330))
+
+* The `GetBinding` method is added for pods in the fake client.
+([#69412](https://github.com/kubernetes/kubernetes/pull/69412))
+
+**Bug fixes and Improvements:**
+
+* The `apiVersion` and action name values for fake evictions are now set.
+([#69035](https://github.com/kubernetes/kubernetes/pull/69035))
+
+* PEM files containing both TLS certificate and key can now be parsed in
+arbitrary order. Previously key was always required to be first.
+([#69536](https://github.com/kubernetes/kubernetes/pull/69536))
+
+* Go clients created from a kubeconfig that specifies a `TokenFile` now
+periodically reload the token from the specified file.
+([#70606](https://github.com/kubernetes/kubernetes/pull/70606))
+
+* It is now ensured that oversized data frames are not written to
+spdystreams in `remotecommand.NewSPDYExecutor`.
+([#70999](https://github.com/kubernetes/kubernetes/pull/70999))
+
+* A panic occuring on calling `scheme.Convert` is fixed by populating the fake
+dynamic client scheme. ([#69125](https://github.com/kubernetes/kubernetes/pull/69125))
+
+* Add step to correctly setup permissions for the in-cluster-client-configuration example.
+([#69232](https://github.com/kubernetes/kubernetes/pull/69232))
+
+* The function `Parallelize` is deprecated. Use `ParallelizeUntil` instead.
+([#68403](https://github.com/kubernetes/kubernetes/pull/68403))
+
+* [k8s.io/apimachinery] Restrict redirect following from the apiserver to
+same-host redirects, and ignore redirects in some cases.
+([#66516](https://github.com/kubernetes/kubernetes/pull/66516))
+
+## API changes
+
+**New Features:**
+
+* GlusterFS PersistentVolumes sources can now reference endpoints in any
+namespace using the `spec.glusterfs.endpointsNamespace` field.
+Ensure all kubelets are upgraded to 1.13+ before using this capability.
+([#60195](https://github.com/kubernetes/kubernetes/pull/60195))
+
+* The [dynamic audit configuration](https://github.com/kubernetes/community/blob/master/keps/sig-auth/0014-dynamic-audit-configuration.md)
+API is added. ([#67547](https://github.com/kubernetes/kubernetes/pull/67547))
+
+* A new field `EnableServiceLinks` is added to the `PodSpec` to indicate whether
+information about services should be injected into pod's environment variables.
+([#68754](https://github.com/kubernetes/kubernetes/pull/68754))
+
+* `CSIPersistentVolume` feature, i.e. `PersistentVolumes` with
+`CSIPersistentVolumeSource`, is GA. `CSIPersistentVolume` feature gate is now
+deprecated and will be removed according to deprecation policy.
+([#69929](https://github.com/kubernetes/kubernetes/pull/69929))
+
+* Raw block volume support is promoted to beta, and enabled by default.
+This is accessible via the `volumeDevices` container field in pod specs,
+and the `volumeMode` field in persistent volume and persistent volume claims definitions.
+([#71167](https://github.com/kubernetes/kubernetes/pull/71167))
+
+**Bug fixes and Improvements:**
+
+* The default value of extensions/v1beta1 Deployment's `RevisionHistoryLimit`
+is set to `MaxInt32`. ([#66605](https://github.com/kubernetes/kubernetes/pull/66605))
+
+* `procMount` field is no longer incorrectly marked as required in openapi schema.
+([#69694](https://github.com/kubernetes/kubernetes/pull/69694))
+
+* The caBundle and service fields in admission webhook API objects now correctly
+indicate they are optional. ([#70138](https://github.com/kubernetes/kubernetes/pull/70138))
+
 # v9.0.0
 
 **Breaking Changes:**

--- a/vendor/k8s.io/client-go/Godeps/Godeps.json
+++ b/vendor/k8s.io/client-go/Godeps/Godeps.json
@@ -160,7 +160,7 @@
 		},
 		{
 			"ImportPath": "github.com/json-iterator/go",
-			"Rev": "f2b4162afba35581b6d4a50d3b8f34e33c144682"
+			"Rev": "ab8a2e0c74be9d3be70b3184d9acc634935ded82"
 		},
 		{
 			"ImportPath": "github.com/modern-go/concurrent",
@@ -272,339 +272,339 @@
 		},
 		{
 			"ImportPath": "k8s.io/api/admissionregistration/v1alpha1",
-			"Rev": "d01564359763a39d310efc27866b63d4f5c92f1d"
+			"Rev": "05914d821849570fba9eacfb29466f2d8d3cd229"
 		},
 		{
 			"ImportPath": "k8s.io/api/admissionregistration/v1beta1",
-			"Rev": "d01564359763a39d310efc27866b63d4f5c92f1d"
+			"Rev": "05914d821849570fba9eacfb29466f2d8d3cd229"
 		},
 		{
 			"ImportPath": "k8s.io/api/apps/v1",
-			"Rev": "d01564359763a39d310efc27866b63d4f5c92f1d"
+			"Rev": "05914d821849570fba9eacfb29466f2d8d3cd229"
 		},
 		{
 			"ImportPath": "k8s.io/api/apps/v1beta1",
-			"Rev": "d01564359763a39d310efc27866b63d4f5c92f1d"
+			"Rev": "05914d821849570fba9eacfb29466f2d8d3cd229"
 		},
 		{
 			"ImportPath": "k8s.io/api/apps/v1beta2",
-			"Rev": "d01564359763a39d310efc27866b63d4f5c92f1d"
+			"Rev": "05914d821849570fba9eacfb29466f2d8d3cd229"
 		},
 		{
 			"ImportPath": "k8s.io/api/auditregistration/v1alpha1",
-			"Rev": "d01564359763a39d310efc27866b63d4f5c92f1d"
+			"Rev": "05914d821849570fba9eacfb29466f2d8d3cd229"
 		},
 		{
 			"ImportPath": "k8s.io/api/authentication/v1",
-			"Rev": "d01564359763a39d310efc27866b63d4f5c92f1d"
+			"Rev": "05914d821849570fba9eacfb29466f2d8d3cd229"
 		},
 		{
 			"ImportPath": "k8s.io/api/authentication/v1beta1",
-			"Rev": "d01564359763a39d310efc27866b63d4f5c92f1d"
+			"Rev": "05914d821849570fba9eacfb29466f2d8d3cd229"
 		},
 		{
 			"ImportPath": "k8s.io/api/authorization/v1",
-			"Rev": "d01564359763a39d310efc27866b63d4f5c92f1d"
+			"Rev": "05914d821849570fba9eacfb29466f2d8d3cd229"
 		},
 		{
 			"ImportPath": "k8s.io/api/authorization/v1beta1",
-			"Rev": "d01564359763a39d310efc27866b63d4f5c92f1d"
+			"Rev": "05914d821849570fba9eacfb29466f2d8d3cd229"
 		},
 		{
 			"ImportPath": "k8s.io/api/autoscaling/v1",
-			"Rev": "d01564359763a39d310efc27866b63d4f5c92f1d"
+			"Rev": "05914d821849570fba9eacfb29466f2d8d3cd229"
 		},
 		{
 			"ImportPath": "k8s.io/api/autoscaling/v2beta1",
-			"Rev": "d01564359763a39d310efc27866b63d4f5c92f1d"
+			"Rev": "05914d821849570fba9eacfb29466f2d8d3cd229"
 		},
 		{
 			"ImportPath": "k8s.io/api/autoscaling/v2beta2",
-			"Rev": "d01564359763a39d310efc27866b63d4f5c92f1d"
+			"Rev": "05914d821849570fba9eacfb29466f2d8d3cd229"
 		},
 		{
 			"ImportPath": "k8s.io/api/batch/v1",
-			"Rev": "d01564359763a39d310efc27866b63d4f5c92f1d"
+			"Rev": "05914d821849570fba9eacfb29466f2d8d3cd229"
 		},
 		{
 			"ImportPath": "k8s.io/api/batch/v1beta1",
-			"Rev": "d01564359763a39d310efc27866b63d4f5c92f1d"
+			"Rev": "05914d821849570fba9eacfb29466f2d8d3cd229"
 		},
 		{
 			"ImportPath": "k8s.io/api/batch/v2alpha1",
-			"Rev": "d01564359763a39d310efc27866b63d4f5c92f1d"
+			"Rev": "05914d821849570fba9eacfb29466f2d8d3cd229"
 		},
 		{
 			"ImportPath": "k8s.io/api/certificates/v1beta1",
-			"Rev": "d01564359763a39d310efc27866b63d4f5c92f1d"
+			"Rev": "05914d821849570fba9eacfb29466f2d8d3cd229"
 		},
 		{
 			"ImportPath": "k8s.io/api/coordination/v1beta1",
-			"Rev": "d01564359763a39d310efc27866b63d4f5c92f1d"
+			"Rev": "05914d821849570fba9eacfb29466f2d8d3cd229"
 		},
 		{
 			"ImportPath": "k8s.io/api/core/v1",
-			"Rev": "d01564359763a39d310efc27866b63d4f5c92f1d"
+			"Rev": "05914d821849570fba9eacfb29466f2d8d3cd229"
 		},
 		{
 			"ImportPath": "k8s.io/api/events/v1beta1",
-			"Rev": "d01564359763a39d310efc27866b63d4f5c92f1d"
+			"Rev": "05914d821849570fba9eacfb29466f2d8d3cd229"
 		},
 		{
 			"ImportPath": "k8s.io/api/extensions/v1beta1",
-			"Rev": "d01564359763a39d310efc27866b63d4f5c92f1d"
+			"Rev": "05914d821849570fba9eacfb29466f2d8d3cd229"
 		},
 		{
 			"ImportPath": "k8s.io/api/imagepolicy/v1alpha1",
-			"Rev": "d01564359763a39d310efc27866b63d4f5c92f1d"
+			"Rev": "05914d821849570fba9eacfb29466f2d8d3cd229"
 		},
 		{
 			"ImportPath": "k8s.io/api/networking/v1",
-			"Rev": "d01564359763a39d310efc27866b63d4f5c92f1d"
+			"Rev": "05914d821849570fba9eacfb29466f2d8d3cd229"
 		},
 		{
 			"ImportPath": "k8s.io/api/policy/v1beta1",
-			"Rev": "d01564359763a39d310efc27866b63d4f5c92f1d"
+			"Rev": "05914d821849570fba9eacfb29466f2d8d3cd229"
 		},
 		{
 			"ImportPath": "k8s.io/api/rbac/v1",
-			"Rev": "d01564359763a39d310efc27866b63d4f5c92f1d"
+			"Rev": "05914d821849570fba9eacfb29466f2d8d3cd229"
 		},
 		{
 			"ImportPath": "k8s.io/api/rbac/v1alpha1",
-			"Rev": "d01564359763a39d310efc27866b63d4f5c92f1d"
+			"Rev": "05914d821849570fba9eacfb29466f2d8d3cd229"
 		},
 		{
 			"ImportPath": "k8s.io/api/rbac/v1beta1",
-			"Rev": "d01564359763a39d310efc27866b63d4f5c92f1d"
+			"Rev": "05914d821849570fba9eacfb29466f2d8d3cd229"
 		},
 		{
 			"ImportPath": "k8s.io/api/scheduling/v1alpha1",
-			"Rev": "d01564359763a39d310efc27866b63d4f5c92f1d"
+			"Rev": "05914d821849570fba9eacfb29466f2d8d3cd229"
 		},
 		{
 			"ImportPath": "k8s.io/api/scheduling/v1beta1",
-			"Rev": "d01564359763a39d310efc27866b63d4f5c92f1d"
+			"Rev": "05914d821849570fba9eacfb29466f2d8d3cd229"
 		},
 		{
 			"ImportPath": "k8s.io/api/settings/v1alpha1",
-			"Rev": "d01564359763a39d310efc27866b63d4f5c92f1d"
+			"Rev": "05914d821849570fba9eacfb29466f2d8d3cd229"
 		},
 		{
 			"ImportPath": "k8s.io/api/storage/v1",
-			"Rev": "d01564359763a39d310efc27866b63d4f5c92f1d"
+			"Rev": "05914d821849570fba9eacfb29466f2d8d3cd229"
 		},
 		{
 			"ImportPath": "k8s.io/api/storage/v1alpha1",
-			"Rev": "d01564359763a39d310efc27866b63d4f5c92f1d"
+			"Rev": "05914d821849570fba9eacfb29466f2d8d3cd229"
 		},
 		{
 			"ImportPath": "k8s.io/api/storage/v1beta1",
-			"Rev": "d01564359763a39d310efc27866b63d4f5c92f1d"
+			"Rev": "05914d821849570fba9eacfb29466f2d8d3cd229"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/api/apitesting",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/api/apitesting/fuzzer",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/api/apitesting/roundtrip",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/api/equality",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/api/errors",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/api/meta",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/api/resource",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/apis/meta/fuzzer",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/apis/meta/internalversion",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/apis/meta/v1",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/apis/meta/v1beta1",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/conversion",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/conversion/queryparams",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/fields",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/labels",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/runtime",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/runtime/schema",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer/json",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer/protobuf",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer/recognizer",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer/streaming",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer/versioning",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/selection",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/types",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/cache",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/clock",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/diff",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/errors",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/framer",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/httpstream",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/httpstream/spdy",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/intstr",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/json",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/mergepatch",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/naming",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/net",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/remotecommand",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/runtime",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/sets",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/strategicpatch",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/validation",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/validation/field",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/wait",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/yaml",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/version",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/watch",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/third_party/forked/golang/json",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/third_party/forked/golang/netutil",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/third_party/forked/golang/reflect",
-			"Rev": "0028e7a3cc82b29fea214c5793c77c24a23bb3ef"
+			"Rev": "2b1284ed4c93a43499e781493253e2ac5959c4fd"
 		},
 		{
 			"ImportPath": "k8s.io/klog",

--- a/vendor/k8s.io/client-go/README.md
+++ b/vendor/k8s.io/client-go/README.md
@@ -2,7 +2,7 @@
 
 Go clients for talking to a [kubernetes](http://kubernetes.io/) cluster.
 
-We currently recommend using the v9.0.0 tag. See [INSTALL.md](/INSTALL.md) for
+We currently recommend using the v10.0.0 tag. See [INSTALL.md](/INSTALL.md) for
 detailed installation instructions. `go get k8s.io/client-go/...` works, but
 will build `master`, which doesn't handle the dependencies well.
 
@@ -91,16 +91,16 @@ We will backport bugfixes--but not new features--into older versions of
 
 #### Compatibility matrix
 
-|                     | Kubernetes 1.6 | Kubernetes 1.7 | Kubernetes 1.8 | Kubernetes 1.9 | Kubernetes 1.10 | Kubernetes 1.11 | Kubernetes 1.12 |
-|---------------------|----------------|----------------|----------------|----------------|-----------------|-----------------|-----------------|
-| client-go 3.0       | ✓              | -              | +-             | +-             | +-              | +-              | +-              |
-| client-go 4.0       | +-             | ✓              | +-             | +-             | +-              | +-              | +-              |
-| client-go 5.0       | +-             | +-             | ✓              | +-             | +-              | +-              | +-              |
-| client-go 6.0       | +-             | +-             | +-             | ✓              | +-              | +-              | +-              |
-| client-go 7.0       | +-             | +-             | +-             | +-             | ✓               | +-              | +-              |
-| client-go 8.0       | +-             | +-             | +-             | +-             | +-              | ✓               | +-              |
-| client-go 9.0       | +-             | +-             | +-             | +-             | +-              | +-              | ✓               |
-| client-go HEAD      | +-             | +-             | +-             | +-             | +-              | +-              | +-              |
+|                     | Kubernetes 1.7 | Kubernetes 1.8 | Kubernetes 1.9 | Kubernetes 1.10 | Kubernetes 1.11 | Kubernetes 1.12 | Kubernetes 1.13 |
+|---------------------|----------------|----------------|----------------|-----------------|-----------------|-----------------|-----------------|
+| client-go 4.0       | ✓              | +-             | +-             | +-              | +-              | +-              | +-              |
+| client-go 5.0       | +-             | ✓              | +-             | +-              | +-              | +-              | +-              |
+| client-go 6.0       | +-             | +-             | ✓              | +-              | +-              | +-              | +-              |
+| client-go 7.0       | +-             | +-             | +-             | ✓               | +-              | +-              | +-              |
+| client-go 8.0       | +-             | +-             | +-             | +-              | ✓               | +-              | +-              |
+| client-go 9.0       | +-             | +-             | +-             | +-              | +-              | ✓               | +-              |
+| client-go 10.0      | +-             | +-             | +-             | +-              | +-              | +-              | ✓               |
+| client-go HEAD      | +-             | +-             | +-             | +-              | +-              | +-              | +-              |
 
 Key:
 
@@ -128,9 +128,10 @@ between client-go versions.
 | client-go 4.0  | Kubernetes main repo, 1.7 branch     | = -                           |
 | client-go 5.0  | Kubernetes main repo, 1.8 branch     | = -                           |
 | client-go 6.0  | Kubernetes main repo, 1.9 branch     | = -                           |
-| client-go 7.0  | Kubernetes main repo, 1.10 branch    | ✓                             |
+| client-go 7.0  | Kubernetes main repo, 1.10 branch    | = -                           |
 | client-go 8.0  | Kubernetes main repo, 1.11 branch    | ✓                             |
 | client-go 9.0  | Kubernetes main repo, 1.12 branch    | ✓                             |
+| client-go 10.0 | Kubernetes main repo, 1.13 branch    | ✓                             |
 | client-go HEAD | Kubernetes main repo, master branch  | ✓                             |
 
 Key:

--- a/vendor/k8s.io/client-go/rest/config_test.go
+++ b/vendor/k8s.io/client-go/rest/config_test.go
@@ -264,6 +264,7 @@ func TestAnonymousConfig(t *testing.T) {
 		// is added to Config, update AnonymousClientConfig to preserve the field otherwise.
 		expected.Impersonate = ImpersonationConfig{}
 		expected.BearerToken = ""
+		expected.BearerTokenFile = ""
 		expected.Username = ""
 		expected.Password = ""
 		expected.AuthProvider = nil

--- a/vendor/k8s.io/client-go/tools/clientcmd/client_config.go
+++ b/vendor/k8s.io/client-go/tools/clientcmd/client_config.go
@@ -229,11 +229,12 @@ func (config *DirectClientConfig) getUserIdentificationPartialConfig(configAuthI
 	if len(configAuthInfo.Token) > 0 {
 		mergedConfig.BearerToken = configAuthInfo.Token
 	} else if len(configAuthInfo.TokenFile) > 0 {
-		ts := restclient.NewCachedFileTokenSource(configAuthInfo.TokenFile)
-		if _, err := ts.Token(); err != nil {
+		tokenBytes, err := ioutil.ReadFile(configAuthInfo.TokenFile)
+		if err != nil {
 			return nil, err
 		}
-		mergedConfig.WrapTransport = restclient.TokenSourceWrapTransport(ts)
+		mergedConfig.BearerToken = string(tokenBytes)
+		mergedConfig.BearerTokenFile = configAuthInfo.TokenFile
 	}
 	if len(configAuthInfo.Impersonate) > 0 {
 		mergedConfig.Impersonate = restclient.ImpersonationConfig{

--- a/vendor/k8s.io/client-go/tools/clientcmd/client_config_test.go
+++ b/vendor/k8s.io/client-go/tools/clientcmd/client_config_test.go
@@ -18,7 +18,6 @@ package clientcmd
 
 import (
 	"io/ioutil"
-	"net/http"
 	"os"
 	"reflect"
 	"strings"
@@ -334,19 +333,7 @@ func TestBasicTokenFile(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	var out *http.Request
-	clientConfig.WrapTransport(fakeTransport(func(req *http.Request) (*http.Response, error) {
-		out = req
-		return &http.Response{}, nil
-	})).RoundTrip(&http.Request{})
-
-	matchStringArg(token, strings.TrimPrefix(out.Header.Get("Authorization"), "Bearer "), t)
-}
-
-type fakeTransport func(*http.Request) (*http.Response, error)
-
-func (ft fakeTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	return ft(req)
+	matchStringArg(token, clientConfig.BearerToken, t)
 }
 
 func TestPrecedenceTokenFile(t *testing.T) {

--- a/vendor/k8s.io/client-go/transport/config.go
+++ b/vendor/k8s.io/client-go/transport/config.go
@@ -39,6 +39,11 @@ type Config struct {
 	// Bearer token for authentication
 	BearerToken string
 
+	// Path to a file containing a BearerToken.
+	// If set, the contents are periodically read.
+	// The last successfully read value takes precedence over BearerToken.
+	BearerTokenFile string
+
 	// Impersonate is the config that this Config will impersonate using
 	Impersonate ImpersonationConfig
 
@@ -80,7 +85,7 @@ func (c *Config) HasBasicAuth() bool {
 
 // HasTokenAuth returns whether the configuration has token authentication or not.
 func (c *Config) HasTokenAuth() bool {
-	return len(c.BearerToken) != 0
+	return len(c.BearerToken) != 0 || len(c.BearerTokenFile) != 0
 }
 
 // HasCertAuth returns whether the configuration has certificate authentication or not.

--- a/vendor/k8s.io/client-go/transport/round_trippers.go
+++ b/vendor/k8s.io/client-go/transport/round_trippers.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/oauth2"
 	"k8s.io/klog"
 
 	utilnet "k8s.io/apimachinery/pkg/util/net"
@@ -44,7 +45,11 @@ func HTTPWrappersForConfig(config *Config, rt http.RoundTripper) (http.RoundTrip
 	case config.HasBasicAuth() && config.HasTokenAuth():
 		return nil, fmt.Errorf("username/password or bearer token may be set, but not both")
 	case config.HasTokenAuth():
-		rt = NewBearerAuthRoundTripper(config.BearerToken, rt)
+		var err error
+		rt, err = NewBearerAuthWithRefreshRoundTripper(config.BearerToken, config.BearerTokenFile, rt)
+		if err != nil {
+			return nil, err
+		}
 	case config.HasBasicAuth():
 		rt = NewBasicAuthRoundTripper(config.Username, config.Password, rt)
 	}
@@ -265,13 +270,35 @@ func (rt *impersonatingRoundTripper) WrappedRoundTripper() http.RoundTripper { r
 
 type bearerAuthRoundTripper struct {
 	bearer string
+	source oauth2.TokenSource
 	rt     http.RoundTripper
 }
 
 // NewBearerAuthRoundTripper adds the provided bearer token to a request
 // unless the authorization header has already been set.
 func NewBearerAuthRoundTripper(bearer string, rt http.RoundTripper) http.RoundTripper {
-	return &bearerAuthRoundTripper{bearer, rt}
+	return &bearerAuthRoundTripper{bearer, nil, rt}
+}
+
+// NewBearerAuthRoundTripper adds the provided bearer token to a request
+// unless the authorization header has already been set.
+// If tokenFile is non-empty, it is periodically read,
+// and the last successfully read content is used as the bearer token.
+// If tokenFile is non-empty and bearer is empty, the tokenFile is read
+// immediately to populate the initial bearer token.
+func NewBearerAuthWithRefreshRoundTripper(bearer string, tokenFile string, rt http.RoundTripper) (http.RoundTripper, error) {
+	if len(tokenFile) == 0 {
+		return &bearerAuthRoundTripper{bearer, nil, rt}, nil
+	}
+	source := NewCachedFileTokenSource(tokenFile)
+	if len(bearer) == 0 {
+		token, err := source.Token()
+		if err != nil {
+			return nil, err
+		}
+		bearer = token.AccessToken
+	}
+	return &bearerAuthRoundTripper{bearer, source, rt}, nil
 }
 
 func (rt *bearerAuthRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -280,7 +307,13 @@ func (rt *bearerAuthRoundTripper) RoundTrip(req *http.Request) (*http.Response, 
 	}
 
 	req = utilnet.CloneRequest(req)
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", rt.bearer))
+	token := rt.bearer
+	if rt.source != nil {
+		if refreshedToken, err := rt.source.Token(); err == nil {
+			token = refreshedToken.AccessToken
+		}
+	}
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 	return rt.rt.RoundTrip(req)
 }
 

--- a/vendor/k8s.io/client-go/transport/token_source.go
+++ b/vendor/k8s.io/client-go/transport/token_source.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package rest
+package transport
 
 import (
 	"fmt"

--- a/vendor/k8s.io/client-go/transport/token_source_test.go
+++ b/vendor/k8s.io/client-go/transport/token_source_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package rest
+package transport
 
 import (
 	"fmt"


### PR DESCRIPTION
Update dependencies to k8s 1.13.1 based on the release-1.0 branch.
This is a temporary branch to test with kubebuilder as the latest kubebuilder release depends on k8s 1.13.1.