### PR TITLE
Retrieve the VolumeSnapshotContent before attempting an update

### DIFF
--- a/pkg/sidecar-controller/snapshot_controller.go
+++ b/pkg/sidecar-controller/snapshot_controller.go
@@ -140,11 +140,17 @@ func (ctrl *csiSnapshotSideCarController) checkandUpdateContentStatus(content *c
 func (ctrl *csiSnapshotSideCarController) updateContentErrorStatusWithEvent(content *crdv1.VolumeSnapshotContent, eventtype, reason, message string) error {
 	klog.V(5).Infof("updateContentStatusWithEvent[%s]", content.Name)
 
+	latestContent, err := ctrl.clientset.SnapshotV1().VolumeSnapshotContents().Get(context.TODO(), content.Name, metav1.GetOptions{})
+	if err != nil {
+		klog.V(4).Infof("updateContentStatusWithEvent[%s]: error obtaining volumeSnapshotContent %v", content.Name, err)
+		return nil
+	}
+
 	if content.Status != nil && content.Status.Error != nil && *content.Status.Error.Message == message {
 		klog.V(4).Infof("updateContentStatusWithEvent[%s]: the same error %v is already set", content.Name, content.Status.Error)
 		return nil
 	}
-	contentClone := content.DeepCopy()
+	contentClone := latestContent.DeepCopy()
 	if contentClone.Status == nil {
 		contentClone.Status = &crdv1.VolumeSnapshotContentStatus{}
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
It's been noticed that when we attempt to update the VSC's error the following error can be thrown:

```
I0525 13:07:49.293034       1 snapshot_controller.go:165] updating VolumeSnapshotContent[snapcontent-f24fd046-1664-4bb2-bb43-f91ae0909b02] error status failed Operation cannot be fulfilled on volumesnapshotcontents.snapshot.storage.k8s.io "snapcontent-f24fd046-1664-4bb2-bb43-f91ae0909b02": the object has been modified; please apply your changes to the latest version and try again
```

This PR forces a Get before we attempt the update so that we can avoid this error.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
