### PR TITLE
Use distroless/static image for webhook

### DIFF
--- a/cmd/snapshot-validation-webhook/Dockerfile
+++ b/cmd/snapshot-validation-webhook/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/base:latest
+FROM gcr.io/distroless/static:latest
 LABEL maintainers="Kubernetes Authors"
 LABEL description="Snapshot Validation Webhook"
 ARG binary=./bin/snapshot-validation-webhook


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

The webhook image needlessly used the distroless image containing glibc. The webhook server is a static binary, so it can be packaged using the distroless/static image like the other components.

This should make image security scanners happy. As minor benefits, it also slightly decreases image size and makes it so that the same base image is used for all components

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
