### PR TITLE
Automated cherry pick of #504: Make sure the VolumeSnapshots v1 CRDs exist before starting #505: Update sample implementation #507: fix typo in CRD check

### DIFF
--- a/cmd/snapshot-controller/main.go
+++ b/cmd/snapshot-controller/main.go
@@ -68,7 +68,7 @@ func ensureCustomResourceDefinitionsExist(kubeClient *kubernetes.Clientset, clie
 	condition := func() (bool, error) {
 		var err error
 		_, err = kubeClient.CoreV1().Namespaces().Get(context.TODO(), "kube-system", metav1.GetOptions{})
-		if err != nil {
+		if err == nil {
 			// only execute list VolumeSnapshots if the kube-system namespace exists
 			_, err = client.SnapshotV1().VolumeSnapshots("kube-system").List(context.TODO(), metav1.ListOptions{})
 			if err != nil {

--- a/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml
+++ b/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml
@@ -17,6 +17,15 @@ spec:
   selector:
     matchLabels:
       app: snapshot-controller
+  # the snapshot controller won't be marked as ready if the v1 CRDs are unavailable
+  # in #504 the snapshot-controller will exit after around 7.5 seconds if it
+  # can't find the v1 CRDs so this value should be greater than that
+  minReadySeconds: 15
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:


### PR DESCRIPTION
Cherry pick of #504 #505 #507 on release-4.0.

#504: Make sure the VolumeSnapshots v1 CRDs exist before starting
#505: Update sample implementation
#507: fix typo in CRD check

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add check for v1 CRDs to allow for rolling update of the snapshot-controller
```