### PR TITLE
Leader election lock name should include driver name

### DIFF
--- a/cmd/csi-snapshotter/main.go
+++ b/cmd/csi-snapshotter/main.go
@@ -73,8 +73,8 @@ var (
 )
 
 var (
-	version                = "unknown"
-	leaderElectionLockName = "external-snapshotter-leader-election"
+	version = "unknown"
+	prefix  = "external-snapshotter-leader"
 )
 
 func main() {
@@ -214,7 +214,8 @@ func main() {
 	if !*leaderElection {
 		run(context.TODO())
 	} else {
-		le := leaderelection.NewLeaderElection(kubeClient, leaderElectionLockName, run)
+		lockName := fmt.Sprintf("%s-%s", prefix, strings.Replace(*snapshotterName, "/", "-", -1))
+		le := leaderelection.NewLeaderElection(kubeClient, lockName, run)
 		if *leaderElectionNamespace != "" {
 			le.WithNamespace(*leaderElectionNamespace)
 		}

--- a/cmd/csi-snapshotter/main.go
+++ b/cmd/csi-snapshotter/main.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"strings"
 	"time"
 
 	"google.golang.org/grpc"


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
CSI has many controllers with leader election functionality. It's best to disambiguate between all the different locks used for LE

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #128 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add a prefix "external-snapshotter-leader" and the driver name to the snapshotter leader election lock name.
```
