### PR TITLE
master: update release-tools

### DIFF
--- a/release-tools/build.make
+++ b/release-tools/build.make
@@ -20,7 +20,7 @@
 
 # This is the default. It can be overridden in the main Makefile after
 # including build.make.
-REGISTRY_NAME=quay.io/k8scsi
+REGISTRY_NAME?=quay.io/k8scsi
 
 # Can be set to -mod=vendor to ensure that the "vendor" directory is used.
 GOFLAGS_VENDOR=

--- a/release-tools/cloudbuild.yaml
+++ b/release-tools/cloudbuild.yaml
@@ -16,7 +16,9 @@
 # To promote release images, see https://github.com/kubernetes/k8s.io/tree/master/k8s.gcr.io/images/k8s-staging-sig-storage.
 
 # This must be specified in seconds. If omitted, defaults to 600s (10 mins).
-timeout: 1800s
+# Building three images in external-snapshotter takes roughly half an hour,
+# sometimes more.
+timeout: 3600s
 # This prevents errors if you don't use both _GIT_TAG and _PULL_BASE_REF,
 # or any new substitutions added in the future.
 options:


### PR DESCRIPTION
Squashed 'release-tools/' changes from c6a88c6e..3b6d17b1

[3b6d17b1](https://github.com/kubernetes-csi/csi-release-tools/commit/3b6d17b1) Merge pull request #118 from pohly/cloud-build-timeout
[9318c6cc](https://github.com/kubernetes-csi/csi-release-tools/commit/9318c6cc) cloud build: double the timeout, now 1 hour
[86ff5802](https://github.com/kubernetes-csi/csi-release-tools/commit/86ff5802) Merge pull request #116 from andyzhangx/export-image-name
[c3a96625](https://github.com/kubernetes-csi/csi-release-tools/commit/c3a96625) allow export image name and registry name

git-subtree-dir: release-tools
git-subtree-split: 3b6d17b13db026b354934e0f407b556d63382af4

```release-note
NONE
```