### PR TITLE
Add event for snapshotting in progress

### DIFF
--- a/pkg/common-controller/snapshot_controller.go
+++ b/pkg/common-controller/snapshot_controller.go
@@ -682,6 +682,9 @@ func (ctrl *csiSnapshotCommonController) createSnapshotContent(snapshot *crdv1.V
 		return nil, newControllerUpdateError(utils.SnapshotKey(snapshot), err.Error())
 	}
 
+	msg := fmt.Sprintf("Waiting for a snapshot %s to be created by the CSI driver.", utils.SnapshotKey(snapshot))
+	ctrl.eventRecorder.Event(snapshot, v1.EventTypeNormal, "CreatingSnapshot", msg)
+
 	// Update content in the cache store
 	_, err = ctrl.storeContentUpdate(updateContent)
 	if err != nil {

--- a/pkg/common-controller/snapshot_create_test.go
+++ b/pkg/common-controller/snapshot_create_test.go
@@ -206,7 +206,7 @@ func TestCreateSnapshotSync(t *testing.T) {
 				{"update", "volumesnapshots", errors.New("mock update error")},
 				{"update", "volumesnapshots", errors.New("mock update error")},
 			},
-			expectedEvents: []string{"Warning SnapshotStatusUpdateFailed"},
+			expectedEvents: []string{"Normal CreatingSnapshot"},
 			expectSuccess:  false,
 			test:           testSyncSnapshot,
 		},


### PR DESCRIPTION
Signed-off-by: zhuc <zhucan.k8s@gmail.com>

**What type of PR is this?**
> /kind feature

**What this PR does / why we need it**:
Need to add an event on the VolumeSnapshot API object after we've created VolumeSnapshotContent in the common controller

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #268 

**Special notes for your reviewer**:
@xing-yang 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add event for snapshotting in progress
```
