### PR TITLE
Use JSON patch for many VolumeSnapshot and VolumeSnapshotContent updates

### DIFF
--- a/deploy/kubernetes/csi-snapshotter/rbac-csi-snapshotter.yaml
+++ b/deploy/kubernetes/csi-snapshotter/rbac-csi-snapshotter.yaml
@@ -38,7 +38,7 @@ rules:
     verbs: ["create", "get", "list", "watch", "update", "delete", "patch"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents/status"]
-    verbs: ["update"]
+    verbs: ["update", "patch"]
 
 ---
 kind: ClusterRoleBinding

--- a/deploy/kubernetes/csi-snapshotter/rbac-csi-snapshotter.yaml
+++ b/deploy/kubernetes/csi-snapshotter/rbac-csi-snapshotter.yaml
@@ -35,7 +35,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents"]
-    verbs: ["create", "get", "list", "watch", "update", "delete"]
+    verbs: ["create", "get", "list", "watch", "update", "delete", "patch"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents/status"]
     verbs: ["update"]

--- a/deploy/kubernetes/snapshot-controller/rbac-snapshot-controller.yaml
+++ b/deploy/kubernetes/snapshot-controller/rbac-snapshot-controller.yaml
@@ -34,13 +34,16 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents"]
-    verbs: ["create", "get", "list", "watch", "update", "delete"]
+    verbs: ["create", "get", "list", "watch", "update", "delete", "patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents/status"]
+    verbs: ["patch"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshots"]
-    verbs: ["get", "list", "watch", "update"]
+    verbs: ["get", "list", "watch", "update", "patch"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshots/status"]
-    verbs: ["update"]
+    verbs: ["update", "patch"]
 
 ---
 kind: ClusterRoleBinding

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/container-storage-interface/spec v1.5.0
+	github.com/evanphx/json-patch v4.11.0+incompatible
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/golang/mock v1.4.4
 	github.com/golang/protobuf v1.5.2

--- a/pkg/common-controller/framework_test.go
+++ b/pkg/common-controller/framework_test.go
@@ -354,12 +354,6 @@ func (r *snapshotReactor) React(action core.Action) (handled bool, ret runtime.O
 
 			storedVer, _ := strconv.Atoi(storedSnapshot.ResourceVersion)
 			storedSnapshot.ResourceVersion = strconv.Itoa(storedVer + 1)
-
-			// // If we were updating annotations and the new annotations are nil, leave as empty.
-			// // This seems to be the behavior for merge-patching nil & empty annotations
-			// if !reflect.DeepEqual(storedSnapshotContent.Annotations, content.Annotations) && content.Annotations == nil {
-			// 	content.Annotations = make(map[string]string)
-			// }
 		} else {
 			return true, nil, fmt.Errorf("cannot update snapshot %s: snapshot not found", action.GetName())
 		}

--- a/pkg/common-controller/snapshot_controller.go
+++ b/pkg/common-controller/snapshot_controller.go
@@ -1421,23 +1421,16 @@ func (ctrl *csiSnapshotCommonController) addSnapshotFinalizer(snapshot *crdv1.Vo
 	var updatedSnapshot *crdv1.VolumeSnapshot
 	var err error
 
-	// Must perform an update if no finalizers exist
+	var patches []utils.PatchOp
 	if len(snapshot.ObjectMeta.Finalizers) == 0 {
-		snapshotClone := snapshot.DeepCopy()
-		if addSourceFinalizer {
-			snapshotClone.ObjectMeta.Finalizers = append(snapshotClone.ObjectMeta.Finalizers, utils.VolumeSnapshotAsSourceFinalizer)
-		}
-		if addBoundFinalizer {
-			snapshotClone.ObjectMeta.Finalizers = append(snapshotClone.ObjectMeta.Finalizers, utils.VolumeSnapshotBoundFinalizer)
-		}
-		updatedSnapshot, err = ctrl.clientset.SnapshotV1().VolumeSnapshots(snapshotClone.Namespace).Update(context.TODO(), snapshotClone, metav1.UpdateOptions{})
-		if err != nil {
-			return newControllerUpdateError(utils.SnapshotKey(snapshot), err.Error())
-		}
+		// Replace finalizers with new array if there are no other finalizers
+		patches = append(patches, utils.PatchOp{
+			Op:    "add",
+			Path:  "/metadata/finalizers",
+			Value: []string{utils.VolumeSnapshotContentFinalizer},
+		})
 	} else {
 		// Otherwise, perform a patch
-		var patches []utils.PatchOp
-
 		if addSourceFinalizer {
 			patches = append(patches, utils.PatchOp{
 				Op:    "add",
@@ -1452,11 +1445,10 @@ func (ctrl *csiSnapshotCommonController) addSnapshotFinalizer(snapshot *crdv1.Vo
 				Value: utils.VolumeSnapshotBoundFinalizer,
 			})
 		}
-
-		updatedSnapshot, err = utils.PatchVolumeSnapshot(snapshot, patches, ctrl.clientset)
-		if err != nil {
-			return newControllerUpdateError(utils.SnapshotKey(snapshot), err.Error())
-		}
+	}
+	updatedSnapshot, err = utils.PatchVolumeSnapshot(snapshot, patches, ctrl.clientset)
+	if err != nil {
+		return newControllerUpdateError(utils.SnapshotKey(snapshot), err.Error())
 	}
 
 	_, err = ctrl.storeSnapshotUpdate(updatedSnapshot)

--- a/pkg/common-controller/snapshot_controller.go
+++ b/pkg/common-controller/snapshot_controller.go
@@ -809,23 +809,14 @@ func (ctrl *csiSnapshotCommonController) updateSnapshotErrorStatusWithEvent(snap
 
 // addContentFinalizer adds a Finalizer for VolumeSnapshotContent.
 func (ctrl *csiSnapshotCommonController) addContentFinalizer(content *crdv1.VolumeSnapshotContent) error {
-	// patches := []utils.PatchOp{
-	// 	{
-	// 		Op:    "add",
-	// 		Path:  "/metadata/finalizers/-",
-	// 		Value: utils.VolumeSnapshotContentFinalizer,
-	// 	},
-	// }
+	var patches []utils.PatchOp
+	patches = append(patches, utils.PatchOp{
+		Op:    "add",
+		Path:  "/metadata/finalizers/-",
+		Value: utils.VolumeSnapshotContentFinalizer,
+	})
 
-	// newContent, err := utils.PatchVolumeSnapshotContent(content, patches, ctrl.clientset)
-	// if err != nil {
-	// 	return newControllerUpdateError(content.Name, err.Error())
-	// }
-
-	contentClone := content.DeepCopy()
-	contentClone.ObjectMeta.Finalizers = append(contentClone.ObjectMeta.Finalizers, utils.VolumeSnapshotContentFinalizer)
-
-	newContent, err := ctrl.clientset.SnapshotV1().VolumeSnapshotContents().Update(context.TODO(), contentClone, metav1.UpdateOptions{})
+	newContent, err := utils.PatchVolumeSnapshotContent(content, patches, ctrl.clientset)
 	if err != nil {
 		return newControllerUpdateError(content.Name, err.Error())
 	}
@@ -1440,8 +1431,6 @@ func (ctrl *csiSnapshotCommonController) addSnapshotFinalizer(snapshot *crdv1.Vo
 			})
 		}
 
-		klog.Infof("GGCSI - ADD SNAPSHOT FINALIZER - snapshot: %v", snapshot)
-		klog.Infof("GGCSI - ADD SNAPSHOT FINALIZER - patches: %v", patches)
 		updatedSnapshot, err = utils.PatchVolumeSnapshot(snapshot, patches, ctrl.clientset)
 		if err != nil {
 			return newControllerUpdateError(utils.SnapshotKey(snapshot), err.Error())

--- a/pkg/common-controller/snapshot_finalizer_test.go
+++ b/pkg/common-controller/snapshot_finalizer_test.go
@@ -19,6 +19,7 @@ package common_controller
 import (
 	"testing"
 
+	"github.com/kubernetes-csi/external-snapshotter/v4/pkg/utils"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -70,7 +71,14 @@ func TestSnapshotFinalizer(t *testing.T) {
 			expectSuccess:    true,
 		},
 		{
-			name:             "2-1 - successful remove Snapshot finalizer",
+			name:             "2-2 - successful add single Snapshot finalizer with patch",
+			initialSnapshots: withSnapshotFinalizers(newSnapshotArray("snap6-2", "snapuid6-2", "claim6-2", "", classSilver, "", &False, nil, nil, nil, false, false, nil), utils.VolumeSnapshotBoundFinalizer),
+			initialClaims:    newClaimArray("claim6-2", "pvc-uid6-2", "1Gi", "volume6-2", v1.ClaimBound, &classEmpty),
+			test:             testAddSingleSnapshotFinalizer,
+			expectSuccess:    true,
+		},
+		{
+			name:             "2-3 - successful remove Snapshot finalizer",
 			initialSnapshots: newSnapshotArray("snap6-2", "snapuid6-2", "claim6-2", "", classSilver, "", &False, nil, nil, nil, false, true, nil),
 			initialClaims:    newClaimArray("claim6-2", "pvc-uid6-2", "1Gi", "volume6-2", v1.ClaimBound, &classEmpty),
 			test:             testRemoveSnapshotFinalizer,

--- a/pkg/common-controller/snapshot_update_test.go
+++ b/pkg/common-controller/snapshot_update_test.go
@@ -162,7 +162,7 @@ func TestSync(t *testing.T) {
 			expectedSnapshots: newSnapshotArray("snap2-12", "snapuid2-12", "", "content2-12", validSecretClass, "content2-12", &False, nil, nil, newVolumeError("Snapshot failed to bind VolumeSnapshotContent, mock update error"), false, true, nil),
 			errors: []reactorError{
 				// Inject error to the forth client.VolumesnapshotV1().VolumeSnapshots().Update call.
-				{"update", "volumesnapshotcontents", errors.New("mock update error")},
+				{"patch", "volumesnapshotcontents", errors.New("mock update error")},
 			},
 			test: testSyncSnapshot,
 		},
@@ -312,7 +312,7 @@ func TestSync(t *testing.T) {
 			initialSecrets:   []*v1.Secret{secret()},
 			errors: []reactorError{
 				// Inject error to the forth client.VolumesnapshotV1().VolumeSnapshots().Update call.
-				{"update", "volumesnapshotcontents", errors.New("mock update error")},
+				{"patch", "volumesnapshotcontents", errors.New("mock update error")},
 			},
 			expectSuccess: false,
 			test:          testSyncContentError,

--- a/pkg/sidecar-controller/content_create_test.go
+++ b/pkg/sidecar-controller/content_create_test.go
@@ -85,7 +85,7 @@ func TestSyncContent(t *testing.T) {
 		{
 			name: "1-3: Basic sync content create snapshot with non-existent secret",
 			initialContents: withContentAnnotations(withContentStatus(newContentArray("content1-3", "snapuid1-3", "snap1-3", "sid1-3", invalidSecretClass, "", "volume-handle-1-3", retainPolicy, nil, &defaultSize, true),
-				nil), map[string]string{
+				&crdv1.VolumeSnapshotContentStatus{}), map[string]string{
 				utils.AnnDeletionSecretRefName:      "",
 				utils.AnnDeletionSecretRefNamespace: "",
 			}),
@@ -94,12 +94,12 @@ func TestSyncContent(t *testing.T) {
 					SnapshotHandle: nil,
 					RestoreSize:    nil,
 					ReadyToUse:     &False,
-					Error:          newSnapshotError("Failed to create snapshot: failed to get input parameters to create snapshot for content content1-3: \"cannot retrieve secrets for snapshot content \\\"content1-3\\\", err: secret name or namespace not specified\""),
+					Error:          newSnapshotError("Failed to check and update snapshot content: failed to get input parameters to create snapshot for content content1-3: \"cannot retrieve secrets for snapshot content \\\"content1-3\\\", err: secret name or namespace not specified\""),
 				}), map[string]string{
 				utils.AnnDeletionSecretRefName:      "",
 				utils.AnnDeletionSecretRefNamespace: "",
 			}), initialSecrets: []*v1.Secret{}, // no initial secret created
-			expectedEvents: []string{"Warning SnapshotCreationFailed"},
+			expectedEvents: []string{"Warning SnapshotContentCheckandUpdateFailed"},
 			errors:         noerrors,
 			test:           testSyncContent,
 		},
@@ -149,7 +149,7 @@ func TestSyncContent(t *testing.T) {
 		{
 			name: "1-5: Basic sync content create snapshot with failed secret call",
 			initialContents: withContentAnnotations(withContentStatus(newContentArray("content1-5", "snapuid1-5", "snap1-5", "sid1-5", invalidSecretClass, "", "volume-handle-1-5", retainPolicy, nil, &defaultSize, true),
-				nil), map[string]string{
+				&crdv1.VolumeSnapshotContentStatus{}), map[string]string{
 				utils.AnnDeletionSecretRefName:      "secret",
 				utils.AnnDeletionSecretRefNamespace: "default",
 			}),
@@ -158,12 +158,12 @@ func TestSyncContent(t *testing.T) {
 					SnapshotHandle: nil,
 					RestoreSize:    nil,
 					ReadyToUse:     &False,
-					Error:          newSnapshotError("Failed to create snapshot: failed to get input parameters to create snapshot for content content1-5: \"cannot get credentials for snapshot content \\\"content1-5\\\"\""),
+					Error:          newSnapshotError(`Failed to check and update snapshot content: failed to get input parameters to create snapshot for content content1-5: "cannot get credentials for snapshot content \"content1-5\""`),
 				}), map[string]string{
 				utils.AnnDeletionSecretRefName:      "secret",
 				utils.AnnDeletionSecretRefNamespace: "default",
 			}), initialSecrets: []*v1.Secret{}, // no initial secret created
-			expectedEvents: []string{"Warning SnapshotCreationFailed"},
+			expectedEvents: []string{"Warning SnapshotContentCheckandUpdateFailed"},
 			errors: []reactorError{
 				// Inject error to the first client.VolumesnapshotV1().VolumeSnapshots().Update call.
 				// All other calls will succeed.

--- a/pkg/utils/patch.go
+++ b/pkg/utils/patch.go
@@ -1,0 +1,58 @@
+package utils
+
+import (
+	"context"
+	"encoding/json"
+
+	crdv1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
+	clientset "github.com/kubernetes-csi/external-snapshotter/client/v4/clientset/versioned"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// PatchOp represents a json patch operation
+type PatchOp struct {
+	Op    string      `json:"op"`
+	Path  string      `json:"path"`
+	Value interface{} `json:"value,omitempty"`
+}
+
+// PatchVolumeSnapshotContent patches a volume snapshot content object
+func PatchVolumeSnapshotContent(
+	existingSnapshotContent *crdv1.VolumeSnapshotContent,
+	patch []PatchOp,
+	client clientset.Interface,
+	subresources ...string,
+) (*crdv1.VolumeSnapshotContent, error) {
+	data, err := json.Marshal(patch)
+	if nil != err {
+		return existingSnapshotContent, err
+	}
+
+	newSnapshotContent, err := client.SnapshotV1().VolumeSnapshotContents().Patch(context.TODO(), existingSnapshotContent.Name, types.JSONPatchType, data, metav1.PatchOptions{}, subresources...)
+	if err != nil {
+		return existingSnapshotContent, err
+	}
+
+	return newSnapshotContent, nil
+}
+
+// PatchVolumeSnapshot patches a volume snapshot object
+func PatchVolumeSnapshot(
+	existingSnapshot *crdv1.VolumeSnapshot,
+	patch []PatchOp,
+	client clientset.Interface,
+	subresources ...string,
+) (*crdv1.VolumeSnapshot, error) {
+	data, err := json.Marshal(patch)
+	if nil != err {
+		return existingSnapshot, err
+	}
+
+	newSnapshot, err := client.SnapshotV1().VolumeSnapshots(existingSnapshot.Namespace).Patch(context.TODO(), existingSnapshot.Name, types.JSONPatchType, data, metav1.PatchOptions{}, subresources...)
+	if err != nil {
+		return existingSnapshot, err
+	}
+
+	return newSnapshot, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -10,6 +10,7 @@ github.com/container-storage-interface/spec/lib/go/csi
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew
 # github.com/evanphx/json-patch v4.11.0+incompatible
+## explicit
 github.com/evanphx/json-patch
 # github.com/fsnotify/fsnotify v1.4.9
 ## explicit


### PR DESCRIPTION
Signed-off-by: Grant Griffiths <ggriffiths@purestorage.com>

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR addresses the "object has been modified" issue we see a lot in the snapshot-controller/snapshotter.

Before this PR, we were seeing ~30-50 occurrences of this error in the snapshot-controller/snapshotter logs.

This PR only addresses the problematic areas found in the e2e PR tests. If we continue to see more of these errors, we can    address replace the remaining Update/UpdateStatus calls in a separate PR.

**Which issue(s) this PR fixes**:
Fixes #525 

**Special notes for your reviewer**:
n/a

**Does this PR introduce a user-facing change?**:
```release-note
Replaces many VolumeSnapshot/VolumeSnapshotContent Update/UpdateStatus operations with Patch. This lowers the probability of the "object has been modified" update API errors occurring. This change introduces a dependency on two new RBAC rules for the snapshotter: volumesnapshotcontents:patch, volumesnapshotcontents/status:patch and four new RBAC rules for the snapshot-controller: volumesnapshotcontents:patch, volumesnapshotcontents/status:patch, volumesnapshots:patch, and volumesnapshots/status: patch.
```
