### PR TITLE
Changes to snapshot controller to add sourceVolumeMode

### DIFF
--- a/cmd/snapshot-controller/main.go
+++ b/cmd/snapshot-controller/main.go
@@ -70,6 +70,7 @@ var (
 	retryIntervalStart            = flag.Duration("retry-interval-start", time.Second, "Initial retry interval of failed volume snapshot creation or deletion. It doubles with each failure, up to retry-interval-max. Default is 1 second.")
 	retryIntervalMax              = flag.Duration("retry-interval-max", 5*time.Minute, "Maximum retry interval of failed volume snapshot creation or deletion. Default is 5 minutes.")
 	enableDistributedSnapshotting = flag.Bool("enable-distributed-snapshotting", false, "Enables each node to handle snapshotting for the local volumes created on that node")
+	preventVolumeModeConversion   = flag.Bool("prevent-volume-mode-conversion", false, "Prevents an unauthorised user from modifying the volume mode when creating a PVC from an existing VolumeSnapshot.")
 )
 
 var (
@@ -187,6 +188,7 @@ func main() {
 		workqueue.NewItemExponentialFailureRateLimiter(*retryIntervalStart, *retryIntervalMax),
 		workqueue.NewItemExponentialFailureRateLimiter(*retryIntervalStart, *retryIntervalMax),
 		*enableDistributedSnapshotting,
+		*preventVolumeModeConversion,
 	)
 
 	if err := ensureCustomResourceDefinitionsExist(snapClient); err != nil {

--- a/pkg/common-controller/framework_test.go
+++ b/pkg/common-controller/framework_test.go
@@ -844,6 +844,7 @@ func newTestController(kubeClient kubernetes.Interface, clientset clientset.Inte
 		workqueue.NewItemExponentialFailureRateLimiter(1*time.Millisecond, 1*time.Minute),
 		workqueue.NewItemExponentialFailureRateLimiter(1*time.Millisecond, 1*time.Minute),
 		false,
+		false,
 	)
 
 	ctrl.eventRecorder = record.NewFakeRecorder(1000)

--- a/pkg/common-controller/snapshot_controller.go
+++ b/pkg/common-controller/snapshot_controller.go
@@ -685,17 +685,10 @@ func (ctrl *csiSnapshotCommonController) createSnapshotContent(snapshot *crdv1.V
 	}
 
 	if ctrl.preventVolumeModeConversion {
-		volumeMode := volume.Spec.VolumeMode
-		if volumeMode != nil {
-			snapshotContent.Spec.SourceVolumeMode = new(crdv1.SourceVolumeMode)
-			switch *volumeMode {
-			case v1.PersistentVolumeBlock:
-				*snapshotContent.Spec.SourceVolumeMode = crdv1.SourceVolumeModeBlock
-			case v1.PersistentVolumeFilesystem:
-				*snapshotContent.Spec.SourceVolumeMode = crdv1.SourceVolumeModeFilesystem
-			}
+		if volume.Spec.VolumeMode != nil {
+			snapshotContent.Spec.SourceVolumeMode = volume.Spec.VolumeMode
+			klog.V(5).Infof("snapcontent %s has volume mode %s", snapshotContent.Name, *snapshotContent.Spec.SourceVolumeMode)
 		}
-		klog.V(5).Infof("snapcontent %s has volume mode %s", snapshotContent.Name, *snapshotContent.Spec.SourceVolumeMode)
 	}
 
 	// Set AnnDeletionSecretRefName and AnnDeletionSecretRefNamespace

--- a/pkg/common-controller/snapshot_controller.go
+++ b/pkg/common-controller/snapshot_controller.go
@@ -684,6 +684,20 @@ func (ctrl *csiSnapshotCommonController) createSnapshotContent(snapshot *crdv1.V
 		}
 	}
 
+	if ctrl.preventVolumeModeConversion {
+		volumeMode := volume.Spec.VolumeMode
+		if volumeMode != nil {
+			snapshotContent.Spec.SourceVolumeMode = new(crdv1.SourceVolumeMode)
+			switch *volumeMode {
+			case v1.PersistentVolumeBlock:
+				*snapshotContent.Spec.SourceVolumeMode = crdv1.SourceVolumeModeBlock
+			case v1.PersistentVolumeFilesystem:
+				*snapshotContent.Spec.SourceVolumeMode = crdv1.SourceVolumeModeFilesystem
+			}
+		}
+		klog.V(5).Infof("snapcontent %s has volume mode %s", snapshotContent.Name, *snapshotContent.Spec.SourceVolumeMode)
+	}
+
 	// Set AnnDeletionSecretRefName and AnnDeletionSecretRefNamespace
 	if snapshotterSecretRef != nil {
 		klog.V(5).Infof("createSnapshotContent: set annotation [%s] on content [%s].", utils.AnnDeletionSecretRefName, snapshotContent.Name)

--- a/pkg/common-controller/snapshot_controller_base.go
+++ b/pkg/common-controller/snapshot_controller_base.go
@@ -68,6 +68,7 @@ type csiSnapshotCommonController struct {
 	resyncPeriod time.Duration
 
 	enableDistributedSnapshotting bool
+	preventVolumeModeConversion   bool
 }
 
 // NewCSISnapshotController returns a new *csiSnapshotCommonController
@@ -84,6 +85,7 @@ func NewCSISnapshotCommonController(
 	snapshotRateLimiter workqueue.RateLimiter,
 	contentRateLimiter workqueue.RateLimiter,
 	enableDistributedSnapshotting bool,
+	preventVolumeModeConversion bool,
 ) *csiSnapshotCommonController {
 	broadcaster := record.NewBroadcaster()
 	broadcaster.StartLogging(klog.Infof)
@@ -137,6 +139,8 @@ func NewCSISnapshotCommonController(
 		ctrl.nodeLister = nodeInformer.Lister()
 		ctrl.nodeListerSynced = nodeInformer.Informer().HasSynced
 	}
+
+	ctrl.preventVolumeModeConversion = preventVolumeModeConversion
 
 	return ctrl
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

This PR adds changes to snapshot-controller to read the volume mode of the source PV and add it to the `Spec.SourceVolumeMode` field of the to-be-created `VolumeSnapshotContent` object. 

Also introduce a feature flag for this feature. 

KEP - https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/3141-prevent-volume-mode-conversion


Testing

1. Deploy Hostpath CSI driver with `v6.0.0-rc2` version of `csi-snapshotter` and `VolumeSnapshotContent` CRD. Set `prevent-volume-mode-conversion` to `true` in `snapshot-controller`. 
```
% kubectl get deployment -n kube-system -o yaml snapshot-controller
apiVersion: apps/v1
kind: Deployment
...
spec:
  minReadySeconds: 15
  progressDeadlineSeconds: 600
...
spec:
      containers:
      - args:
        - --v=5
        - --leader-election=true
        - --prevent-volume-mode-conversion=true
        image: snapshot-controller:latest
...
```

2. Create a VolumeSnapshot object from an existing PVC:

```
% kubectl get volumesnapshot -A
NAMESPACE   NAME                   READYTOUSE   SOURCEPVC   SOURCESNAPSHOTCONTENT   RESTORESIZE   SNAPSHOTCLASS               SNAPSHOTCONTENT                                    CREATIONTIME   AGE
default     new-snapshot-demo-v1   true         hpvc                                1Gi           csi-hostpath-snapclass-v1   snapcontent-f4161ad9-9279-4e77-93ee-f8b5898b6010   4d             4d
```

3. Verify VolumeSnapshotContent object for SourceVolumeMode field:
```
% kubectl get volumesnapshotcontent -o yaml
apiVersion: v1
items:
- apiVersion: snapshot.storage.k8s.io/v1
  kind: VolumeSnapshotContent
...
  spec:
    deletionPolicy: Delete
    driver: hostpath.csi.k8s.io
    source:
      volumeHandle: 37a4f46e-afe9-11ec-b141-8ed1e89c66d6
    sourceVolumeMode: Filesystem
    volumeSnapshotClassName: csi-hostpath-snapclass-v1
...
```

4. Verify logs of `snapshot-controller`:

```
I0404 08:10:53.813378       1 snapshot_controller.go:698] snapcontent snapcontent-bbf7be38-ccb9-46bf-a420-f1a436bf10e4 has volume mode Filesystem
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Changes to snapshot controller to add SourceVolumeMode to VolumeSnapshotContents
```
