### PR TITLE
Fix the failing multiarch builds

### DIFF
--- a/cmd/csi-snapshotter/Dockerfile
+++ b/cmd/csi-snapshotter/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/static:latest
+FROM gcr.io/distroless/static:latest-amd64
 LABEL maintainers="Kubernetes Authors"
 LABEL description="CSI External Snapshotter Sidecar"
 ARG binary=./bin/csi-snapshotter

--- a/cmd/snapshot-controller/Dockerfile
+++ b/cmd/snapshot-controller/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/static:latest
+FROM gcr.io/distroless/static:latest-amd64
 LABEL maintainers="Kubernetes Authors"
 LABEL description="Snapshot Controller"
 ARG binary=./bin/snapshot-controller

--- a/cmd/snapshot-validation-webhook/Dockerfile
+++ b/cmd/snapshot-validation-webhook/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/base:latest
+FROM gcr.io/distroless/base:latest-amd64
 LABEL maintainers="Kubernetes Authors"
 LABEL description="Snapshot Validation Webhook"
 ARG binary=./bin/snapshot-validation-webhook


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**: As distroless image is now multiarch, image push job fails on s390x and ppc64le due to lack of support.

**Which issue(s) this PR fixes**:
Fixes # https://github.com/kubernetes-csi/csi-release-tools/issues/105

**Special notes for your reviewer**: Workaround to allow builds to pass while we add support to distroless image.

**Does this PR introduce a user-facing change?**: 
```release-note
Changing distroless base image from multiarch to -amd64 to fix Prow builds
```
