### PR TITLE
[release-3.0] Automated cherry pick of #550: Use distroless/static image for webhook

### DIFF
--- a/cmd/snapshot-validation-webhook/Dockerfile
+++ b/cmd/snapshot-validation-webhook/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/base:latest-amd64
+FROM gcr.io/distroless/static:latest-amd64
 LABEL maintainers="Kubernetes Authors"
 LABEL description="Snapshot Validation Webhook"
 ARG binary=./bin/snapshot-validation-webhook


### PR DESCRIPTION
Cherry pick of #550 on release-3.0.

#550: Use distroless/static image for webhook

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```
Cherry-pick #550: Use distroless/static image for webhook
```