### PR TITLE
Fix snapshotter metrics server to use http-endpoint when provided

### DIFF
--- a/cmd/csi-snapshotter/main.go
+++ b/cmd/csi-snapshotter/main.go
@@ -154,7 +154,7 @@ func main() {
 		metricsManager.SetDriverName(driverName)
 		go func() {
 			klog.Infof("ServeMux listening at %q", addr)
-			err := http.ListenAndServe(*metricsAddress, mux)
+			err := http.ListenAndServe(addr, mux)
 			if err != nil {
 				klog.Fatalf("Failed to start HTTP server at specified address (%q) and metrics path (%q): %s", addr, *metricsPath, err)
 			}


### PR DESCRIPTION
Signed-off-by: Grant Griffiths <ggriffiths@purestorage.com>

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
We do not honor httpEndpoint when it's provided. 

**Which issue(s) this PR fixes**:
Fixes #492

**Special notes for your reviewer**:
n/a

**Does this PR introduce a user-facing change?**:
```release-note
--http-endpoint will now correctly be used for the metrics server address when --metrics-address is not provided.
```
