### PR TITLE
Add VS namespace to VSC printed columns

### DIFF
--- a/client/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml
+++ b/client/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml
@@ -42,6 +42,10 @@ spec:
       jsonPath: .spec.volumeSnapshotRef.name
       name: VolumeSnapshot
       type: string
+    - description: Namespace of the VolumeSnapshot object to which this VolumeSnapshotContent object is bound.
+      jsonPath: .spec.volumeSnapshotRef.namespace
+      name: VolumeSnapshotNamespace
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -176,6 +180,10 @@ spec:
     - description: Name of the VolumeSnapshot object to which this VolumeSnapshotContent object is bound.
       jsonPath: .spec.volumeSnapshotRef.name
       name: VolumeSnapshot
+      type: string
+    - description: Namespace of the VolumeSnapshot object to which this VolumeSnapshotContent object is bound.
+      jsonPath: .spec.volumeSnapshotRef.namespace
+      name: VolumeSnapshotNamespace
       type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:
When using `kubectl get volumesnapshotcontent` the result prints also referenced VolumeSnapshot object. That is not enough to identify the correct one though, since VolumeSnapshot is namespaced. It would be probably good to display also the namespace of the VolumeSnapshot.

**Does this PR introduce a user-facing change?**:
Yes.

```release-note
The namespace of the referenced VolumeSnapshot is printed when printing a VolumeSnapshotContent.
```
