### PR TITLE
Remove snapshot Finalizer if content deletionPolicy changes

### DIFF
--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -356,6 +356,11 @@ func NeedToAddSnapshotBoundFinalizer(snapshot *crdv1.VolumeSnapshot) bool {
 	return snapshot.ObjectMeta.DeletionTimestamp == nil && !slice.ContainsString(snapshot.ObjectMeta.Finalizers, VolumeSnapshotBoundFinalizer, nil) && IsBoundVolumeSnapshotContentNameSet(snapshot)
 }
 
+// NeedToRemoveSnapshotBoundFinalizer checks if the volume snapshot content Finalizer is on the content and the deletionPolicy is Retain
+func NeedToRemoveSnapshotBoundFinalizer(snapshot *crdv1.VolumeSnapshot, content *crdv1.VolumeSnapshotContent) bool {
+	return slice.ContainsString(snapshot.ObjectMeta.Finalizers, VolumeSnapshotBoundFinalizer, nil) && content.Spec.DeletionPolicy == crdv1.VolumeSnapshotContentRetain
+}
+
 func deprecationWarning(deprecatedParam, newParam, removalVersion string) string {
 	if removalVersion == "" {
 		removalVersion = "a future release"


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Previously, if a VolumeSnapshot was created from a class with the Delete DeletionPolicy and the content was updated to have the Retain policy, then the VolumeSnapshot would persist as the finalizer remained on it indefinitely. Now, the VolumeSnapshot is updated to remove the finalizer if the associated content has its deletionPolicy updated.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
If the VolumeSnapshotContent's DeletionPolicy is modified to Retain, then the associated VolumeSnapshot can be successfully deleted.
```
