### PR TITLE
release-2.1: fix testing on Kubernetes 1.20

### DIFF
--- a/.prow.sh
+++ b/.prow.sh
@@ -3,6 +3,7 @@
 # This is specific to the release-2.1 branch and overrides the
 # version set in the prow config.
 export CSI_SNAPSHOTTER_VERSION=v2.1.2
+export CSI_PROW_DRIVER_VERSION=v1.4.0
 
 . release-tools/prow.sh
 

--- a/.prow.sh
+++ b/.prow.sh
@@ -3,7 +3,13 @@
 # This is specific to the release-2.1 branch and overrides the
 # version set in the prow config.
 export CSI_SNAPSHOTTER_VERSION=v2.1.2
+
+# The problem that this solves is that the prow config assumes
+# that Kubernetes 1.20 uses the v1 snapshotter API, whereas this
+# branch still uses v1beta1. By downgrading to an older deployment
+# and e2e.test suite we get tests to run.
 export CSI_PROW_DRIVER_VERSION=v1.4.0
+export CSI_PROW_E2E_VERSION=v1.19.7
 
 . release-tools/prow.sh
 

--- a/release-tools/prow.sh
+++ b/release-tools/prow.sh
@@ -65,6 +65,18 @@ get_versioned_variable () {
     echo "$value"
 }
 
+# This takes a version string like CSI_PROW_KUBERNETES_VERSION and
+# maps it to the corresponding git tag, branch or commit.
+version_to_git () {
+    version="$1"
+    shift
+    case "$version" in
+        latest|master) echo "master";;
+        release-*) echo "$version";;
+        *) echo "v$version";;
+    esac
+}
+
 # Note that in the release-2.1 branch the s390x architecture is not supported.
 configvar CSI_PROW_BUILD_PLATFORMS "linux amd64; windows amd64 .exe; linux ppc64le -ppc64le; linux arm64 -arm64" "Go target platforms (= GOOS + GOARCH) and file suffix of the resulting binaries"
 
@@ -210,16 +222,7 @@ configvar CSI_PROW_DRIVER_CANARY_REGISTRY "gcr.io/k8s-staging-sig-storage" "regi
 # all generated files are present.
 #
 # CSI_PROW_E2E_REPO=none disables E2E testing.
-tag_from_version () {
-    version="$1"
-    shift
-    case "$version" in
-        latest) echo "master";;
-        release-*) echo "$version";;
-        *) echo "v$version";;
-    esac
-}
-configvar CSI_PROW_E2E_VERSION "$(tag_from_version "${CSI_PROW_KUBERNETES_VERSION}")"  "E2E version"
+configvar CSI_PROW_E2E_VERSION "$(version_to_git "${CSI_PROW_KUBERNETES_VERSION}")"  "E2E version"
 configvar CSI_PROW_E2E_REPO "https://github.com/kubernetes/kubernetes" "E2E repo"
 configvar CSI_PROW_E2E_IMPORT_PATH "k8s.io/kubernetes" "E2E package"
 
@@ -468,20 +471,22 @@ git_checkout () {
 
 # This clones a repo ("https://github.com/kubernetes/kubernetes")
 # in a certain location ("$GOPATH/src/k8s.io/kubernetes") at
-# a the head of a specific branch (i.e., release-1.13, master).
-# The directory cannot exist.
-git_clone_branch () {
-    local repo path branch parent
+# a the head of a specific branch (i.e., release-1.13, master),
+# tag (v1.20.0) or commit.
+#
+# The directory must not exist.
+git_clone () {
+    local repo path name parent
     repo="$1"
     shift
     path="$1"
     shift
-    branch="$1"
+    name="$1"
     shift
 
     parent="$(dirname "$path")"
     mkdir -p "$parent"
-    (cd "$parent" && run git clone --single-branch --branch "$branch" "$repo" "$path") || die "cloning $repo" failed
+    (cd "$parent" && run git clone --single-branch --branch "$name" "$repo" "$path") || die "cloning $repo" failed
     # This is useful for local testing or when switching between different revisions in the same
     # repo.
     (cd "$path" && run git clean -fdx) || die "failed to clean $path"
@@ -570,7 +575,7 @@ start_cluster () {
             else
                 type="docker"
             fi
-            git_clone_branch https://github.com/kubernetes/kubernetes "${CSI_PROW_WORK}/src/kubernetes" "$version" || die "checking out Kubernetes $version failed"
+            git_clone https://github.com/kubernetes/kubernetes "${CSI_PROW_WORK}/src/kubernetes" "$(version_to_git "$version")" || die "checking out Kubernetes $version failed"
 
             go_version="$(go_version_for_kubernetes "${CSI_PROW_WORK}/src/kubernetes" "$version")" || die "cannot proceed without knowing Go version for Kubernetes"
             # Changing into the Kubernetes source code directory is a workaround for https://github.com/kubernetes-sigs/kind/issues/1910


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:

As discussed in https://github.com/kubernetes/test-infra/pull/20792 we want to test on 1.20, but in this branch can only do it when using the v1beta1 API.

**Which issue(s) this PR fixes**:
Related to https://github.com/kubernetes-csi/external-snapshotter/issues/472

**Special notes for your reviewer**:

This replaces https://github.com/kubernetes-csi/external-snapshotter/pull/471

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
