### PR TITLE
Deletes snapshot if associated content has a deletion timestamp

### DIFF
--- a/pkg/common-controller/snapshot_controller.go
+++ b/pkg/common-controller/snapshot_controller.go
@@ -327,7 +327,7 @@ func (ctrl *csiSnapshotCommonController) checkandRemoveSnapshotFinalizersAndChec
 	//       by snapshot sidecar controller.
 	//    c. If deletion will not cascade to the content, remove the finalizer on
 	//       the snapshot such that it can be removed from API server.
-	removeBoundFinalizer := !(content != nil && deleteContent)
+	removeBoundFinalizer := !((content != nil && content.ObjectMeta.DeletionTimestamp == nil) && deleteContent)
 	return ctrl.removeSnapshotFinalizer(snapshot, true, removeBoundFinalizer)
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When running the e2e tests, it seems that ~2% of the time some of the VolumeSnapshot and VolumeSnapshotContent resources remain behind. Both contain a DeletionTimestamp, but the bound finalizer prevents either from ultimately being deleted.

This PR adjusts the way we delete VolumeSnapshots, so that if the associated VolumeSnapshotContent exists but has a DeletionTimestamp, then we'll go ahead and proceed with deleting the VolumeSnapshot.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
