### PR TITLE
replace serviceAccountName key, rbac and cleanup in the code

### DIFF
--- a/cmd/snapshot-controller/main.go
+++ b/cmd/snapshot-controller/main.go
@@ -72,9 +72,7 @@ var (
 	enableDistributedSnapshotting = flag.Bool("enable-distributed-snapshotting", false, "Enables each node to handle snapshotting for the local volumes created on that node")
 )
 
-var (
-	version = "unknown"
-)
+var version = "unknown"
 
 // Checks that the VolumeSnapshot v1 CRDs exist.
 func ensureCustomResourceDefinitionsExist(client *clientset.Clientset) error {

--- a/deploy/kubernetes/csi-snapshotter/rbac-external-provisioner.yaml
+++ b/deploy/kubernetes/csi-snapshotter/rbac-external-provisioner.yaml
@@ -68,7 +68,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 
 ---
-# Provisioner must be able to work with endpoints and leases in current namespace
+# Provisioner must be able to work with leases in current namespace
 # if (and only if) leadership election is enabled
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
@@ -77,9 +77,6 @@ metadata:
   namespace: default
   name: external-provisioner-cfg
 rules:
-- apiGroups: [""]
-  resources: ["endpoints"]
-  verbs: ["get", "watch", "list", "delete", "update", "create"]
 - apiGroups: ["coordination.k8s.io"]
   resources: ["leases"]
   verbs: ["get", "watch", "list", "delete", "update", "create"]

--- a/deploy/kubernetes/csi-snapshotter/setup-csi-snapshotter.yaml
+++ b/deploy/kubernetes/csi-snapshotter/setup-csi-snapshotter.yaml
@@ -69,7 +69,7 @@ spec:
       labels:
         app: csi-snapshotter
     spec:
-      serviceAccount: csi-snapshotter
+      serviceAccountName: csi-snapshotter
       containers:
         - name: csi-provisioner
           image: k8s.gcr.io/sig-storage/csi-provisioner:v3.0.0

--- a/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml
+++ b/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml
@@ -30,7 +30,7 @@ spec:
       labels:
         app: snapshot-controller
     spec:
-      serviceAccount: snapshot-controller
+      serviceAccountName: snapshot-controller
       containers:
         - name: snapshot-controller
           image: gcr.io/k8s-staging-sig-storage/snapshot-controller:v5.0.1

--- a/pkg/common-controller/framework_test.go
+++ b/pkg/common-controller/framework_test.go
@@ -112,14 +112,18 @@ type controllerTest struct {
 
 type testCall func(ctrl *csiSnapshotCommonController, reactor *snapshotReactor, test controllerTest) error
 
-const testNamespace = "default"
-const mockDriverName = "csi-mock-plugin"
+const (
+	testNamespace  = "default"
+	mockDriverName = "csi-mock-plugin"
+)
 
-var errVersionConflict = errors.New("VersionError")
-var nocontents []*crdv1.VolumeSnapshotContent
-var nosnapshots []*crdv1.VolumeSnapshot
-var noevents = []string{}
-var noerrors = []reactorError{}
+var (
+	errVersionConflict = errors.New("VersionError")
+	nocontents         []*crdv1.VolumeSnapshotContent
+	nosnapshots        []*crdv1.VolumeSnapshot
+	noevents           = []string{}
+	noerrors           = []reactorError{}
+)
 
 // snapshotReactor is a core.Reactor that simulates etcd and API server. It
 // stores:
@@ -920,6 +924,7 @@ func withSnapshotContentInvalidLabel(contents []*crdv1.VolumeSnapshotContent) []
 	}
 	return contents
 }
