### PR TITLE
Update release-1.2 to use csi-snapshotter v1.2.2

### DIFF
--- a/deploy/kubernetes/setup-csi-snapshotter.yaml
+++ b/deploy/kubernetes/setup-csi-snapshotter.yaml
@@ -85,7 +85,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-snapshotter
-          image: quay.io/k8scsi/csi-snapshotter:v1.1.0
+          image: k8s.gcr.io/sig-storage/csi-snapshotter:v1.2.2
           args:
             - "--csi-address=$(ADDRESS)"
             - "--connection-timeout=15s"


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
updates release-1.2 branch to use the latest 1.2.x image, v1.2.2.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
v1.2.2 is not yet on gcr.io, unless the image name changed for 1.x on gcr.io?
```
~ docker pull k8s.gcr.io/sig-storage/csi-snapshotter:v1.2.2


Error response from daemon: manifest for k8s.gcr.io/sig-storage/csi-snapshotter:v1.2.2 not found
```

**Does this PR introduce a user-facing change?**
```release-note
NONE
```
