### PR TITLE
[Cherry-pick] Change SourceVolumeMode type to v1.PersistentVolumeMode.

### DIFF
--- a/client/apis/volumesnapshot/v1/types.go
+++ b/client/apis/volumesnapshot/v1/types.go
@@ -335,7 +335,7 @@ type VolumeSnapshotContentSpec struct {
 	// This field is immutable.
 	// This field is an alpha field.
 	// +optional
-	SourceVolumeMode *SourceVolumeMode `json:"sourceVolumeMode" protobuf:"bytes,6,opt,name=sourceVolumeMode"`
+	SourceVolumeMode *core_v1.PersistentVolumeMode `json:"sourceVolumeMode" protobuf:"bytes,6,opt,name=sourceVolumeMode"`
 }
 
 // VolumeSnapshotContentSource represents the CSI source of a snapshot.
@@ -446,14 +446,3 @@ type VolumeSnapshotError struct {
 	// +optional
 	Message *string `json:"message,omitempty" protobuf:"bytes,2,opt,name=message"`
 }
-
-// SourceVolumeMode describes the volume mode of the source volume from which a snapshot was created.
-// +enum
-type SourceVolumeMode string
-
-const (
-	// SourceVolumeModeBlock describes a snapshot that is created from a raw block volume.
-	SourceVolumeModeBlock SourceVolumeMode = "Block"
-	// SourceVolumeModeFilesystem describes a snapshot that is created from a filesystem volume.
-	SourceVolumeModeFilesystem SourceVolumeMode = "Filesystem"
-)

--- a/client/apis/volumesnapshot/v1/zz_generated.deepcopy.go
+++ b/client/apis/volumesnapshot/v1/zz_generated.deepcopy.go
@@ -22,6 +22,7 @@ limitations under the License.
 package v1
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -226,7 +227,7 @@ func (in *VolumeSnapshotContentSpec) DeepCopyInto(out *VolumeSnapshotContentSpec
 	in.Source.DeepCopyInto(&out.Source)
 	if in.SourceVolumeMode != nil {
 		in, out := &in.SourceVolumeMode, &out.SourceVolumeMode
-		*out = new(SourceVolumeMode)
+		*out = new(corev1.PersistentVolumeMode)
 		**out = **in
 	}
 	return

--- a/vendor/github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1/types.go
+++ b/vendor/github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1/types.go
@@ -335,7 +335,7 @@ type VolumeSnapshotContentSpec struct {
 	// This field is immutable.
 	// This field is an alpha field.
 	// +optional
-	SourceVolumeMode *SourceVolumeMode `json:"sourceVolumeMode" protobuf:"bytes,6,opt,name=sourceVolumeMode"`
+	SourceVolumeMode *core_v1.PersistentVolumeMode `json:"sourceVolumeMode" protobuf:"bytes,6,opt,name=sourceVolumeMode"`
 }
 
 // VolumeSnapshotContentSource represents the CSI source of a snapshot.
@@ -446,14 +446,3 @@ type VolumeSnapshotError struct {
 	// +optional
 	Message *string `json:"message,omitempty" protobuf:"bytes,2,opt,name=message"`
 }
-
-// SourceVolumeMode describes the volume mode of the source volume from which a snapshot was created.
-// +enum
-type SourceVolumeMode string
-
-const (
-	// SourceVolumeModeBlock describes a snapshot that is created from a raw block volume.
-	SourceVolumeModeBlock SourceVolumeMode = "Block"
-	// SourceVolumeModeFilesystem describes a snapshot that is created from a filesystem volume.
-	SourceVolumeModeFilesystem SourceVolumeMode = "Filesystem"
-)

--- a/vendor/github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1/zz_generated.deepcopy.go
+++ b/vendor/github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1/zz_generated.deepcopy.go
@@ -22,6 +22,7 @@ limitations under the License.
 package v1
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -226,7 +227,7 @@ func (in *VolumeSnapshotContentSpec) DeepCopyInto(out *VolumeSnapshotContentSpec
 	in.Source.DeepCopyInto(&out.Source)
 	if in.SourceVolumeMode != nil {
 		in, out := &in.SourceVolumeMode, &out.SourceVolumeMode
-		*out = new(SourceVolumeMode)
+		*out = new(corev1.PersistentVolumeMode)
 		**out = **in
 	}
 	return


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind api-change

**What this PR does / why we need it**:

Cherry pick of https://github.com/kubernetes-csi/external-snapshotter/pull/683

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Cherry-pick #683: Change SourceVolumeMode type to v1.PersistentVolumeMode
```
