### PR TITLE
snap client version update and kube dependency update

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/imdario/mergo v0.3.11 // indirect
 	github.com/kubernetes-csi/csi-lib-utils v0.9.0
 	github.com/kubernetes-csi/csi-test/v4 v4.0.2
-	github.com/kubernetes-csi/external-snapshotter/client/v4 v4.0.0
+	github.com/kubernetes-csi/external-snapshotter/client/v4 v4.1.0
 	github.com/prometheus/client_golang v1.11.0
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.26.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -67,7 +67,7 @@ github.com/kubernetes-csi/csi-lib-utils/rpc
 ## explicit
 github.com/kubernetes-csi/csi-test/v4/driver
 github.com/kubernetes-csi/csi-test/v4/utils
-# github.com/kubernetes-csi/external-snapshotter/client/v4 v4.0.0 => ./client
+# github.com/kubernetes-csi/external-snapshotter/client/v4 v4.1.0 => ./client
 ## explicit
 github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1
 github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1beta1


### PR DESCRIPTION
 Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

> /kind cleanup

**What this PR does / why we need it**:
The snapclient reference from the external-snapshotter package `4.0.0` which has been lifted to `4.1.1` tag
The snapshot client was depending on kube 1.19.0 before and it has been updated to 1.21.0

-->
```release-note-none

```
