### PR TITLE
master: update release-tools

### DIFF
--- a/release-tools/build.make
+++ b/release-tools/build.make
@@ -69,12 +69,17 @@ endif
 # toolchain.
 BUILD_PLATFORMS =
 
+# Add go ldflags using LDFLAGS at the time of compilation.
+IMPORTPATH_LDFLAGS = -X main.version=$(REV) 
+EXT_LDFLAGS = -extldflags "-static"
+LDFLAGS = 
+FULL_LDFLAGS = $(LDFLAGS) $(IMPORTPATH_LDFLAGS) $(EXT_LDFLAGS)
 # This builds each command (= the sub-directories of ./cmd) for the target platform(s)
 # defined by BUILD_PLATFORMS.
 $(CMDS:%=build-%): build-%: check-go-version-go
 	mkdir -p bin
 	echo '$(BUILD_PLATFORMS)' | tr ';' '\n' | while read -r os arch suffix; do \
-		if ! (set -x; CGO_ENABLED=0 GOOS="$$os" GOARCH="$$arch" go build $(GOFLAGS_VENDOR) -a -ldflags '-X main.version=$(REV) -extldflags "-static"' -o "./bin/$*$$suffix" ./cmd/$*); then \
+		if ! (set -x; CGO_ENABLED=0 GOOS="$$os" GOARCH="$$arch" go build $(GOFLAGS_VENDOR) -a -ldflags '$(FULL_LDFLAGS)' -o "./bin/$*$$suffix" ./cmd/$*); then \
 			echo "Building $* for GOOS=$$os GOARCH=$$arch failed, see error(s) above."; \
 			exit 1; \
 		fi; \


### PR DESCRIPTION
Squashed 'release-tools/' changes from 3041b8a4..4aff857d

