### PR TITLE
Revert to multiarch distroless base image

### DIFF
--- a/cmd/csi-snapshotter/Dockerfile
+++ b/cmd/csi-snapshotter/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/static:latest-amd64
+FROM gcr.io/distroless/static:latest
 LABEL maintainers="Kubernetes Authors"
 LABEL description="CSI External Snapshotter Sidecar"
 ARG binary=./bin/csi-snapshotter

--- a/cmd/snapshot-controller/Dockerfile
+++ b/cmd/snapshot-controller/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/static:latest-amd64
+FROM gcr.io/distroless/static:latest
 LABEL maintainers="Kubernetes Authors"
 LABEL description="Snapshot Controller"
 ARG binary=./bin/snapshot-controller

--- a/cmd/snapshot-validation-webhook/Dockerfile
+++ b/cmd/snapshot-validation-webhook/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/base:latest-amd64
+FROM gcr.io/distroless/base:latest
 LABEL maintainers="Kubernetes Authors"
 LABEL description="Snapshot Validation Webhook"
 ARG binary=./bin/snapshot-validation-webhook


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**: Support for s390x/ppc64le has been added to distroless static/base images and hence the Dockerfiles can go back to using multiarch images.

**Which issue(s) this PR fixes**:

Fixes # https://github.com/kubernetes-csi/csi-release-tools/issues/105

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note

Changing distroless image back to multiarch
```