### PR TITLE
Emit event even if status update fails

### DIFF
--- a/pkg/common-controller/snapshot_controller.go
+++ b/pkg/common-controller/snapshot_controller.go
@@ -741,13 +741,13 @@ func (ctrl *csiSnapshotCommonController) updateSnapshotErrorStatusWithEvent(snap
 	snapshotClone.Status.ReadyToUse = &ready
 	newSnapshot, err := ctrl.clientset.SnapshotV1beta1().VolumeSnapshots(snapshotClone.Namespace).UpdateStatus(context.TODO(), snapshotClone, metav1.UpdateOptions{})
 
+	// Emit the event even if the status update fails so that user can see the error
+	ctrl.eventRecorder.Event(newSnapshot, eventtype, reason, message)
+
 	if err != nil {
 		klog.V(4).Infof("updating VolumeSnapshot[%s] error status failed %v", utils.SnapshotKey(snapshot), err)
 		return err
 	}
-
-	// Emit the event only when the status change happens
-	ctrl.eventRecorder.Event(newSnapshot, eventtype, reason, message)
 
 	_, err = ctrl.storeSnapshotUpdate(newSnapshot)
 	if err != nil {

--- a/pkg/sidecar-controller/snapshot_controller.go
+++ b/pkg/sidecar-controller/snapshot_controller.go
@@ -159,13 +159,13 @@ func (ctrl *csiSnapshotSideCarController) updateContentErrorStatusWithEvent(cont
 	contentClone.Status.ReadyToUse = &ready
 	newContent, err := ctrl.clientset.SnapshotV1beta1().VolumeSnapshotContents().UpdateStatus(context.TODO(), contentClone, metav1.UpdateOptions{})
 
+	// Emit the event even if the status update fails so that user can see the error
+	ctrl.eventRecorder.Event(newContent, eventtype, reason, message)
+
 	if err != nil {
 		klog.V(4).Infof("updating VolumeSnapshotContent[%s] error status failed %v", content.Name, err)
 		return err
 	}
-
-	// Emit the event only when the status change happens
-	ctrl.eventRecorder.Event(newContent, eventtype, reason, message)
 
 	_, err = ctrl.storeContentUpdate(newContent)
 	if err != nil {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR moves the event up so event will be emitted even if snapshot/content status update fails so user can see the error.

**Which issue(s) this PR fixes**:
Fixes #346 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Emit event even if status update fails.
```
