### PR TITLE
Add process_start_time_seconds metric

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -111,6 +111,9 @@ type MetricsManager interface {
 	// status - the operation status, if not specified, i.e., status == nil, an
 	//          "Unknown" status of the passed-in operation is assumed.
 	RecordMetrics(op OperationKey, status OperationStatus, driverName string)
+
+	// GetRegistry() returns the metrics.KubeRegistry used by this metrics manager.
+	GetRegistry() k8smetrics.KubeRegistry
 }
 
 // OperationKey is a structure which holds information to
@@ -265,6 +268,7 @@ func (opMgr *operationMetricsManager) recordCancelMetric(val OperationValue, key
 
 func (opMgr *operationMetricsManager) init() {
 	opMgr.registry = k8smetrics.NewKubeRegistry()
+	k8smetrics.RegisterProcessStartTime(opMgr.registry.Register)
 	opMgr.opLatencyMetrics = k8smetrics.NewHistogramVec(
 		&k8smetrics.HistogramOpts{
 			Subsystem: subSystem,
@@ -325,6 +329,10 @@ func (opMgr *operationMetricsManager) StartMetricsEndpoint(pattern, addr string,
 		}
 	}()
 	return srv, nil
+}
+
+func (opMgr *operationMetricsManager) GetRegistry() k8smetrics.KubeRegistry {
+	return opMgr.registry
 }
 
 // snapshotProvisionType represents which kind of snapshot a metric is

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -44,8 +44,9 @@ var (
 )
 
 const (
-	httpPattern = "/metrics"
-	addr        = "localhost:0"
+	httpPattern            = "/metrics"
+	addr                   = "localhost:0"
+	processStartTimeMetric = "process_start_time_seconds"
 )
 
 type fakeOpStatus struct {
@@ -706,4 +707,25 @@ func containsMetrics(expectedMfs, gotMfs []*cmg.MetricFamily) bool {
 	}
 
 	return true
+}
+
+func TestProcessStartTimeMetricExist(t *testing.T) {
+	mgr, wg, srv := initMgr()
+	defer shutdown(srv, wg)
+	metricsFamilies, err := mgr.GetRegistry().Gather()
+	if err != nil {
+		t.Fatalf("Error fetching metrics: %v", err)
+	}
+
+	for _, metricsFamily := range metricsFamilies {
+		if metricsFamily.GetName() == processStartTimeMetric {
+			return
+		}
+		m := metricsFamily.GetMetric()
+		if m[0].GetGauge().GetValue() <= 0 {
+			t.Fatalf("Expected non zero timestamp for process start time")
+		}
+	}
+
+	t.Fatalf("Metrics does not contain %v. Scraped content: %v", processStartTimeMetric, metricsFamilies)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
process_start_time metric needs to be initialized for cummulative latency metric.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
The component-base [v0.22.0-rc.0](https://github.com/kubernetes-csi/external-snapshotter/blob/master/go.mod#L41)
contains the [bug-fix](https://github.com/kubernetes/component-base/commit/791c326f981f31f14efdfd177a9a869f01038f1a) for [RegisterProcessStartTime](https://github.com/kubernetes-csi/external-snapshotter/blob/master/vendor/k8s.io/component-base/metrics/processstarttime.go#L37).


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add process_start_time_seconds metric
```