[4aff857d](https://github.com/kubernetes-csi/csi-release-tools/commit/4aff857d) Merge pull request #109 from pohly/alpha-test-defaults
[0427289d](https://github.com/kubernetes-csi/csi-release-tools/commit/0427289d) Merge pull request #110 from pohly/kind-0.9-bazel-build-workaround
[9a370ab9](https://github.com/kubernetes-csi/csi-release-tools/commit/9a370ab9) prow.sh: work around "kind build node-image" failure
[522361ec](https://github.com/kubernetes-csi/csi-release-tools/commit/522361ec) prow.sh: only run alpha tests for latest Kubernetes release
[22c0395c](https://github.com/kubernetes-csi/csi-release-tools/commit/22c0395c) Merge pull request #108 from bnrjee/master
[b5b447b5](https://github.com/kubernetes-csi/csi-release-tools/commit/b5b447b5) Add go ldflags using LDFLAGS at the time of compilation
[16f4afbd](https://github.com/kubernetes-csi/csi-release-tools/commit/16f4afbd) Merge pull request #107 from pohly/kind-update
[7bcee13d](https://github.com/kubernetes-csi/csi-release-tools/commit/7bcee13d) prow.sh: update to kind 0.9, support Kubernetes 1.19
[df518fbd](https://github.com/kubernetes-csi/csi-release-tools/commit/df518fbd) prow.sh: usage of Bazel optional
[c3afd427](https://github.com/kubernetes-csi/csi-release-tools/commit/c3afd427) Merge pull request #104 from xing-yang/snapshot
[dde93b22](https://github.com/kubernetes-csi/csi-release-tools/commit/dde93b22) Update to snapshot-controller v3.0.0
[a0f195cc](https://github.com/kubernetes-csi/csi-release-tools/commit/a0f195cc) Merge pull request #106 from msau42/fix-canary
[7100c120](https://github.com/kubernetes-csi/csi-release-tools/commit/7100c120) Only set staging registry when running canary job
[b3c65f9c](https://github.com/kubernetes-csi/csi-release-tools/commit/b3c65f9c) Merge pull request #99 from msau42/add-release-process
[e53f3e85](https://github.com/kubernetes-csi/csi-release-tools/commit/e53f3e85) Merge pull request #103 from msau42/fix-canary
[d1294628](https://github.com/kubernetes-csi/csi-release-tools/commit/d1294628) Document new method for adding CI jobs are new K8s versions
[e73c2ce5](https://github.com/kubernetes-csi/csi-release-tools/commit/e73c2ce5) Use staging registry for canary tests
[2c098465](https://github.com/kubernetes-csi/csi-release-tools/commit/2c098465) Add cleanup instructions to release-notes generation
[60e1cd3d](https://github.com/kubernetes-csi/csi-release-tools/commit/60e1cd3d) Merge pull request #98 from pohly/kubernetes-1-19-fixes
[0979c091](https://github.com/kubernetes-csi/csi-release-tools/commit/0979c091) prow.sh: fix E2E suite for Kubernetes >= 1.18
[3b4a2f1d](https://github.com/kubernetes-csi/csi-release-tools/commit/3b4a2f1d) prow.sh: fix installing Go for Kubernetes 1.19.0
[1fbb636c](https://github.com/kubernetes-csi/csi-release-tools/commit/1fbb636c) Merge pull request #97 from pohly/go-1.15
[82d108ac](https://github.com/kubernetes-csi/csi-release-tools/commit/82d108ac) switch to Go 1.15
[d8a25300](https://github.com/kubernetes-csi/csi-release-tools/commit/d8a25300) Merge pull request #95 from msau42/add-release-process
[843bddca](https://github.com/kubernetes-csi/csi-release-tools/commit/843bddca) Add steps on promoting release images
[0345a835](https://github.com/kubernetes-csi/csi-release-tools/commit/0345a835) Merge pull request #94 from linux-on-ibm-z/bump-timeout
[1fdf2d53](https://github.com/kubernetes-csi/csi-release-tools/commit/1fdf2d53) cloud build: bump timeout in Prow job
[41ec6d15](https://github.com/kubernetes-csi/csi-release-tools/commit/41ec6d15) Merge pull request #93 from animeshk08/patch-1
[5a54e67d](https://github.com/kubernetes-csi/csi-release-tools/commit/5a54e67d) filter-junit: Fix gofmt error
[0676fcbd](https://github.com/kubernetes-csi/csi-release-tools/commit/0676fcbd) Merge pull request #92 from animeshk08/patch-1
[36ea4ffa](https://github.com/kubernetes-csi/csi-release-tools/commit/36ea4ffa) filter-junit: Fix golint error
[f5a42037](https://github.com/kubernetes-csi/csi-release-tools/commit/f5a42037) Merge pull request #91 from cyb70289/arm64
[43e50d6f](https://github.com/kubernetes-csi/csi-release-tools/commit/43e50d6f) prow.sh: enable building arm64 image
[0d5bd843](https://github.com/kubernetes-csi/csi-release-tools/commit/0d5bd843) Merge pull request #90 from pohly/k8s-staging-sig-storage
[3df86b7d](https://github.com/kubernetes-csi/csi-release-tools/commit/3df86b7d) cloud build: k8s-staging-sig-storage
[c5fd9610](https://github.com/kubernetes-csi/csi-release-tools/commit/c5fd9610) Merge pull request #89 from pohly/cloud-build-binfmt
[db0c2a7d](https://github.com/kubernetes-csi/csi-release-tools/commit/db0c2a7d) cloud build: initialize support for running commands in Dockerfile
[be902f40](https://github.com/kubernetes-csi/csi-release-tools/commit/be902f40) Merge pull request #88 from pohly/multiarch-windows-fix
[340e082f](https://github.com/kubernetes-csi/csi-release-tools/commit/340e082f) build.make: optional inclusion of Windows in multiarch images
[5231f05d](https://github.com/kubernetes-csi/csi-release-tools/commit/5231f05d) build.make: properly declare push-multiarch
[4569f27a](https://github.com/kubernetes-csi/csi-release-tools/commit/4569f27a) build.make: fix push-multiarch ambiguity
[17dde9ef](https://github.com/kubernetes-csi/csi-release-tools/commit/17dde9ef) Merge pull request #87 from pohly/cloud-build
[bd416901](https://github.com/kubernetes-csi/csi-release-tools/commit/bd416901) cloud build: initial set of shared files
[9084fecb](https://github.com/kubernetes-csi/csi-release-tools/commit/9084fecb) Merge pull request #81 from msau42/add-release-process
[6f2322e8](https://github.com/kubernetes-csi/csi-release-tools/commit/6f2322e8) Update patch release notes generation command
[0fcc3b1b](https://github.com/kubernetes-csi/csi-release-tools/commit/0fcc3b1b) Merge pull request #78 from ggriffiths/fix_csi_snapshotter_rbac_version_set
[d8c76fee](https://github.com/kubernetes-csi/csi-release-tools/commit/d8c76fee) Support local snapshot RBAC for pull jobs
[c1bdf5bf](https://github.com/kubernetes-csi/csi-release-tools/commit/c1bdf5bf) Merge pull request #80 from msau42/add-release-process
[ea1f94aa](https://github.com/kubernetes-csi/csi-release-tools/commit/ea1f94aa) update release tools instructions
[152396e2](https://github.com/kubernetes-csi/csi-release-tools/commit/152396e2) Merge pull request #77 from ggriffiths/snapshotter201_update
[7edc1461](https://github.com/kubernetes-csi/csi-release-tools/commit/7edc1461) Update snapshotter to version 2.0.1
[4cf843f6](https://github.com/kubernetes-csi/csi-release-tools/commit/4cf843f6) Merge pull request #76 from pohly/build-targets
[3863a0f6](https://github.com/kubernetes-csi/csi-release-tools/commit/3863a0f6) build for multiple platforms only in CI, add s390x
[8322a7d0](https://github.com/kubernetes-csi/csi-release-tools/commit/8322a7d0) Merge pull request #72 from pohly/hostpath-update
[7c5a89c8](https://github.com/kubernetes-csi/csi-release-tools/commit/7c5a89c8) prow.sh: use 1.3.0 hostpath driver for testing
[b8587b2b](https://github.com/kubernetes-csi/csi-release-tools/commit/b8587b2b) Merge pull request #71 from wozniakjan/test-vet
[fdb32183](https://github.com/kubernetes-csi/csi-release-tools/commit/fdb32183) Change 'make test-vet' to call 'go vet'
[d717c8c4](https://github.com/kubernetes-csi/csi-release-tools/commit/d717c8c4) Merge pull request #69 from pohly/test-driver-config
[a1432bc9](https://github.com/kubernetes-csi/csi-release-tools/commit/a1432bc9) Merge pull request #70 from pohly/kubelet-feature-gates
[5f74333a](https://github.com/kubernetes-csi/csi-release-tools/commit/5f74333a) prow.sh: also configure feature gates for kubelet
[84f78b12](https://github.com/kubernetes-csi/csi-release-tools/commit/84f78b12) prow.sh: generic driver installation
[3c34b4f2](https://github.com/kubernetes-csi/csi-release-tools/commit/3c34b4f2) Merge pull request #67 from windayski/fix-link
[fa90abd0](https://github.com/kubernetes-csi/csi-release-tools/commit/fa90abd0) fix incorrect link
[ff3cc3f1](https://github.com/kubernetes-csi/csi-release-tools/commit/ff3cc3f1) Merge pull request #54 from msau42/add-release-process
[ac8a0212](https://github.com/kubernetes-csi/csi-release-tools/commit/ac8a0212) Document the process for releasing a new sidecar
[23be6525](https://github.com/kubernetes-csi/csi-release-tools/commit/23be6525) Merge pull request #65 from msau42/update-hostpath
[6582f2ff](https://github.com/kubernetes-csi/csi-release-tools/commit/6582f2ff) Update hostpath driver version to get fix for connection-timeout
[4cc91745](https://github.com/kubernetes-csi/csi-release-tools/commit/4cc91745) Merge pull request #64 from ggriffiths/snapshotter_2_version_update
[8191eab6](https://github.com/kubernetes-csi/csi-release-tools/commit/8191eab6) Update snapshotter to version v2.0.0
[3c463fb1](https://github.com/kubernetes-csi/csi-release-tools/commit/3c463fb1) Merge pull request #61 from msau42/enable-snapshots
[8b0316c7](https://github.com/kubernetes-csi/csi-release-tools/commit/8b0316c7) Fix overriding of junit results by using unique names for each e2e run
[5f444b80](https://github.com/kubernetes-csi/csi-release-tools/commit/5f444b80) Merge pull request #60 from saad-ali/updateHostpathVersion
[af9549b5](https://github.com/kubernetes-csi/csi-release-tools/commit/af9549b5) Update prow hostpath driver version to 1.3.0-rc2
[f6c74b30](https://github.com/kubernetes-csi/csi-release-tools/commit/f6c74b30) Merge pull request #57 from ggriffiths/version_gt_kubernetes_fix
[fc809759](https://github.com/kubernetes-csi/csi-release-tools/commit/fc809759) Fix version_gt to work with kubernetes prefix
[9f1f3dd8](https://github.com/kubernetes-csi/csi-release-tools/commit/9f1f3dd8) Merge pull request #56 from msau42/enable-snapshots
[b98b2aed](https://github.com/kubernetes-csi/csi-release-tools/commit/b98b2aed) Enable snapshot tests in 1.17 to be run in non-alpha jobs.
[9ace0204](https://github.com/kubernetes-csi/csi-release-tools/commit/9ace0204) Merge pull request #52 from msau42/update-readme
[540599ba](https://github.com/kubernetes-csi/csi-release-tools/commit/540599ba) Merge pull request #53 from msau42/fix-make
[a4e62996](https://github.com/kubernetes-csi/csi-release-tools/commit/a4e62996) fix syntax for ppc64le build
[771ca6f2](https://github.com/kubernetes-csi/csi-release-tools/commit/771ca6f2) Merge pull request #49 from ggriffiths/prowsh_improve_version_gt
[d7c69d2f](https://github.com/kubernetes-csi/csi-release-tools/commit/d7c69d2f) Merge pull request #51 from msau42/enable-multinode
[4ad69492](https://github.com/kubernetes-csi/csi-release-tools/commit/4ad69492) Improve snapshot pod running checks and improve version_gt
[53888ae7](https://github.com/kubernetes-csi/csi-release-tools/commit/53888ae7) Improve README by adding an explicit Kubernetes dependency section
[9a7a685e](https://github.com/kubernetes-csi/csi-release-tools/commit/9a7a685e) Create a kind cluster with two worker nodes so that the topology feature can be tested. Test cases that test accessing volumes from multiple nodes need to be skipped
[4ff2f5f0](https://github.com/kubernetes-csi/csi-release-tools/commit/4ff2f5f0) Merge pull request #50 from darkowlzz/kind-0.6.0
[80bba1fe](https://github.com/kubernetes-csi/csi-release-tools/commit/80bba1fe) Use kind v0.6.0
[6d674a7f](https://github.com/kubernetes-csi/csi-release-tools/commit/6d674a7f) Merge pull request #47 from Pensu/multi-arch
[8adde494](https://github.com/kubernetes-csi/csi-release-tools/commit/8adde494) Merge pull request #45 from ggriffiths/snapshot_beta_crds
[003c14b2](https://github.com/kubernetes-csi/csi-release-tools/commit/003c14b2) Add snapshotter CRDs after cluster setup
[a41f3860](https://github.com/kubernetes-csi/csi-release-tools/commit/a41f3860) Merge pull request #46 from mucahitkurt/kind-cluster-cleanup
[1eaaaa1c](https://github.com/kubernetes-csi/csi-release-tools/commit/1eaaaa1c) Delete kind cluster after tests run.
[83a4ef15](https://github.com/kubernetes-csi/csi-release-tools/commit/83a4ef15) Adding build for ppc64le
[4fcafece](https://github.com/kubernetes-csi/csi-release-tools/commit/4fcafece) Merge pull request #43 from pohly/system-pod-logging
[f41c1351](https://github.com/kubernetes-csi/csi-release-tools/commit/f41c1351) prow.sh: also log output of system containers
[ee22a9ca](https://github.com/kubernetes-csi/csi-release-tools/commit/ee22a9ca) Merge pull request #42 from pohly/use-vendor-dir
[80678456](https://github.com/kubernetes-csi/csi-release-tools/commit/80678456) travis.yml: also use vendor directory
[23df4aef](https://github.com/kubernetes-csi/csi-release-tools/commit/23df4aef) prow.sh: use vendor directory if available
[a53bd4c4](https://github.com/kubernetes-csi/csi-release-tools/commit/a53bd4c4) Merge pull request #41 from pohly/go-version
[c8a1c4af](https://github.com/kubernetes-csi/csi-release-tools/commit/c8a1c4af) better handling of Go version
[5e773d2d](https://github.com/kubernetes-csi/csi-release-tools/commit/5e773d2d) update CI to use Go 1.13.3
[f419d745](https://github.com/kubernetes-csi/csi-release-tools/commit/f419d745) Merge pull request #40 from msau42/add-1.16
[e0fde8c4](https://github.com/kubernetes-csi/csi-release-tools/commit/e0fde8c4) Add new variables for 1.16 and remove 1.13
[adf00fea](https://github.com/kubernetes-csi/csi-release-tools/commit/adf00fea) Merge pull request #36 from msau42/full-clone
[f1697d2c](https://github.com/kubernetes-csi/csi-release-tools/commit/f1697d2c) Do full git clones in travis. Shallow clones are causing test-subtree errors when the depth is exactly 50.
[2c819198](https://github.com/kubernetes-csi/csi-release-tools/commit/2c819198) Merge pull request #34 from pohly/go-mod-tidy
[518d6af6](https://github.com/kubernetes-csi/csi-release-tools/commit/518d6af6) Merge pull request #35 from ddebroy/winbld2
[2d6b3ce8](https://github.com/kubernetes-csi/csi-release-tools/commit/2d6b3ce8) Build Windows only for amd64
[c1078a65](https://github.com/kubernetes-csi/csi-release-tools/commit/c1078a65) go-get-kubernetes.sh: automate Kubernetes dependency handling
[194289aa](https://github.com/kubernetes-csi/csi-release-tools/commit/194289aa) update Go mod support
[0affdf95](https://github.com/kubernetes-csi/csi-release-tools/commit/0affdf95) Merge pull request #33 from gnufied/enable-hostpath-expansion
[6208f6ab](https://github.com/kubernetes-csi/csi-release-tools/commit/6208f6ab) Enable hostpath expansion
[6ecaa76e](https://github.com/kubernetes-csi/csi-release-tools/commit/6ecaa76e) Merge pull request #30 from msau42/fix-windows
[ea2f1b52](https://github.com/kubernetes-csi/csi-release-tools/commit/ea2f1b52) build windows binaries with .exe suffix
[2d335506](https://github.com/kubernetes-csi/csi-release-tools/commit/2d335506) Merge pull request #29 from mucahitkurt/create-2-node-kind-cluster
[a8ea8bcc](https://github.com/kubernetes-csi/csi-release-tools/commit/a8ea8bcc) create 2-node kind cluster since topology support is added to hostpath driver
[df8530d9](https://github.com/kubernetes-csi/csi-release-tools/commit/df8530d9) Merge pull request #27 from pohly/dep-vendor-check
[35ceaedc](https://github.com/kubernetes-csi/csi-release-tools/commit/35ceaedc) prow.sh: install dep if needed
[f85ab5af](https://github.com/kubernetes-csi/csi-release-tools/commit/f85ab5af) Merge pull request #26 from ddebroy/windows1
[9fba09b4](https://github.com/kubernetes-csi/csi-release-tools/commit/9fba09b4) Add rule for building Windows binaries
[04008676](https://github.com/kubernetes-csi/csi-release-tools/commit/04008676) Merge pull request #25 from msau42/fix-master-jobs
[dc0a5d83](https://github.com/kubernetes-csi/csi-release-tools/commit/dc0a5d83) Update kind to v0.5.0
[aa85b82c](https://github.com/kubernetes-csi/csi-release-tools/commit/aa85b82c) Merge pull request #23 from msau42/fix-master-jobs
[f46191d9](https://github.com/kubernetes-csi/csi-release-tools/commit/f46191d9) Kubernetes master changed the way that releases are tagged, which needed changes to kind. There are 3 changes made to prow.sh:
[1cac3af3](https://github.com/kubernetes-csi/csi-release-tools/commit/1cac3af3) Merge pull request #22 from msau42/add-1.15-jobs
[0c0dc300](https://github.com/kubernetes-csi/csi-release-tools/commit/0c0dc300) prow.sh: tag master images with a large version number
[f4f73cef](https://github.com/kubernetes-csi/csi-release-tools/commit/f4f73cef) Merge pull request #21 from msau42/add-1.15-jobs
[4e31f078](https://github.com/kubernetes-csi/csi-release-tools/commit/4e31f078) Change default hostpath driver name to hostpath.csi.k8s.io
[4b6fa4a0](https://github.com/kubernetes-csi/csi-release-tools/commit/4b6fa4a0) Update hostpath version for sidecar testing to v1.2.0-rc2
[ecc79187](https://github.com/kubernetes-csi/csi-release-tools/commit/ecc79187) Update kind to v0.4.0. This requires overriding Kubernetes versions with specific patch versions that kind 0.4.0 supports. Also, feature gate setting is only supported on 1.15+ due to kind.sigs.k8s.io/v1alpha3 and kubeadm.k8s.io/v1beta2 dependencies.
[a6f21d40](https://github.com/kubernetes-csi/csi-release-tools/commit/a6f21d40) Add variables for 1.15
[db8abb6e](https://github.com/kubernetes-csi/csi-release-tools/commit/db8abb6e) Merge pull request #20 from pohly/test-driver-config
[b2f4e051](https://github.com/kubernetes-csi/csi-release-tools/commit/b2f4e051) prow.sh: flexible test driver config
[03999882](https://github.com/kubernetes-csi/csi-release-tools/commit/03999882) Merge pull request #19 from pohly/go-mod-vendor
[066143d1](https://github.com/kubernetes-csi/csi-release-tools/commit/066143d1) build.make: allow repos to use 'go mod' for vendoring
[0bee7493](https://github.com/kubernetes-csi/csi-release-tools/commit/0bee7493) Merge pull request #18 from pohly/go-version
[e157b6b5](https://github.com/kubernetes-csi/csi-release-tools/commit/e157b6b5) update to Go 1.12.4
[88dc9a47](https://github.com/kubernetes-csi/csi-release-tools/commit/88dc9a47) Merge pull request #17 from pohly/prow
[0fafc663](https://github.com/kubernetes-csi/csi-release-tools/commit/0fafc663) prow.sh: skip sanity testing if component doesn't support it
[bcac1c1f](https://github.com/kubernetes-csi/csi-release-tools/commit/bcac1c1f) Merge pull request #16 from pohly/prow
[0b10f6a4](https://github.com/kubernetes-csi/csi-release-tools/commit/0b10f6a4) prow.sh: update csi-driver-host-path
[0c2677e8](https://github.com/kubernetes-csi/csi-release-tools/commit/0c2677e8) Merge pull request #15 from pengzhisun/master
[ff9bce4a](https://github.com/kubernetes-csi/csi-release-tools/commit/ff9bce4a) Replace 'return' to 'exit' to fix shellcheck error
[c60f3823](https://github.com/kubernetes-csi/csi-release-tools/commit/c60f3823) Merge pull request #14 from pohly/prow
[7aaac225](https://github.com/kubernetes-csi/csi-release-tools/commit/7aaac225) prow.sh: remove AllAlpha=all, part II
[66177736](https://github.com/kubernetes-csi/csi-release-tools/commit/66177736) Merge pull request #13 from pohly/prow
[cda2fc58](https://github.com/kubernetes-csi/csi-release-tools/commit/cda2fc58) prow.sh: avoid AllAlpha=true
[546d5504](https://github.com/kubernetes-csi/csi-release-tools/commit/546d5504) prow.sh: debug failing KinD cluster creation
[9b0d9cd7](https://github.com/kubernetes-csi/csi-release-tools/commit/9b0d9cd7) build.make: skip shellcheck if Docker is not available
[aa45a1cd](https://github.com/kubernetes-csi/csi-release-tools/commit/aa45a1cd) prow.sh: more efficient execution of individual tests
[f3d1d2df](https://github.com/kubernetes-csi/csi-release-tools/commit/f3d1d2df) prow.sh: fix hostpath driver version check
[31dfaf31](https://github.com/kubernetes-csi/csi-release-tools/commit/31dfaf31) prow.sh: fix running of just "alpha" tests
[f5014439](https://github.com/kubernetes-csi/csi-release-tools/commit/f5014439) prow.sh: AllAlpha=true for unknown Kubernetes versions
[95ae9de9](https://github.com/kubernetes-csi/csi-release-tools/commit/95ae9de9) Merge pull request #9 from pohly/prow
[d87eccb4](https://github.com/kubernetes-csi/csi-release-tools/commit/d87eccb4) prow.sh: switch back to upstream csi-driver-host-path
[6602d38b](https://github.com/kubernetes-csi/csi-release-tools/commit/6602d38b) prow.sh: different E2E suite depending on Kubernetes version
[741319bd](https://github.com/kubernetes-csi/csi-release-tools/commit/741319bd) prow.sh: improve building Kubernetes from source
[29545bb0](https://github.com/kubernetes-csi/csi-release-tools/commit/29545bb0) prow.sh: take Go version from Kubernetes source
[429581c5](https://github.com/kubernetes-csi/csi-release-tools/commit/429581c5) prow.sh: pull Go version from travis.yml
[0a0fd49b](https://github.com/kubernetes-csi/csi-release-tools/commit/0a0fd49b) prow.sh: comment clarification
[2069a0af](https://github.com/kubernetes-csi/csi-release-tools/commit/2069a0af) Merge pull request #11 from pohly/verify-shellcheck
[55212ff2](https://github.com/kubernetes-csi/csi-release-tools/commit/55212ff2) initial Prow test job
[6c7ba1be](https://github.com/kubernetes-csi/csi-release-tools/commit/6c7ba1be) build.make: integrate shellcheck into "make test"
[b2d25d4f](https://github.com/kubernetes-csi/csi-release-tools/commit/b2d25d4f) verify-shellcheck.sh: make it usable in csi-release-tools
[3b6af7b1](https://github.com/kubernetes-csi/csi-release-tools/commit/3b6af7b1) Merge pull request #12 from pohly/local-e2e-suite
[104a1ac9](https://github.com/kubernetes-csi/csi-release-tools/commit/104a1ac9) build.make: avoid unit-testing E2E test suite
[34010e75](https://github.com/kubernetes-csi/csi-release-tools/commit/34010e75) Merge pull request #10 from pohly/vendor-check
[e6db50df](https://github.com/kubernetes-csi/csi-release-tools/commit/e6db50df) check vendor directory
[fb13c519](https://github.com/kubernetes-csi/csi-release-tools/commit/fb13c519) verify-shellcheck.sh: import from Kubernetes
[94fc1e31](https://github.com/kubernetes-csi/csi-release-tools/commit/94fc1e31) build.make: avoid unit-testing E2E test suite
[849db0ad](https://github.com/kubernetes-csi/csi-release-tools/commit/849db0ad) Merge pull request #8 from pohly/subtree-check-relax
[cc564f92](https://github.com/kubernetes-csi/csi-release-tools/commit/cc564f92) verify-subtree.sh: relax check and ignore old content
[33d58fdc](https://github.com/kubernetes-csi/csi-release-tools/commit/33d58fdc) Merge pull request #5 from pohly/test-enhancements
[be8a4400](https://github.com/kubernetes-csi/csi-release-tools/commit/be8a4400) Merge pull request #4 from pohly/canary-fix
[b0336b55](https://github.com/kubernetes-csi/csi-release-tools/commit/b0336b55) build.make: more readable "make test" output
[09436b9f](https://github.com/kubernetes-csi/csi-release-tools/commit/09436b9f) build.make: fix pushing of "canary" image from master branch
[147892c9](https://github.com/kubernetes-csi/csi-release-tools/commit/147892c9) build.make: support suppressing checks
[154e33d4](https://github.com/kubernetes-csi/csi-release-tools/commit/154e33d4) build.make: clarify usage of "make V=1"

git-subtree-dir: release-tools
git-subtree-split: 4aff857d88149e07951fcd1322f462f765401a86

```release-note
NONE
```