### PR TITLE
Stop calling CreateSnapshot when ReadyToUse is true

### DIFF
--- a/pkg/sidecar-controller/snapshot_controller.go
+++ b/pkg/sidecar-controller/snapshot_controller.go
@@ -80,6 +80,13 @@ func (ctrl *csiSnapshotSideCarController) syncContent(content *crdv1.VolumeSnaps
 				return err
 			}
 		} else {
+			// Skip checkandUpdateContentStatus() if ReadyToUse is
+			// already true. We don't want to keep calling CreateSnapshot
+			// or ListSnapshots CSI methods over and over again for
+			// performance reasons.
+			if content.Status != nil && content.Status.ReadyToUse != nil && *content.Status.ReadyToUse == true {
+				return nil
+			}
 			if err = ctrl.checkandUpdateContentStatus(content); err != nil {
 				ctrl.updateContentErrorStatusWithEvent(content, v1.EventTypeWarning, "SnapshotContentStatusUpdateFailed", fmt.Sprintf("Failed to update snapshot content status with error %v", err))
 				return err


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR stops calling CSI CreateSnapshot when ReadyToUse is already true in VolumeSnapshotContent status.

**Which issue(s) this PR fixes**:
Fixes #223 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
