### PR TITLE
Backport: Avoid constantly retries CreateSnapshot call on error without exponential backoff

### DIFF
--- a/pkg/sidecar-controller/snapshot_controller_base.go
+++ b/pkg/sidecar-controller/snapshot_controller_base.go
@@ -25,6 +25,7 @@ import (
 	storageinformers "github.com/kubernetes-csi/external-snapshotter/client/v4/informers/externalversions/volumesnapshot/v1"
 	storagelisters "github.com/kubernetes-csi/external-snapshotter/client/v4/listers/volumesnapshot/v1"
 	"github.com/kubernetes-csi/external-snapshotter/v4/pkg/snapshotter"
+	"github.com/kubernetes-csi/external-snapshotter/v4/pkg/utils"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -94,8 +95,22 @@ func NewCSISnapshotSideCarController(
 
 	volumeSnapshotContentInformer.Informer().AddEventHandlerWithResyncPeriod(
 		cache.ResourceEventHandlerFuncs{
-			AddFunc:    func(obj interface{}) { ctrl.enqueueContentWork(obj) },
-			UpdateFunc: func(oldObj, newObj interface{}) { ctrl.enqueueContentWork(newObj) },
+			AddFunc: func(obj interface{}) { ctrl.enqueueContentWork(obj) },
+			UpdateFunc: func(oldObj, newObj interface{}) {
+				// If the CSI driver fails to create a snapshot and returns a failure, the CSI Snapshotter sidecar
+				// will remove the "AnnVolumeSnapshotBeingCreated" annotation from the VolumeSnapshotContent.
+				// This will trigger a VolumeSnapshotContent update and it will cause the obj to be re-queued immediately
+				// and CSI CreateSnapshot will be called again without exponential backoff.
+				// So we are skipping the re-queue here to avoid CreateSnapshot being called without exponential backoff.
+				newSnapContent := newObj.(*crdv1.VolumeSnapshotContent)
+				oldSnapContent := oldObj.(*crdv1.VolumeSnapshotContent)
+				_, newExists := newSnapContent.ObjectMeta.Annotations[utils.AnnVolumeSnapshotBeingCreated]
+				_, oldExists := oldSnapContent.ObjectMeta.Annotations[utils.AnnVolumeSnapshotBeingCreated]
+				if !newExists && oldExists {
+					return
+				}
+				ctrl.enqueueContentWork(newObj)
+			},
 			DeleteFunc: func(obj interface{}) { ctrl.enqueueContentWork(obj) },
 		},
 		ctrl.resyncPeriod,

--- a/pkg/sidecar-controller/snapshot_controller_base.go
+++ b/pkg/sidecar-controller/snapshot_controller_base.go
@@ -104,7 +104,7 @@ func NewCSISnapshotSideCarController(
 				// and CSI CreateSnapshot will be called again without exponential backoff.
 				// So we are skipping the re-queue here to avoid CreateSnapshot being called without exponential backoff.
 				newSnapContent := newObj.(*crdv1.VolumeSnapshotContent)
-				if newSnapContent.Status.Error != nil {
+				if newSnapContent.Status != nil && newSnapContent.Status.Error != nil {
 					oldSnapContent := oldObj.(*crdv1.VolumeSnapshotContent)
 					_, newExists := newSnapContent.ObjectMeta.Annotations[utils.AnnVolumeSnapshotBeingCreated]
 					_, oldExists := oldSnapContent.ObjectMeta.Annotations[utils.AnnVolumeSnapshotBeingCreated]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

Backport #651, #666 and #669

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Backport #651, #666 and #669: Avoid constantly retries CreateSnapshot call on error without exponential backoff
```
