### PR TITLE
Add webhook to make SourceVolumeMode immutable

### DIFF
--- a/pkg/validation-webhook/snapshot.go
+++ b/pkg/validation-webhook/snapshot.go
@@ -377,5 +377,9 @@ func checkSnapshotContentImmutableFieldsV1(snapcontent, oldSnapcontent *volumesn
 	if !reflect.DeepEqual(source.SnapshotHandle, oldSource.SnapshotHandle) {
 		return fmt.Errorf("Spec.Source.SnapshotHandle is immutable but was changed from %s to %s", strPtrDereference(oldSource.SnapshotHandle), strPtrDereference(source.SnapshotHandle))
 	}
+	if !reflect.DeepEqual(snapcontent.Spec.SourceVolumeMode, oldSnapcontent.Spec.SourceVolumeMode) {
+		return fmt.Errorf("Spec.SourceVolumeMode is immutable but was changed from %v to %v", *oldSnapcontent.Spec.SourceVolumeMode, *snapcontent.Spec.SourceVolumeMode)
+	}
+
 	return nil
 }

--- a/pkg/validation-webhook/snapshot.go
+++ b/pkg/validation-webhook/snapshot.go
@@ -377,8 +377,11 @@ func checkSnapshotContentImmutableFieldsV1(snapcontent, oldSnapcontent *volumesn
 	if !reflect.DeepEqual(source.SnapshotHandle, oldSource.SnapshotHandle) {
 		return fmt.Errorf("Spec.Source.SnapshotHandle is immutable but was changed from %s to %s", strPtrDereference(oldSource.SnapshotHandle), strPtrDereference(source.SnapshotHandle))
 	}
-	if !reflect.DeepEqual(snapcontent.Spec.SourceVolumeMode, oldSnapcontent.Spec.SourceVolumeMode) {
-		return fmt.Errorf("Spec.SourceVolumeMode is immutable but was changed from %v to %v", *oldSnapcontent.Spec.SourceVolumeMode, *snapcontent.Spec.SourceVolumeMode)
+
+	if preventVolumeModeConversion {
+		if !reflect.DeepEqual(snapcontent.Spec.SourceVolumeMode, oldSnapcontent.Spec.SourceVolumeMode) {
+			return fmt.Errorf("Spec.SourceVolumeMode is immutable but was changed from %v to %v", *oldSnapcontent.Spec.SourceVolumeMode, *snapcontent.Spec.SourceVolumeMode)
+		}
 	}
 
 	return nil

--- a/pkg/validation-webhook/webhook.go
+++ b/pkg/validation-webhook/webhook.go
@@ -39,10 +39,11 @@ import (
 )
 
 var (
-	certFile       string
-	keyFile        string
-	kubeconfigFile string
-	port           int
+	certFile                    string
+	keyFile                     string
+	kubeconfigFile              string
+	port                        int
+	preventVolumeModeConversion bool
 )
 
 // CmdWebhook is used by Cobra.
@@ -67,6 +68,8 @@ func init() {
 	CmdWebhook.MarkFlagRequired("tls-private-key-file")
 	// Add optional flag for kubeconfig
 	CmdWebhook.Flags().StringVar(&kubeconfigFile, "kubeconfig", "", "kubeconfig file to use for volumesnapshotclasses")
+	CmdWebhook.Flags().BoolVar(&preventVolumeModeConversion, "prevent-volume-mode-conversion",
+		false, "Prevents an unauthorised user from modifying the volume mode when creating a PVC from an existing VolumeSnapshot.")
 }
 
 // admitv1beta1Func handles a v1beta1 admission

--- a/vendor/github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1/types.go
+++ b/vendor/github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1/types.go
@@ -341,8 +341,6 @@ type VolumeSnapshotContentSpec struct {
 // VolumeSnapshotContentSource represents the CSI source of a snapshot.
 // Exactly one of its members must be set.
 // Members in VolumeSnapshotContentSource are immutable.
-// TODO(xiangqian): Add a webhook to ensure that VolumeSnapshotContentSource members
-// will be immutable once specified.
 type VolumeSnapshotContentSource struct {
 	// volumeHandle specifies the CSI "volume_id" of the volume from which a snapshot
 	// should be dynamically taken from.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

This PR adds changes to snapshot-validation-webhook to make the `SourceVolumeMode` field immutable. 

KEP - https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/3141-prevent-volume-mode-conversion

Testing 

1. Deploy `snapshot-controller` with https://github.com/kubernetes-csi/external-snapshotter/pull/679

2. Create `VolumeSnapshot` object and attempt to alter `Spec.SourceVolumeMode` from `Filesystem` to `Block`. The attempt fails with the below error:

```
% kubectl edit volumesnapshotcontent                  
error: volumesnapshotcontents.snapshot.storage.k8s.io "snapcontent-bbf7be38-ccb9-46bf-a420-f1a436bf10e4" could not be patched: admission webhook "validation-webhook.snapshot.storage.k8s.io" denied the request: Spec.SourceVolumeMode is immutable but was changed from Filesystem to Block
You can run `kubectl replace -f /var/folders/th/sx982z_x23g8jdhw6vxqtjz40000gn/T/kubectl-edit-2559984217.yaml` to try this update again.

```
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add webhook to make SourceVolumeMode immutable
```
