### PR TITLE
Remove redundant validation checks

### DIFF
--- a/pkg/common-controller/snapshot_controller.go
+++ b/pkg/common-controller/snapshot_controller.go
@@ -96,9 +96,7 @@ func (ctrl *csiSnapshotCommonController) syncContent(content *crdv1.VolumeSnapsh
 		return err
 	}
 
-	// TODO(xiangqian): Putting this check in controller as webhook has not been implemented
-	//                   yet. Remove the source checking once issue #187 is resolved:
-	//                   https://github.com/kubernetes-csi/external-snapshotter/issues/187
+	// Keep this check in the controller since the validation webhook may not have been deployed.
 	if (content.Spec.Source.VolumeHandle == nil && content.Spec.Source.SnapshotHandle == nil) ||
 		(content.Spec.Source.VolumeHandle != nil && content.Spec.Source.SnapshotHandle != nil) {
 		err := fmt.Errorf("Exactly one of VolumeHandle and SnapshotHandle should be specified")
@@ -207,9 +205,7 @@ func (ctrl *csiSnapshotCommonController) syncSnapshot(snapshot *crdv1.VolumeSnap
 		return ctrl.processSnapshotWithDeletionTimestamp(snapshot)
 	}
 
-	// TODO(xiangqian@): Putting this check in controller as webhook has not been implemented
-	//                   yet. Remove the source checking once issue #187 is resolved:
-	//                   https://github.com/kubernetes-csi/external-snapshotter/issues/187
+	// Keep this check in the controller since the validation webhook may not have been deployed.
 	klog.V(5).Infof("syncSnapshot[%s]: validate snapshot to make sure source has been correctly specified", utils.SnapshotKey(snapshot))
 	if (snapshot.Spec.Source.PersistentVolumeClaimName == nil && snapshot.Spec.Source.VolumeSnapshotContentName == nil) ||
 		(snapshot.Spec.Source.PersistentVolumeClaimName != nil && snapshot.Spec.Source.VolumeSnapshotContentName != nil) {


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
This PR removes checks that are performed as part of the webhook after https://github.com/kubernetes-csi/external-snapshotter/issues/187 was closed. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Remove redundant validation checks.
```
