### PR TITLE
Backport: Update comment in types.go, to be included in the new CRD docs

### DIFF
--- a/client/apis/volumesnapshot/v1/types.go
+++ b/client/apis/volumesnapshot/v1/types.go
@@ -341,8 +341,6 @@ type VolumeSnapshotContentSpec struct {
 // VolumeSnapshotContentSource represents the CSI source of a snapshot.
 // Exactly one of its members must be set.
 // Members in VolumeSnapshotContentSource are immutable.
-// TODO(xiangqian): Add a webhook to ensure that VolumeSnapshotContentSource members
-// will be immutable once specified.
 type VolumeSnapshotContentSource struct {
 	// volumeHandle specifies the CSI "volume_id" of the volume from which a snapshot
 	// should be dynamically taken from.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

This PR backports commit d470451a2f9eef2ac17315302dd6579d237a17c0 to release-6.0, as requested by @xing-yang. See https://github.com/kubernetes-csi/external-snapshotter/pull/697#issuecomment-1101002492.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of https://github.com/kubernetes-csi/external-snapshotter/issues/102.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
