### PR TITLE
Make the QPS and Burst of kube client config to be configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,10 @@ Read more about how to install the example webhook [here](deploy/kubernetes/webh
 
 * `--leader-election-retry-period <duration>`: Duration, in seconds, the LeaderElector clients should wait between tries of actions. Defaults to 5 seconds.
 
+* `--kube-api-qps <num>`: QPS for clients that communicate with the kubernetes apiserver. Defaults to `5.0`.
+
+* `--kube-api-burst <num>`: Burst for clients that communicate with the kubernetes apiserver. Defaults to `10`.
+
 * `--http-endpoint`: The TCP network address where the HTTP server for diagnostics, including metrics and leader election health check, will listen (example: `:8080` which corresponds to port 8080 on local host). The default is empty string, which means the server is disabled.
 
 * `--metrics-path`: The HTTP path where prometheus metrics will be exposed. Default is `/metrics`.
@@ -156,6 +160,10 @@ Read more about how to install the example webhook [here](deploy/kubernetes/webh
 * `--leader-election-renew-deadline <duration>`: Duration, in seconds, that the acting leader will retry refreshing leadership before giving up. Defaults to 10 seconds.
 
 * `--leader-election-retry-period <duration>`: Duration, in seconds, the LeaderElector clients should wait between tries of actions. Defaults to 5 seconds.
+
+* `--kube-api-qps <num>`: QPS for clients that communicate with the kubernetes apiserver. Defaults to `5.0`.
+
+* `--kube-api-burst <num>`: Burst for clients that communicate with the kubernetes apiserver. Defaults to `10`.
 
 * `--timeout <duration>`: Timeout of all calls to CSI driver. It should be set to value that accommodates majority of `CreateSnapshot`, `DeleteSnapshot`, and `ListSnapshots` calls. 1 minute is used by default.
 

--- a/cmd/csi-snapshotter/main.go
+++ b/cmd/csi-snapshotter/main.go
@@ -28,6 +28,7 @@ import (
 
 	"google.golang.org/grpc"
 
+	"github.com/spf13/pflag"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -72,6 +73,9 @@ var (
 	leaderElectionRenewDeadline = flag.Duration("leader-election-renew-deadline", 10*time.Second, "Duration, in seconds, that the acting leader will retry refreshing leadership before giving up. Defaults to 10 seconds.")
 	leaderElectionRetryPeriod   = flag.Duration("leader-election-retry-period", 5*time.Second, "Duration, in seconds, the LeaderElector clients should wait between tries of actions. Defaults to 5 seconds.")
 
+	kubeAPIQPS   = pflag.Float32("kube-api-qps", 5, "QPS to use while communicating with the kubernetes apiserver. Defaults to 5.0.")
+	kubeAPIBurst = flag.Int("kube-api-burst", 10, "Burst to use while communicating with the kubernetes apiserver. Defaults to 10.")
+
 	metricsAddress     = flag.String("metrics-address", "", "(deprecated) The TCP network address where the prometheus metrics endpoint will listen (example: `:8080`). The default is empty string, which means metrics endpoint is disabled. Only one of `--metrics-address` and `--http-endpoint` can be set.")
 	httpEndpoint       = flag.String("http-endpoint", "", "The TCP network address where the HTTP server for diagnostics, including metrics and leader election health check, will listen (example: `:8080`). The default is empty string, which means the server is disabled. Only one of `--metrics-address` and `--http-endpoint` can be set.")
 	metricsPath        = flag.String("metrics-path", "/metrics", "The HTTP path where prometheus metrics will be exposed. Default is `/metrics`.")
@@ -101,6 +105,9 @@ func main() {
 		klog.Error(err.Error())
 		os.Exit(1)
 	}
+
+	config.QPS = *kubeAPIQPS
+	config.Burst = *kubeAPIBurst
 
 	kubeClient, err := kubernetes.NewForConfig(config)
 	if err != nil {

--- a/cmd/snapshot-controller/main.go
+++ b/cmd/snapshot-controller/main.go
@@ -27,6 +27,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/spf13/pflag"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -60,6 +61,9 @@ var (
 	leaderElectionLeaseDuration = flag.Duration("leader-election-lease-duration", 15*time.Second, "Duration, in seconds, that non-leader candidates will wait to force acquire leadership. Defaults to 15 seconds.")
 	leaderElectionRenewDeadline = flag.Duration("leader-election-renew-deadline", 10*time.Second, "Duration, in seconds, that the acting leader will retry refreshing leadership before giving up. Defaults to 10 seconds.")
 	leaderElectionRetryPeriod   = flag.Duration("leader-election-retry-period", 5*time.Second, "Duration, in seconds, the LeaderElector clients should wait between tries of actions. Defaults to 5 seconds.")
+
+	kubeAPIQPS   = pflag.Float32("kube-api-qps", 5, "QPS to use while communicating with the kubernetes apiserver. Defaults to 5.0.")
+	kubeAPIBurst = flag.Int("kube-api-burst", 10, "Burst to use while communicating with the kubernetes apiserver. Defaults to 10.")
 
 	httpEndpoint       = flag.String("http-endpoint", "", "The TCP network address where the HTTP server for diagnostics, including metrics, will listen (example: :8080). The default is empty string, which means the server is disabled.")
 	metricsPath        = flag.String("metrics-path", "/metrics", "The HTTP path where prometheus metrics will be exposed. Default is `/metrics`.")
@@ -126,6 +130,9 @@ func main() {
 		klog.Error(err.Error())
 		os.Exit(1)
 	}
+
+	config.QPS = *kubeAPIQPS
+	config.Burst = *kubeAPIBurst
 
 	kubeClient, err := kubernetes.NewForConfig(config)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.26.0
 	github.com/spf13/cobra v1.1.3
+	github.com/spf13/pflag v1.0.5
 	golang.org/x/oauth2 v0.0.0-20201208152858-08078c50e5b5 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/grpc v1.38.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -115,6 +115,7 @@ github.com/prometheus/procfs/internal/util
 ## explicit
 github.com/spf13/cobra
 # github.com/spf13/pflag v1.0.5
+## explicit
 github.com/spf13/pflag
 # golang.org/x/net v0.0.0-20210520170846-37e1c6afe023
 golang.org/x/net/context


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

>/kind flake


**What this PR does / why we need it**:

This change adds two new flags "kube-api-qps" and "kube-api-burst" to make the QPS and Burst of clients to the API server configurable. Their default values stay the same as defaults of kube client.

**Experiment**

To justify the necessity to make this change, we run experiments on external-snapshotters between defaullt qps and burst and a pair of hardcoded ones. Following are the results for 32 threads runs.

1) Default QPS and Burst: QPS=5.0 and Burst=10

| tput.ops.per.sec | littles.law |
| ---------------- | ----------- |
|            0.497 |      32.367 |
|            1.266 |      31.614 |


2) QPS and Burst set to 100

| tput.ops.per.sec | littles.law |
| ---------------- | ----------- |
|            9.760 |      32.050 |
|           11.361 |      32.097 |

We built the snapshot-controller and csi-snapshotter with the hardcoded value of 100 for both QPS and Burst and observed 9x improvement for CreateSnapshot and 11x improvement for DeleteSnapshot.

** Testing **

Run the following unit tests to ensure there is no regression.

```
$pwd
/Users/lintongj/go/src/github.com/kubernetes-csi/external-snapshotter
$go test -timeout 30s  ./pkg/... --count=1
ok  	github.com/kubernetes-csi/external-snapshotter/v4/pkg/common-controller	0.495s
ok  	github.com/kubernetes-csi/external-snapshotter/v4/pkg/metrics	4.454s
ok  	github.com/kubernetes-csi/external-snapshotter/v4/pkg/sidecar-controller	0.337s
ok  	github.com/kubernetes-csi/external-snapshotter/v4/pkg/snapshotter	0.245s
ok  	github.com/kubernetes-csi/external-snapshotter/v4/pkg/utils	0.319s
ok  	github.com/kubernetes-csi/external-snapshotter/v4/pkg/validation-webhook	9.735s
```

Also run through `make test` locally. And get the following message.

```
$make test
...
Congratulations! All shell files are passing lint.
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

There is no issue opened for this issue. I can open one if required.

**Special notes for your reviewer**:
N/A

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Make the QPS and Burst of kube client config to be configurable in both snapshot-controller and CSI snapshotter sidecar
```
