### PR TITLE
added labels to the resources to be used for collective operation

### DIFF
--- a/deploy/kubernetes/csi-snapshotter/rbac-csi-snapshotter.yaml
+++ b/deploy/kubernetes/csi-snapshotter/rbac-csi-snapshotter.yaml
@@ -12,6 +12,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: csi-snapshotter
+  labels:
+    app: csi-snapshotter
 
 ---
 kind: ClusterRole
@@ -19,6 +21,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   # rename if there are conflicts
   name: external-snapshotter-runner
+  labels:
+    app: csi-snapshotter
 rules:
   - apiGroups: [""]
     resources: ["events"]
@@ -45,6 +49,8 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: csi-snapshotter-role
+  labels:
+    app: csi-snapshotter
 subjects:
   - kind: ServiceAccount
     name: csi-snapshotter
@@ -62,6 +68,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: default # TODO: replace with the namespace you want for your sidecar
   name: external-snapshotter-leaderelection
+  labels:
+    app: csi-snapshotter
 rules:
 - apiGroups: ["coordination.k8s.io"]
   resources: ["leases"]
@@ -73,6 +81,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: external-snapshotter-leaderelection
   namespace: default # TODO: replace with the namespace you want for your sidecar
+  labels:
+    app: csi-snapshotter
 subjects:
   - kind: ServiceAccount
     name: csi-snapshotter

--- a/deploy/kubernetes/csi-snapshotter/rbac-external-provisioner.yaml
+++ b/deploy/kubernetes/csi-snapshotter/rbac-external-provisioner.yaml
@@ -14,12 +14,16 @@ metadata:
   name: csi-provisioner
   # replace with non-default namespace name
   namespace: default
+  labels:
+    app: csi-provisioner
 
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: external-provisioner-runner
+  labels:
+    app: csi-provisioner
 rules:
   - apiGroups: [""]
     resources: ["secrets"]
@@ -48,6 +52,8 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: csi-provisioner-role
+  labels:
+    app: csi-provisioner
 subjects:
   - kind: ServiceAccount
     name: csi-provisioner
@@ -67,6 +73,8 @@ metadata:
   # replace with non-default namespace name
   namespace: default
   name: external-provisioner-cfg
+  labels:
+    app: csi-provisioner
 rules:
 - apiGroups: [""]
   resources: ["endpoints"]
@@ -82,6 +90,8 @@ metadata:
   name: csi-provisioner-role-cfg
   # replace with non-default namespace name
   namespace: default
+  labels:
+    app: csi-provisioner
 subjects:
   - kind: ServiceAccount
     name: csi-provisioner

--- a/deploy/kubernetes/csi-snapshotter/setup-csi-snapshotter.yaml
+++ b/deploy/kubernetes/csi-snapshotter/setup-csi-snapshotter.yaml
@@ -17,6 +17,8 @@ subjects:
     name: csi-snapshotter # from rbac.yaml
     # replace with non-default namespace name
     namespace: default
+    labels:
+      app: csi-snapshotter
 roleRef:
   kind: ClusterRole
   name: external-provisioner-runner # from rbac-external-provisioner.yaml
@@ -29,6 +31,8 @@ metadata:
   name: csi-snapshotter-provisioner-role-cfg
   # replace with non-default namespace name
   namespace: default
+  labels:
+    app: csi-snapshotter
 subjects:
   - kind: ServiceAccount
     name: csi-snapshotter # from rbac.yaml
@@ -58,6 +62,8 @@ kind: StatefulSet
 apiVersion: apps/v1
 metadata:
   name: csi-snapshotter
+  labels:
+    app: csi-snapshotter
 spec:
   serviceName: "csi-snapshotter"
   replicas: 1

--- a/deploy/kubernetes/snapshot-controller/rbac-snapshot-controller.yaml
+++ b/deploy/kubernetes/snapshot-controller/rbac-snapshot-controller.yaml
@@ -10,6 +10,8 @@ kind: ServiceAccount
 metadata:
   name: snapshot-controller
   namespace: default # TODO: replace with the namespace you want for your controller, e.g. kube-system
+  labels:
+    app: csi-snapshotter
 
 ---
 kind: ClusterRole
@@ -17,6 +19,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   # rename if there are conflicts
   name: snapshot-controller-runner
+  labels:
+    app: csi-snapshotter
 rules:
   - apiGroups: [""]
     resources: ["persistentvolumes"]
@@ -48,6 +52,8 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: snapshot-controller-role
+  labels:
+    app: csi-snapshotter
 subjects:
   - kind: ServiceAccount
     name: snapshot-controller
@@ -64,6 +70,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: default # TODO: replace with the namespace you want for your controller, e.g. kube-system
   name: snapshot-controller-leaderelection
+  labels:
+    app: csi-snapshotter
 rules:
 - apiGroups: ["coordination.k8s.io"]
   resources: ["leases"]
@@ -75,6 +83,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: snapshot-controller-leaderelection
   namespace: default # TODO: replace with the namespace you want for your controller, e.g. kube-system
+  labels:
+    app: csi-snapshotter
 subjects:
   - kind: ServiceAccount
     name: snapshot-controller

--- a/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml
+++ b/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml
@@ -11,6 +11,8 @@ apiVersion: apps/v1
 metadata:
   name: snapshot-controller
   namespace: default # TODO: replace with the namespace you want for your controller, e.g. kube-system
+  labels:
+    app: csi-snapshotter
 spec:
   serviceName: "snapshot-controller"
   replicas: 1


### PR DESCRIPTION

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
We need to add the common/generic labels to all the resources which are being deployed as the part of any csi driver. It is the part of this [PR](https://github.com/kubernetes-csi/csi-driver-host-path/pull/216)

**Special notes for your reviewer**:
Since there was no common labels to identify all the items in one set of resources installed, these labels can help us to identify resources and operate on them in a collective manner


**Does this PR introduce a user-facing change?**:

NONE

```release note
NONE
```