### PR TITLE
Backport 688: Updating readme and webhook tempate to capture changes made for volumesnapshotclasses 

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,27 @@ Read more about how to install the example webhook [here](deploy/kubernetes/webh
 
 * `--port`: Secure port that the webhook listens on (default 443)
 
+* `--kubeconfig <path>`: Path to Kubernetes client configuration that the webhook uses to connect to Kubernetes API server. When omitted, default token provided by Kubernetes will be used. This option is useful only when the snapshot controller does not run as a Kubernetes pod, e.g. for debugging.
+
+#### Validating Webhook Validations
+
+##### Volume Snapshot
+
+* Spec.VolumeSnapshotClassName must not be an empty string or nil on creation
+* Spec.Source.PersistentVolumeClaimName must not be changed on update requests
+* Spec.Source.VolumeSnapshotContentName must not be changed on update requests
+
+##### Volume Snapshot Content
+
+* Spec.VolumeSnapshotRef.Name must not be an empty string on creation
+* Spec.VolumeSnapshotRef.Namespace must not be an empty stringon creation
+* Spec.Source.VolumeHandle must not be changed on update requests
+* Spec.Source.SnapshotHandle must not be changed on update requests
+
+##### Volume Snapshot Classes
+
+* There can only be a single default volume snapshot class for a particular driver. 
+
 ### Distributed Snapshotting
 
 The distributed snapshotting feature is provided to handle snapshot operations for local volumes. To use this functionality, the snapshotter sidecar should be deployed along with the csi driver on each node so that every node manages the snapshot operations only for the volumes local to that node. This feature can be enabled by setting the following command line options to true:

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Read more about how to install the example webhook [here](deploy/kubernetes/webh
 
 ##### Volume Snapshot Classes
 
-* There can only be a single default volume snapshot class for a particular driver. 
+* There can only be a single default volume snapshot class for a particular driver.
 
 ### Distributed Snapshotting
 

--- a/deploy/kubernetes/webhook-example/admission-configuration-template
+++ b/deploy/kubernetes/webhook-example/admission-configuration-template
@@ -8,7 +8,7 @@ webhooks:
   - apiGroups:   ["snapshot.storage.k8s.io"]
     apiVersions: ["v1", "v1beta1"]
     operations:  ["CREATE", "UPDATE"]
-    resources:   ["volumesnapshots", "volumesnapshotcontents"]
+    resources:   ["volumesnapshots", "volumesnapshotcontents", "volumesnapshotclasses"]
     scope:       "*"
   clientConfig:
     service:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests4. -->

**What type of PR is this?**
/kind documentation


**What this PR does / why we need it**:
Updating the readme based on the new kubeconfig flag for the webhook and webhook template such that the webhook will be used for volumesnapshotclasses as well

```release-note
Cherry-pick #688: Action required: Added admission webhook to ensure that only one VolumeSnapshotClass can be default for each CSI driver. To benefit from this validation, please update your webhook configuration as shown in deploy/kubernetes/webhook-example/admission-configuration-template.```
