### PR TITLE
Provide better defaults for external-snapshotter

### DIFF
--- a/deploy/kubernetes/snapshot-controller/rbac-snapshot-controller.yaml
+++ b/deploy/kubernetes/snapshot-controller/rbac-snapshot-controller.yaml
@@ -9,13 +9,12 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: snapshot-controller
-  namespace: default # TODO: replace with the namespace you want for your controller, e.g. kube-system
+  namespace: kube-system
 
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  # rename if there are conflicts
   name: snapshot-controller-runner
 rules:
   - apiGroups: [""]
@@ -51,10 +50,9 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: snapshot-controller
-    namespace: default # TODO: replace with the namespace you want for your controller, e.g. kube-system
+    namespace: kube-system
 roleRef:
   kind: ClusterRole
-  # change the name also here if the ClusterRole gets renamed
   name: snapshot-controller-runner
   apiGroup: rbac.authorization.k8s.io
 
@@ -62,8 +60,8 @@ roleRef:
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  namespace: default # TODO: replace with the namespace you want for your controller, e.g. kube-system
   name: snapshot-controller-leaderelection
+  namespace: kube-system
 rules:
 - apiGroups: ["coordination.k8s.io"]
   resources: ["leases"]
@@ -74,13 +72,11 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: snapshot-controller-leaderelection
-  namespace: default # TODO: replace with the namespace you want for your controller, e.g. kube-system
+  namespace: kube-system
 subjects:
   - kind: ServiceAccount
     name: snapshot-controller
-    namespace: default # TODO: replace with the namespace you want for your controller, e.g. kube-system
 roleRef:
   kind: Role
   name: snapshot-controller-leaderelection
   apiGroup: rbac.authorization.k8s.io
-

--- a/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml
+++ b/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml
@@ -6,14 +6,13 @@
 # Vanilla Kubernetes, kube-system makes sense for the namespace.
 
 ---
-kind: StatefulSet
+kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: snapshot-controller
-  namespace: default # TODO: replace with the namespace you want for your controller, e.g. kube-system
+  namespace: kube-system
 spec:
-  serviceName: "snapshot-controller"
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: snapshot-controller
@@ -28,5 +27,5 @@ spec:
           image: k8s.gcr.io/sig-storage/snapshot-controller:v4.0.0
           args:
             - "--v=5"
-            - "--leader-election=false"
+            - "--leader-election=true"
           imagePullPolicy: IfNotPresent


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Provided manifests for external-snapshotter are not optimal in most use-cases.

Since external-snapshotter is most common component among various Kubernetes distributions and csi-plugins, I think we need to correct the manifests and include the following changes. They are needed to simplify the setup and provide optimal defaults for every user.

- Deploy external-snapshotter into kube-system namespace by default
- Enable leader-election
- Use Deployment instead of Statefulset and deploy minimum 2 replicas for redundancy

The following changes would allow to simple install working external-snapshotter using just few commands, as described here:
https://kubernetes-csi.github.io/docs/snapshot-controller.html#deployment

but without having to manually edit manifests

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
external-snapshotter manifests adjusted to reflect more common example
```
