### PR TITLE
Add CSI secret templates as annotation in volumeSnapshotContent

### DIFF
--- a/pkg/common-controller/snapshot_controller.go
+++ b/pkg/common-controller/snapshot_controller.go
@@ -678,6 +678,17 @@ func (ctrl *csiSnapshotCommonController) createSnapshotContent(snapshot *crdv1.V
 
 		klog.V(5).Infof("createSnapshotContent: set annotation [%s] on content [%s].", utils.AnnDeletionSecretRefNamespace, snapshotContent.Name)
 		metav1.SetMetaDataAnnotation(&snapshotContent.ObjectMeta, utils.AnnDeletionSecretRefNamespace, snapshotterSecretRef.Namespace)
+
+		nameTemplate, namespaceTemplate, err := utils.VerifyAndGetSecretNameAndNamespaceTemplate(utils.SnapshotterSecretParams, class.Parameters)
+		if err != nil {
+			return nil, err
+		}
+
+		klog.V(6).Infof("createSnapshotContent: set annotation [%s] on content [%s].", utils.PrefixedSnapshotterSecretNameKey, nameTemplate)
+		metav1.SetMetaDataAnnotation(&snapshotContent.ObjectMeta, utils.PrefixedSnapshotterSecretNameKey, nameTemplate)
+
+		klog.V(5).Infof("createSnapshotContent: set annotation [%s] on content [%s].", utils.PrefixedSnapshotterSecretNamespaceKey, namespaceTemplate)
+		metav1.SetMetaDataAnnotation(&snapshotContent.ObjectMeta, utils.PrefixedSnapshotterSecretNamespaceKey, namespaceTemplate)
 	}
 
 	var updateContent *crdv1.VolumeSnapshotContent

--- a/pkg/common-controller/snapshot_create_test.go
+++ b/pkg/common-controller/snapshot_create_test.go
@@ -63,6 +63,8 @@ func TestCreateSnapshotSync(t *testing.T) {
 				map[string]string{
 					"snapshot.storage.kubernetes.io/deletion-secret-name":      "secret",
 					"snapshot.storage.kubernetes.io/deletion-secret-namespace": "default",
+					"csi.storage.k8s.io/snapshotter-secret-name":               "secret",
+					"csi.storage.k8s.io/snapshotter-secret-namespace":          "default",
 				}),
 			initialSnapshots:  newSnapshotArray("snap6-2", "snapuid6-2", "claim6-2", "", validSecretClass, "", &False, nil, nil, nil, false, true, nil),
 			expectedSnapshots: newSnapshotArray("snap6-2", "snapuid6-2", "claim6-2", "", validSecretClass, "snapcontent-snapuid6-2", &False, nil, nil, nil, false, true, nil),

