### PR TITLE
Retain CreateSnapshot error

### DIFF
--- a/pkg/sidecar-controller/snapshot_controller.go
+++ b/pkg/sidecar-controller/snapshot_controller.go
@@ -300,13 +300,12 @@ func (ctrl *csiSnapshotSideCarController) createSnapshotWrapper(content *crdv1.V
 		// storage system has responded with an error
 		klog.Infof("createSnapshotWrapper: CreateSnapshot for content %s returned error: %v", content.Name, err)
 		if isCSIFinalError(err) {
-			err = ctrl.removeAnnVolumeSnapshotBeingCreated(content)
-			if err != nil {
-				return nil, fmt.Errorf("failed to remove VolumeSnapshotBeingCreated annotation from the content %s: %q", content.Name, err)
+			if err := ctrl.removeAnnVolumeSnapshotBeingCreated(content); err != nil {
+				return nil, fmt.Errorf("failed to remove VolumeSnapshotBeingCreated annotation from the content %s: %s", content.Name, err)
 			}
 		}
 
-		return nil, fmt.Errorf("failed to take snapshot of the volume, %s: %q", *content.Spec.Source.VolumeHandle, err)
+		return nil, fmt.Errorf("failed to take snapshot of the volume %s: %q", *content.Spec.Source.VolumeHandle, err)
 	}
 
 	klog.V(5).Infof("Created snapshot: driver %s, snapshotId %s, creationTime %v, size %d, readyToUse %t", driverName, snapshotID, creationTime, size, readyToUse)


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug

**What this PR does / why we need it**:
The error returned from `CreateSnapshot` was overwritten by the call to `removeAnnVolumeSnapshotBeingCreated`, making the corresponding event look like this:

```
default     5m42s       Warning   SnapshotCreationFailed   volumesnapshotcontent                   Failed to create snapshot: failed to take snapshot of the volume, 6e34868e-6982-11eb-9971-0a58ac14d08c: %!q(<nil>)
```

(Note the `%!q(<nil>)` part in the end.)

 Retain the error through variable shadowing so that it can be propagated and reported upwards the call stack.

We also improve the error line by dropping an unnecessary comma and dequoting the error string (since we already employ a colon separator).

**Does this PR introduce a user-facing change?**:
```release-note
Retain error from CreateSnapshot call
```
