### PR TITLE
Check if Status on Snapshot before checking if Status.Error is present

### DIFF
--- a/pkg/sidecar-controller/snapshot_controller_base.go
+++ b/pkg/sidecar-controller/snapshot_controller_base.go
@@ -104,7 +104,7 @@ func NewCSISnapshotSideCarController(
 				// and CSI CreateSnapshot will be called again without exponential backoff.
 				// So we are skipping the re-queue here to avoid CreateSnapshot being called without exponential backoff.
 				newSnapContent := newObj.(*crdv1.VolumeSnapshotContent)
-				if newSnapContent.Status.Error != nil {
+				if newSnapContent.Status != nil && newSnapContent.Status.Error != nil {
 					oldSnapContent := oldObj.(*crdv1.VolumeSnapshotContent)
 					_, newExists := newSnapContent.ObjectMeta.Annotations[utils.AnnVolumeSnapshotBeingCreated]
 					_, oldExists := oldSnapContent.ObjectMeta.Annotations[utils.AnnVolumeSnapshotBeingCreated]


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fixes a `nil pointer dereference` introduced in #666. Check if Status field is nil before dereferencing the `Error` field on this object.

**Which issue(s) this PR fixes**:
Fixes a `nil pointer dereference` in https://github.com/kubernetes-csi/external-snapshotter/pull/666

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Fixes a `nil pointer dereference` regression introduced in #666 
```