--- a/pkg/common-controller/snapshot_update_test.go
+++ b/pkg/common-controller/snapshot_update_test.go
@@ -466,7 +466,7 @@ func TestSync(t *testing.T) {
 			// Snapshot status nil, no initial content, new content should be created.
 			name:              "8-1 - Snapshot status nil, no initial snapshot content, new content should be created",
 			initialContents:   nocontents,
-			expectedContents:  withContentAnnotations(newContentArrayNoStatus("snapcontent-snapuid8-1", "snapuid8-1", "snap8-1", "sid8-1", validSecretClass, "", "pv-handle8-1", deletionPolicy, nil, nil, false, false), map[string]string{utils.AnnDeletionSecretRefName: "secret", utils.AnnDeletionSecretRefNamespace: "default"}),
+			expectedContents:  withContentAnnotations(newContentArrayNoStatus("snapcontent-snapuid8-1", "snapuid8-1", "snap8-1", "sid8-1", validSecretClass, "", "pv-handle8-1", deletionPolicy, nil, nil, false, false), map[string]string{utils.AnnDeletionSecretRefName: "secret", utils.AnnDeletionSecretRefNamespace: "default", utils.PrefixedSnapshotterSecretNameKey: "secret", utils.PrefixedSnapshotterSecretNamespaceKey: "default"}),
 			initialSnapshots:  newSnapshotArray("snap8-1", "snapuid8-1", "claim8-1", "", validSecretClass, "", nil, nil, nil, nil, true, false, nil),
 			expectedSnapshots: newSnapshotArray("snap8-1", "snapuid8-1", "claim8-1", "", validSecretClass, "snapcontent-snapuid8-1", &False, nil, nil, nil, false, false, nil),
 			initialClaims:     newClaimArray("claim8-1", "pvc-uid8-1", "1Gi", "volume8-1", v1.ClaimBound, &classEmpty),
@@ -480,7 +480,7 @@ func TestSync(t *testing.T) {
 			// Snapshot status with nil error, no initial content, new content should be created.
 			name:              "8-2 - Snapshot status with nil error, no initial snapshot content, new content should be created",
 			initialContents:   nocontents,
-			expectedContents:  withContentAnnotations(newContentArrayNoStatus("snapcontent-snapuid8-2", "snapuid8-2", "snap8-2", "sid8-2", validSecretClass, "", "pv-handle8-2", deletionPolicy, nil, nil, false, false), map[string]string{utils.AnnDeletionSecretRefName: "secret", utils.AnnDeletionSecretRefNamespace: "default"}),
+			expectedContents:  withContentAnnotations(newContentArrayNoStatus("snapcontent-snapuid8-2", "snapuid8-2", "snap8-2", "sid8-2", validSecretClass, "", "pv-handle8-2", deletionPolicy, nil, nil, false, false), map[string]string{utils.AnnDeletionSecretRefName: "secret", utils.AnnDeletionSecretRefNamespace: "default", utils.PrefixedSnapshotterSecretNameKey: "secret", utils.PrefixedSnapshotterSecretNamespaceKey: "default"}),
 			initialSnapshots:  newSnapshotArray("snap8-2", "snapuid8-2", "claim8-2", "", validSecretClass, "", nil, nil, nil, nil, false, false, nil),
 			expectedSnapshots: newSnapshotArray("snap8-2", "snapuid8-2", "claim8-2", "", validSecretClass, "snapcontent-snapuid8-2", &False, nil, nil, nil, false, false, nil),
 			initialClaims:     newClaimArray("claim8-2", "pvc-uid8-2", "1Gi", "volume8-2", v1.ClaimBound, &classEmpty),
@@ -494,7 +494,7 @@ func TestSync(t *testing.T) {
 			// Snapshot status with error, no initial content, new content should be created, snapshot error should be cleared.
 			name:              "8-3 - Snapshot status with error, no initial content, new content should be created, snapshot error should be cleared",
 			initialContents:   nocontents,
-			expectedContents:  withContentAnnotations(newContentArrayNoStatus("snapcontent-snapuid8-3", "snapuid8-3", "snap8-3", "sid8-3", validSecretClass, "", "pv-handle8-3", deletionPolicy, nil, nil, false, false), map[string]string{utils.AnnDeletionSecretRefName: "secret", utils.AnnDeletionSecretRefNamespace: "default"}),
+			expectedContents:  withContentAnnotations(newContentArrayNoStatus("snapcontent-snapuid8-3", "snapuid8-3", "snap8-3", "sid8-3", validSecretClass, "", "pv-handle8-3", deletionPolicy, nil, nil, false, false), map[string]string{utils.AnnDeletionSecretRefName: "secret", utils.AnnDeletionSecretRefNamespace: "default", utils.PrefixedSnapshotterSecretNameKey: "secret", utils.PrefixedSnapshotterSecretNamespaceKey: "default"}),
 			initialSnapshots:  newSnapshotArray("snap8-3", "snapuid8-3", "claim8-3", "", validSecretClass, "", nil, nil, nil, snapshotErr, false, false, nil),
 			expectedSnapshots: newSnapshotArray("snap8-3", "snapuid8-3", "claim8-3", "", validSecretClass, "snapcontent-snapuid8-3", &False, nil, nil, nil, false, false, nil),
 			initialClaims:     newClaimArray("claim8-3", "pvc-uid8-3", "1Gi", "volume8-3", v1.ClaimBound, &classEmpty),

--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -235,9 +235,9 @@ func IsDefaultAnnotation(obj metav1.ObjectMeta) bool {
 	return false
 }
 
-// verifyAndGetSecretNameAndNamespaceTemplate gets the values (templates) associated
+// VerifyAndGetSecretNameAndNamespaceTemplate gets the values (templates) associated
 // with the parameters specified in "secret" and verifies that they are specified correctly.
-func verifyAndGetSecretNameAndNamespaceTemplate(secret secretParamsMap, snapshotClassParams map[string]string) (nameTemplate, namespaceTemplate string, err error) {
+func VerifyAndGetSecretNameAndNamespaceTemplate(secret secretParamsMap, snapshotClassParams map[string]string) (nameTemplate, namespaceTemplate string, err error) {
 	numName := 0
 	numNamespace := 0
 	if t, ok := snapshotClassParams[secret.secretNameKey]; ok {
@@ -285,7 +285,7 @@ func verifyAndGetSecretNameAndNamespaceTemplate(secret secretParamsMap, snapshot
 // - the resolved name is not a valid secret name
 // - the resolved namespace is not a valid namespace name
 func GetSecretReference(secretParams secretParamsMap, snapshotClassParams map[string]string, snapContentName string, snapshot *crdv1.VolumeSnapshot) (*v1.SecretReference, error) {
-	nameTemplate, namespaceTemplate, err := verifyAndGetSecretNameAndNamespaceTemplate(secretParams, snapshotClassParams)
+	nameTemplate, namespaceTemplate, err := VerifyAndGetSecretNameAndNamespaceTemplate(secretParams, snapshotClassParams)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get name and namespace template from params: %v", err)
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Add CSI secret templates as annotation in volumeSnapshotContent

This is required to handle volumeSnapshotContent with secretRef after volumeSnapshotClass is changed/deleted.

**Which issue(s) this PR fixes**:
Fixes #577

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
If "csi.storage.k8s.io/snapshotter-secret-namespace" and "snapshot.storage.kubernetes.io/deletion-secret-name" are defined as SnapshotClass parameters, they are copied to volumeSnapshotContent as annotations.
```