+
 func withContentAnnotations(contents []*crdv1.VolumeSnapshotContent, annotations map[string]string) []*crdv1.VolumeSnapshotContent {
 	for i := range contents {
 		if contents[i].ObjectMeta.Annotations == nil {
@@ -1199,7 +1204,6 @@ func testSyncSnapshot(ctrl *csiSnapshotCommonController, reactor *snapshotReacto
 
 func testSyncSnapshotError(ctrl *csiSnapshotCommonController, reactor *snapshotReactor, test controllerTest) error {
 	err := ctrl.syncSnapshot(test.initialSnapshots[0])
-
 	if err != nil {
 		return nil
 	}
@@ -1302,7 +1306,6 @@ var (
 //   controller waits for the operation lock. Controller is then resumed and we
 //   check how it behaves.
 func wrapTestWithInjectedOperation(toWrap testCall, injectBeforeOperation func(ctrl *csiSnapshotCommonController, reactor *snapshotReactor)) testCall {
-
 	return func(ctrl *csiSnapshotCommonController, reactor *snapshotReactor, test controllerTest) error {
 		// Inject a hook before async operation starts
 		klog.V(4).Infof("reactor:injecting call")

--- a/pkg/common-controller/snapshot_controller.go
+++ b/pkg/common-controller/snapshot_controller.go
@@ -77,8 +77,10 @@ import (
 // bi-directional binding is complete and readyToUse becomes true. Error field
 // in the snapshot status will be updated accordingly when failure occurs.
 
-const snapshotKind = "VolumeSnapshot"
-const snapshotAPIGroup = crdv1.GroupName
+const (
+	snapshotKind     = "VolumeSnapshot"
+	snapshotAPIGroup = crdv1.GroupName
+)
 
 const controllerUpdateFailMsg = "snapshot controller failed to update"
 
@@ -822,7 +824,6 @@ func (ctrl *csiSnapshotCommonController) updateSnapshotErrorStatusWithEvent(snap
 
 // addContentFinalizer adds a Finalizer for VolumeSnapshotContent.
 func (ctrl *csiSnapshotCommonController) addContentFinalizer(content *crdv1.VolumeSnapshotContent) error {
-
 	var patches []utils.PatchOp
 	if len(content.Finalizers) > 0 {
 		// Add to the end of the finalizers if we have any other finalizers
@@ -831,7 +832,6 @@ func (ctrl *csiSnapshotCommonController) addContentFinalizer(content *crdv1.Volu
 			Path:  "/metadata/finalizers/-",
 			Value: utils.VolumeSnapshotContentFinalizer,
 		})
-
 	} else {
 		// Replace finalizers with new array if there are no other finalizers
 		patches = append(patches, utils.PatchOp{

--- a/pkg/common-controller/snapshot_controller_test.go
+++ b/pkg/common-controller/snapshot_controller_test.go
@@ -111,7 +111,6 @@ func TestControllerCacheParsingError(t *testing.T) {
 }
 
 func TestGetManagedByNode(t *testing.T) {
-
 	// Test that a matching node is found
 
 	node1 := &v1.Node{

--- a/pkg/common-controller/snapshot_create_test.go
+++ b/pkg/common-controller/snapshot_create_test.go
@@ -26,18 +26,22 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var timeNow = time.Now()
-var timeNowStamp = timeNow.UnixNano()
-var False = false
-var True = true
+var (
+	timeNow      = time.Now()
+	timeNowStamp = timeNow.UnixNano()
+	False        = false
+	True         = true
+)
 
 var metaTimeNowUnix = &metav1.Time{
 	Time: timeNow,
 }
 
-var defaultSize int64 = 1000
-var deletePolicy = crdv1.VolumeSnapshotContentDelete
-var retainPolicy = crdv1.VolumeSnapshotContentRetain
+var (
+	defaultSize  int64 = 1000
+	deletePolicy       = crdv1.VolumeSnapshotContentDelete
+	retainPolicy       = crdv1.VolumeSnapshotContentRetain
+)
 
 // Test single call to SyncSnapshot, expecting create snapshot to happen.
 // 1. Fill in the controller with initial data

--- a/pkg/common-controller/snapshot_delete_test.go
+++ b/pkg/common-controller/snapshot_delete_test.go
@@ -40,8 +40,8 @@ var class3Parameters = map[string]string{
 }
 
 var class4Parameters = map[string]string{
-	//utils.SnapshotterSecretNameKey:      "emptysecret",
-	//utils.SnapshotterSecretNamespaceKey: "default",
+	// utils.SnapshotterSecretNameKey:      "emptysecret",
+	// utils.SnapshotterSecretNamespaceKey: "default",
 }
 
 var class5Parameters = map[string]string{
@@ -51,8 +51,10 @@ var class5Parameters = map[string]string{
 
 var timeNowMetav1 = metav1.Now()
 
-var content31 = "content3-1"
-var claim31 = "claim3-1"
+var (
+	content31 = "content3-1"
+	claim31   = "claim3-1"
+)
 
 var snapshotClasses = []*crdv1.VolumeSnapshotClass{
 	{

--- a/pkg/common-controller/snapshot_finalizer_test.go
+++ b/pkg/common-controller/snapshot_finalizer_test.go
@@ -26,7 +26,6 @@ import (
 // Test single call to ensurePVCFinalizer, checkandRemovePVCFinalizer, addSnapshotFinalizer, removeSnapshotFinalizer
 // expecting finalizers to be added or removed
 func TestSnapshotFinalizer(t *testing.T) {
-
 	tests := []controllerTest{
 		{
 			name:             "1-1 - successful add PVC finalizer",

--- a/pkg/sidecar-controller/content_create_test.go
+++ b/pkg/sidecar-controller/content_create_test.go
@@ -27,7 +27,6 @@ import (
 )
 
 func TestSyncContent(t *testing.T) {
-
 	tests := []controllerTest{
 		{
 			name:            "1-1: Basic content update ready to use",

--- a/pkg/sidecar-controller/csi_handler.go
+++ b/pkg/sidecar-controller/csi_handler.go
@@ -57,7 +57,6 @@ func NewCSIHandler(
 }
 
 func (handler *csiHandler) CreateSnapshot(content *crdv1.VolumeSnapshotContent, parameters map[string]string, snapshotterCredentials map[string]string) (string, string, time.Time, int64, bool, error) {
-
 	ctx, cancel := context.WithTimeout(context.Background(), handler.timeout)
 	defer cancel()
 

--- a/pkg/sidecar-controller/framework_test.go
+++ b/pkg/sidecar-controller/framework_test.go
@@ -100,13 +100,17 @@ type controllerTest struct {
 
 type testCall func(ctrl *csiSnapshotSideCarController, reactor *snapshotReactor, test controllerTest) error
 
-const testNamespace = "default"
-const mockDriverName = "csi-mock-plugin"
+const (
+	testNamespace  = "default"
+	mockDriverName = "csi-mock-plugin"
+)
 
-var errVersionConflict = errors.New("VersionError")
-var nocontents []*crdv1.VolumeSnapshotContent
-var noevents = []string{}
-var noerrors = []reactorError{}
+var (
+	errVersionConflict = errors.New("VersionError")
+	nocontents         []*crdv1.VolumeSnapshotContent
+	noevents           = []string{}
+	noerrors           = []reactorError{}
+)
 
 // snapshotReactor is a core.Reactor that simulates etcd and API server. It
 // stores:
@@ -681,6 +685,7 @@ func withContentAnnotations(content []*crdv1.VolumeSnapshotContent, annotations 
 func testSyncContent(ctrl *csiSnapshotSideCarController, reactor *snapshotReactor, test controllerTest) error {
 	return ctrl.syncContent(test.initialContents[0])
 }
+
 func testSyncContentError(ctrl *csiSnapshotSideCarController, reactor *snapshotReactor, test controllerTest) error {
 	err := ctrl.syncContent(test.initialContents[0])
 	if err != nil {
@@ -712,7 +717,6 @@ var (
 //   controller waits for the operation lock. Controller is then resumed and we
 //   check how it behaves.
 func wrapTestWithInjectedOperation(toWrap testCall, injectBeforeOperation func(ctrl *csiSnapshotSideCarController, reactor *snapshotReactor)) testCall {
-
 	return func(ctrl *csiSnapshotSideCarController, reactor *snapshotReactor, test controllerTest) error {
 		// Inject a hook before async operation starts
 		klog.V(4).Infof("reactor:injecting call")

--- a/pkg/sidecar-controller/snapshot_controller.go
+++ b/pkg/sidecar-controller/snapshot_controller.go
@@ -233,7 +233,7 @@ func (ctrl *csiSnapshotSideCarController) checkandUpdateContentStatusOperation(c
 	var err error
 	var creationTime time.Time
 	var size int64
-	var readyToUse = false
+	readyToUse := false
 	var driverName string
 	var snapshotID string
 	var snapshotterListCredentials map[string]string
@@ -283,7 +283,6 @@ func (ctrl *csiSnapshotSideCarController) checkandUpdateContentStatusOperation(c
 		return updatedContent, nil
 	}
 	return ctrl.createSnapshotWrapper(content)
-
 }
 
 // This is a wrapper function for the snapshot creation process.

--- a/pkg/sidecar-controller/snapshot_delete_test.go
+++ b/pkg/sidecar-controller/snapshot_delete_test.go
@@ -17,11 +17,10 @@ limitations under the License.
 package sidecar_controller
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 	"time"
-
-	"errors"
 
 	crdv1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
 	"github.com/kubernetes-csi/external-snapshotter/v6/pkg/utils"
@@ -29,14 +28,16 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var defaultSize int64 = 1000
-var emptySize int64
-var deletePolicy = crdv1.VolumeSnapshotContentDelete
-var retainPolicy = crdv1.VolumeSnapshotContentRetain
-var timeNow = time.Now()
-var timeNowMetav1 = metav1.Now()
-var False = false
-var True = true
+var (
+	defaultSize   int64 = 1000
+	emptySize     int64
+	deletePolicy  = crdv1.VolumeSnapshotContentDelete
+	retainPolicy  = crdv1.VolumeSnapshotContentRetain
+	timeNow       = time.Now()
+	timeNowMetav1 = metav1.Now()
+	False         = false
+	True          = true
+)
 
 var class1Parameters = map[string]string{
 	"param1": "value1",
@@ -149,7 +150,6 @@ var snapshotClasses = []*crdv1.VolumeSnapshotClass{
 // 2. Call the syncContent *once*.
 // 3. Compare resulting contents with expected contents.
 func TestDeleteSync(t *testing.T) {
-
 	tests := []controllerTest{
 		{
 			name:             "1-1 - content non-nil DeletionTimestamp with delete policy will delete snapshot",

--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -35,9 +35,7 @@ import (
 	klog "k8s.io/klog/v2"
 )
 
-var (
-	keyFunc = cache.DeletionHandlingMetaNamespaceKeyFunc
-)
+var keyFunc = cache.DeletionHandlingMetaNamespaceKeyFunc
 
 type secretParamsMap struct {
 	name               string
@@ -267,7 +265,6 @@ func verifyAndGetSecretNameAndNamespaceTemplate(secret secretParamsMap, snapshot
 	}
 	// THIS IS NOT A VALID CASE
 	return "", "", fmt.Errorf("unknown error with getting secret name and namespace templates")
-
 }
 
 // getSecretReference returns a reference to the secret specified in the given nameTemplate

--- a/pkg/validation-webhook/scheme.go
+++ b/pkg/validation-webhook/scheme.go
@@ -28,8 +28,10 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 )
 
-var scheme = runtime.NewScheme()
-var codecs = serializer.NewCodecFactory(scheme)
+var (
+	scheme = runtime.NewScheme()
+	codecs = serializer.NewCodecFactory(scheme)
+)
 
 func init() {
 	addToScheme(scheme)

--- a/pkg/validation-webhook/webhook.go
+++ b/pkg/validation-webhook/webhook.go
@@ -246,9 +246,9 @@ func main(cmd *cobra.Command, args []string) {
 	factory := informers.NewSharedInformerFactory(snapClient, 0)
 	lister := factory.Snapshot().V1().VolumeSnapshotClasses().Lister()
 
-	//Start the informers
+	// Start the informers
 	factory.Start(ctx.Done())
-	//wait for the caches to sync
+	// wait for the caches to sync
 	factory.WaitForCacheSync(ctx.Done())
 
 	if err := startServer(ctx, tlsConfig, cw, lister); err != nil {

--- a/pkg/validation-webhook/webhook_test.go
+++ b/pkg/validation-webhook/webhook_test.go
@@ -22,7 +22,7 @@ func TestWebhookCertReload(t *testing.T) {
 	certFile = tmpDir + "/tls.crt"
 	keyFile = tmpDir + "/tls.key"
 	port = 30443
-	err := os.Mkdir(tmpDir, 0777)
+	err := os.Mkdir(tmpDir, 0o777)
 	if err != nil && err != os.ErrExist {
 		t.Errorf("unexpected error occurred while creating tmp dir: %v", err)
 	}
@@ -149,7 +149,7 @@ func generateTestCertKeyPair(t *testing.T, certPath, keyPath string) error {
 	}
 	fmt.Printf("wrote new cert: %s\n", certPath)
 
-	keyOut, err := os.OpenFile(keyPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	keyOut, err := os.OpenFile(keyPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
 		return fmt.Errorf("Failed to open tls.key for writing: %v", err)
 	}


### PR DESCRIPTION
This PR address the below:

- [x] Removal of endpoint based leader election RBAC as its no longer needed
- [x] Replacing `serviceAccount` with `ServiceAccountName` as the former has been deprecated already
- [x] Cleanup in various source files for variable declaration...etc.  

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

/kind cleanup


-->
```release-note
NONE
```
