### PR TITLE
Fix VolumeSnapshotContentStatus field type

### DIFF
--- a/client/apis/volumesnapshot/v1/types.go
+++ b/client/apis/volumesnapshot/v1/types.go
@@ -379,7 +379,7 @@ type VolumeSnapshotContentStatus struct {
 	// On Unix, the command `date +%s%N` returns the current time in nanoseconds
 	// since 1970-01-01 00:00:00 UTC.
 	// +optional
-	CreationTime *int64 `json:"creationTime,omitempty" protobuf:"varint,2,opt,name=creationTime"`
+	CreationTime *metav1.Time `json:"creationTime,omitempty" protobuf:"varint,2,opt,name=creationTime"`
 
 	// restoreSize represents the complete size of the snapshot in bytes.
 	// In dynamic snapshot creation case, this field will be filled in by the
@@ -392,7 +392,7 @@ type VolumeSnapshotContentStatus struct {
 	// If not specified, it indicates that the size is unknown.
 	// +kubebuilder:validation:Minimum=0
 	// +optional
-	RestoreSize *int64 `json:"restoreSize,omitempty" protobuf:"bytes,3,opt,name=restoreSize"`
+	RestoreSize *resource.Quantity `json:"restoreSize,omitempty" protobuf:"bytes,3,opt,name=restoreSize"`
 
 	// readyToUse indicates if a snapshot is ready to be used to restore a volume.
 	// In dynamic snapshot creation case, this field will be filled in by the

--- a/client/apis/volumesnapshot/v1beta1/types.go
+++ b/client/apis/volumesnapshot/v1beta1/types.go
@@ -337,7 +337,7 @@ type VolumeSnapshotContentStatus struct {
 	// On Unix, the command `date +%s%N` returns the current time in nanoseconds
 	// since 1970-01-01 00:00:00 UTC.
 	// +optional
-	CreationTime *int64 `json:"creationTime,omitempty" protobuf:"varint,2,opt,name=creationTime"`
+	CreationTime *metav1.Time `json:"creationTime,omitempty" protobuf:"varint,2,opt,name=creationTime"`
 
 	// restoreSize represents the complete size of the snapshot in bytes.
 	// In dynamic snapshot creation case, this field will be filled in with the
@@ -349,7 +349,7 @@ type VolumeSnapshotContentStatus struct {
 	// If not specified, it indicates that the size is unknown.
 	// +kubebuilder:validation:Minimum=0
 	// +optional
-	RestoreSize *int64 `json:"restoreSize,omitempty" protobuf:"bytes,3,opt,name=restoreSize"`
+	RestoreSize *resource.Quantity `json:"restoreSize,omitempty" protobuf:"bytes,3,opt,name=restoreSize"`
 
 	// readyToUse indicates if a snapshot is ready to be used to restore a volume.
 	// In dynamic snapshot creation case, this field will be filled in with the


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When get a ready `VolumeSnapshotContentStatus`: `kubectl get volumesnapshotcontent snapcontent-xxx -oyaml`
got follows output:
```
apiVersion: snapshot.storage.k8s.io/v1beta1
kind: VolumeSnapshotContent
metadata:
  ...
spec:
  ...
status:
  creationTime: 1633315996000000000
  readyToUse: true
  restoreSize: 536870912000
  snapshotHandle: snap-xxx
```

To be consistent with `VolumeSnapshotStatus`:
the `creationTime: 1633315996000000000` should be like `creationTime: "2021-10-04T02:53:16Z"`
the `restoreSize: 536870912000` should be like `restoreSize: 500Gi`

**Which issue(s) this PR fixes**:
Fixes #595

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```