### PR TITLE
Makes the number of worker threads configurable.

### DIFF
--- a/cmd/csi-snapshotter/main.go
+++ b/cmd/csi-snapshotter/main.go
@@ -48,9 +48,6 @@ import (
 )
 
 const (
-	// Number of worker threads
-	threads = 10
-
 	// Default timeout of short CSI calls like GetPluginInfo
 	defaultCSITimeout = time.Minute
 )
@@ -63,6 +60,7 @@ var (
 	snapshotNamePrefix     = flag.String("snapshot-name-prefix", "snapshot", "Prefix to apply to the name of a created snapshot")
 	snapshotNameUUIDLength = flag.Int("snapshot-name-uuid-length", -1, "Length in characters for the generated uuid of a created snapshot. Defaults behavior is to NOT truncate.")
 	showVersion            = flag.Bool("version", false, "Show version.")
+	threads                = flag.Int("worker-threads", 10, "Number of worker threads.")
 	csiTimeout             = flag.Duration("timeout", defaultCSITimeout, "The timeout for any RPCs to the CSI driver. Default is 1 minute.")
 
 	leaderElection          = flag.Bool("leader-election", false, "Enables leader election.")
@@ -182,7 +180,7 @@ func main() {
 		stopCh := make(chan struct{})
 		factory.Start(stopCh)
 		coreFactory.Start(stopCh)
-		go ctrl.Run(threads, stopCh)
+		go ctrl.Run(*threads, stopCh)
 
 		// ...until SIGINT
 		c := make(chan os.Signal, 1)

--- a/cmd/snapshot-controller/main.go
+++ b/cmd/snapshot-controller/main.go
@@ -39,16 +39,12 @@ import (
 	coreinformers "k8s.io/client-go/informers"
 )
 
-const (
-	// Number of worker threads
-	threads = 10
-)
-
 // Command line flags
 var (
 	kubeconfig   = flag.String("kubeconfig", "", "Absolute path to the kubeconfig file. Required only when running out of cluster.")
 	resyncPeriod = flag.Duration("resync-period", 60*time.Second, "Resync interval of the controller.")
 	showVersion  = flag.Bool("version", false, "Show version.")
+	threads      = flag.Int("worker-threads", 10, "Number of worker threads.")
 
 	leaderElection          = flag.Bool("leader-election", false, "Enables leader election.")
 	leaderElectionNamespace = flag.String("leader-election-namespace", "", "The namespace where the leader election resource exists. Defaults to the pod namespace if not set.")
@@ -111,7 +107,7 @@ func main() {
 		stopCh := make(chan struct{})
 		factory.Start(stopCh)
 		coreFactory.Start(stopCh)
-		go ctrl.Run(threads, stopCh)
+		go ctrl.Run(*threads, stopCh)
 
 		// ...until SIGINT
 		c := make(chan os.Signal, 1)


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Adjusts the worker threads to be configurable for the snapshot-controller and csi-snapshotter.

**Which issue(s) this PR fixes**:
Fixes #276 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
The number of worker threads in the snapshot-controller and csi-snapshotter is now configurable via the `worker-threads` flag.
```
