### PR TITLE
doc: add workaround for hack/update-generated-code.sh

### DIFF
--- a/hack/README.md
+++ b/hack/README.md
@@ -10,7 +10,35 @@ This is the script to update clientset/informers/listers and API deepcopy code u
 
 Make sure to run this script after making changes to /pkg/apis/volumesnapshot/v1beta1/types.go.
 
-To run this script, simply run: ./hack/update-generated-code.sh from the project root directory.
+To run this script, you have to patch it:
+```patch
+diff --git a/hack/update-generated-code.sh b/hack/update-generated-code.sh
+--- a/hack/update-generated-code.sh
++++ b/hack/update-generated-code.sh
+@@ -27,7 +27,7 @@ CODEGEN_PKG=${CODEGEN_PKG:-$(cd ${SCRIPT_ROOT}; ls -d -1 ./vendor/k8s.io/code-ge
+ #                  k8s.io/kubernetes. The output-base is needed for the generators to output into the vendor dir
+ #                  instead of the $GOPATH directly. For normal projects this can be dropped.
+ bash ${CODEGEN_PKG}/generate-groups.sh "deepcopy,client,informer,lister" \
+-  github.com/kubernetes-csi/external-snapshotter/pkg/client github.com/kubernetes-csi/external-snapshotter/pkg/apis \
++  github.com/kubernetes-csi/external-snapshotter/v2/pkg/client github.com/kubernetes-csi/external-snapshotter/v2/pkg/apis \
+   volumesnapshot:v1beta1 \
+   --go-header-file ${SCRIPT_ROOT}/hack/boilerplate.go.txt
+```
+
+Once you are done with patching, continue:
+```bash
+rm -fr v2/
+ln -sfvn $(pwd) v2
+rm -fr pkg/client
+```
+
+Run: ./hack/update-generated-code.sh from the project root directory.
+
+Do not forget to revert previously applied workaround:
+```bash
+git checkout -- v2/
+git checkout -- hack/update-generated-code.sh
+```
 
 ## update-crd.sh
 


### PR DESCRIPTION
****What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
Add missing workaround to hack/update-generated-code.sh

**Which issue(s) this PR fixes**:
Fixes #239

**Special notes for your reviewer**:
As per reviewer's request https://github.com/kubernetes-csi/external-snapshotter/issues/239#issuecomment-577985400, added the steps to let users to use update-generated-code.sh..
**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

