### PR TITLE
Refactor http server and register leaderelection health check

### DIFF
--- a/pkg/sidecar-controller/snapshot_controller_base.go
+++ b/pkg/sidecar-controller/snapshot_controller_base.go
@@ -26,7 +26,7 @@ import (
 	storagelisters "github.com/kubernetes-csi/external-snapshotter/client/v4/listers/volumesnapshot/v1"
 	"github.com/kubernetes-csi/external-snapshotter/v4/pkg/snapshotter"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"


### PR DESCRIPTION

Signed-off-by: Grant Griffiths <ggriffiths@purestorage.com>

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
- Needed to start the http server outside of pkg/metric for the snapshot controller
- We needed this because we want to add other endpoints to the server

**Which issue(s) this PR fixes**:
Fixes #572 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Adds the leader election health check for the snapshot controller at `/healthz/leader-election`
```
