### PR TITLE
Add short names for Volume Snapshot CRDs

### DIFF
--- a/client/apis/volumesnapshot/v1/types.go
+++ b/client/apis/volumesnapshot/v1/types.go
@@ -29,7 +29,7 @@ import (
 // VolumeSnapshot is a user's request for either creating a point-in-time
 // snapshot of a persistent volume, or binding to a pre-existing snapshot.
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:scope=Namespaced
+// +kubebuilder:resource:scope=Namespaced,shortName=vs
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="ReadyToUse",type=boolean,JSONPath=`.status.readyToUse`,description="Indicates if the snapshot is ready to be used to restore a volume."
 // +kubebuilder:printcolumn:name="SourcePVC",type=string,JSONPath=`.spec.source.persistentVolumeClaimName`,description="If a new snapshot needs to be created, this contains the name of the source PVC from which this snapshot was (or will be) created."
@@ -194,7 +194,7 @@ type VolumeSnapshotStatus struct {
 // name in a VolumeSnapshot object.
 // VolumeSnapshotClasses are non-namespaced
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:scope=Cluster,shortName=vsclass;vsclasses
 // +kubebuilder:printcolumn:name="Driver",type=string,JSONPath=`.driver`
 // +kubebuilder:printcolumn:name="DeletionPolicy",type=string,JSONPath=`.deletionPolicy`,description="Determines whether a VolumeSnapshotContent created through the VolumeSnapshotClass should be deleted when its bound VolumeSnapshot is deleted."
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
@@ -245,7 +245,7 @@ type VolumeSnapshotClassList struct {
 // VolumeSnapshotContent represents the actual "on-disk" snapshot object in the
 // underlying storage system
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:scope=Cluster,shortName=vsc;vscs
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="ReadyToUse",type=boolean,JSONPath=`.status.readyToUse`,description="Indicates if the snapshot is ready to be used to restore a volume."
 // +kubebuilder:printcolumn:name="RestoreSize",type=integer,JSONPath=`.status.restoreSize`,description="Represents the complete size of the snapshot in bytes"

--- a/client/apis/volumesnapshot/v1beta1/types.go
+++ b/client/apis/volumesnapshot/v1beta1/types.go
@@ -29,7 +29,7 @@ import (
 // VolumeSnapshot is a user's request for either creating a point-in-time
 // snapshot of a persistent volume, or binding to a pre-existing snapshot.
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:scope=Namespaced
+// +kubebuilder:resource:scope=Namespaced,shortName=vs
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="ReadyToUse",type=boolean,JSONPath=`.status.readyToUse`,description="Indicates if a snapshot is ready to be used to restore a volume."
 // +kubebuilder:printcolumn:name="SourcePVC",type=string,JSONPath=`.spec.source.persistentVolumeClaimName`,description="Name of the source PVC from where a dynamically taken snapshot will be created."
@@ -170,7 +170,7 @@ type VolumeSnapshotStatus struct {
 // name in a VolumeSnapshot object.
 // VolumeSnapshotClasses are non-namespaced
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:scope=Cluster,shortName=vsclass;vsclasses
 // +kubebuilder:printcolumn:name="Driver",type=string,JSONPath=`.driver`
 // +kubebuilder:printcolumn:name="DeletionPolicy",type=string,JSONPath=`.deletionPolicy`,description="Determines whether a VolumeSnapshotContent created through the VolumeSnapshotClass should be deleted when its bound VolumeSnapshot is deleted."
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
@@ -221,7 +221,7 @@ type VolumeSnapshotClassList struct {
 // VolumeSnapshotContent represents the actual "on-disk" snapshot object in the
 // underlying storage system
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:scope=Cluster,shortName=vsc;vscs
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="ReadyToUse",type=boolean,JSONPath=`.status.readyToUse`,description="Indicates if a snapshot is ready to be used to restore a volume."
 // +kubebuilder:printcolumn:name="RestoreSize",type=integer,JSONPath=`.status.restoreSize`,description="Represents the complete size of the snapshot in bytes"

--- a/client/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml
+++ b/client/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml
@@ -14,6 +14,9 @@ spec:
     kind: VolumeSnapshotClass
     listKind: VolumeSnapshotClassList
     plural: volumesnapshotclasses
+    shortNames:
+    - vsclass
+    - vsclasses
     singular: volumesnapshotclass
   scope: Cluster
   versions:

--- a/client/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml
+++ b/client/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml
@@ -14,6 +14,9 @@ spec:
     kind: VolumeSnapshotContent
     listKind: VolumeSnapshotContentList
     plural: volumesnapshotcontents
+    shortNames:
+    - vsc
+    - vscs
     singular: volumesnapshotcontent
   scope: Cluster
   versions:

--- a/client/config/crd/snapshot.storage.k8s.io_volumesnapshots.yaml
+++ b/client/config/crd/snapshot.storage.k8s.io_volumesnapshots.yaml
@@ -14,6 +14,8 @@ spec:
     kind: VolumeSnapshot
     listKind: VolumeSnapshotList
     plural: volumesnapshots
+    shortNames:
+    - vs
     singular: volumesnapshot
   scope: Namespaced
   versions:

--- a/vendor/github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1/types.go
+++ b/vendor/github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1/types.go
@@ -29,7 +29,7 @@ import (
 // VolumeSnapshot is a user's request for either creating a point-in-time
 // snapshot of a persistent volume, or binding to a pre-existing snapshot.
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:scope=Namespaced
+// +kubebuilder:resource:scope=Namespaced,shortName=vs
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="ReadyToUse",type=boolean,JSONPath=`.status.readyToUse`,description="Indicates if the snapshot is ready to be used to restore a volume."
 // +kubebuilder:printcolumn:name="SourcePVC",type=string,JSONPath=`.spec.source.persistentVolumeClaimName`,description="If a new snapshot needs to be created, this contains the name of the source PVC from which this snapshot was (or will be) created."
@@ -194,7 +194,7 @@ type VolumeSnapshotStatus struct {
 // name in a VolumeSnapshot object.
 // VolumeSnapshotClasses are non-namespaced
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:scope=Cluster,shortName=vsclass;vsclasses
 // +kubebuilder:printcolumn:name="Driver",type=string,JSONPath=`.driver`
 // +kubebuilder:printcolumn:name="DeletionPolicy",type=string,JSONPath=`.deletionPolicy`,description="Determines whether a VolumeSnapshotContent created through the VolumeSnapshotClass should be deleted when its bound VolumeSnapshot is deleted."
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
@@ -245,7 +245,7 @@ type VolumeSnapshotClassList struct {
 // VolumeSnapshotContent represents the actual "on-disk" snapshot object in the
 // underlying storage system
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:scope=Cluster,shortName=vsc;vscs
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="ReadyToUse",type=boolean,JSONPath=`.status.readyToUse`,description="Indicates if the snapshot is ready to be used to restore a volume."
 // +kubebuilder:printcolumn:name="RestoreSize",type=integer,JSONPath=`.status.restoreSize`,description="Represents the complete size of the snapshot in bytes"

--- a/vendor/github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1beta1/types.go
+++ b/vendor/github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1beta1/types.go
@@ -29,7 +29,7 @@ import (
 // VolumeSnapshot is a user's request for either creating a point-in-time
 // snapshot of a persistent volume, or binding to a pre-existing snapshot.
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:scope=Namespaced
+// +kubebuilder:resource:scope=Namespaced,shortName=vs
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="ReadyToUse",type=boolean,JSONPath=`.status.readyToUse`,description="Indicates if a snapshot is ready to be used to restore a volume."
 // +kubebuilder:printcolumn:name="SourcePVC",type=string,JSONPath=`.spec.source.persistentVolumeClaimName`,description="Name of the source PVC from where a dynamically taken snapshot will be created."
@@ -170,7 +170,7 @@ type VolumeSnapshotStatus struct {
 // name in a VolumeSnapshot object.
 // VolumeSnapshotClasses are non-namespaced
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:scope=Cluster,shortName=vsclass;vsclasses
 // +kubebuilder:printcolumn:name="Driver",type=string,JSONPath=`.driver`
 // +kubebuilder:printcolumn:name="DeletionPolicy",type=string,JSONPath=`.deletionPolicy`,description="Determines whether a VolumeSnapshotContent created through the VolumeSnapshotClass should be deleted when its bound VolumeSnapshot is deleted."
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
@@ -221,7 +221,7 @@ type VolumeSnapshotClassList struct {
 // VolumeSnapshotContent represents the actual "on-disk" snapshot object in the
 // underlying storage system
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:scope=Cluster,shortName=vsc;vscs
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="ReadyToUse",type=boolean,JSONPath=`.status.readyToUse`,description="Indicates if a snapshot is ready to be used to restore a volume."
 // +kubebuilder:printcolumn:name="RestoreSize",type=integer,JSONPath=`.status.restoreSize`,description="Represents the complete size of the snapshot in bytes"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

# _**NOTE: This is a backport of #604**_

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This allows end users to run `kubectl get vs`, for example, instead of
`kubectl get volumesnapshot`. The following short names have been
implemented:

* `VolumeSnapshot` - `vs`
* `VolumeSnapshotContent` - `vsc`, `vscs`
* `VolumeSnapshotClass` - `vsclass`, `vsclasses`

<img width="1680" alt="Screen Shot 2021-11-11 at 5 12 19 PM" src="https://user-images.githubusercontent.com/20929870/141376376-ffe089bc-baa7-431f-add5-ef7fe5cbfd3a.png">

**Which issue(s) this PR fixes**:

Fixes #603

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

Yes

```release-note
Cherry-pick: #604: Added short names for Volume Snapshot CRDs:
* VolumeSnapshot - vs
* VolumeSnapshotContent - vsc, vscs
* VolumeSnapshotClass` - vsclass, vsclasses
```
