### PR TITLE
Adding webhook RBAC to enable validation of snapshotclasses

### DIFF
--- a/deploy/kubernetes/webhook-example/README.md
+++ b/deploy/kubernetes/webhook-example/README.md
@@ -56,7 +56,7 @@ These commands should be run from the top level directory.
 
 3. Change the namespace in the generated `admission-configuration.yaml` file. Change the namespace in the service and deployment in the `webhook.yaml` file.
 
-4. Create the deployment, service and admission configuration objects on the cluster.
+4. Create the deployment, service, RBAC, and admission configuration objects on the cluster.
 
     ```bash
     kubectl apply -f ./deploy/kubernetes/webhook-example

--- a/deploy/kubernetes/webhook-example/rbac-snapshot-webhook.yaml
+++ b/deploy/kubernetes/webhook-example/rbac-snapshot-webhook.yaml
@@ -1,0 +1,34 @@
+# RBAC file for the snapshot webhook.
+#
+# The snapshot webhook implements the validation and admission for CSI snapshot functionality.
+# It should be installed as part of the base Kubernetes distribution in an appropriate
+# namespace for components implementing base system functionality. For installing with
+# Vanilla Kubernetes, kube-system makes sense for the namespace.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: snapshot-webhook
+  namespace: default # NOTE: change the namespace
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: snapshot-webhook-runner
+rules:
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotclasses"]
+    verbs: ["get", "list", "watch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: snapshot-webhook-role
+subjects:
+  - kind: ServiceAccount
+    name: snapshot-webhook
+    namespace: default # NOTE: change the namespace
+roleRef:
+  kind: ClusterRole
+  name: snapshot-webhook-runner
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy/kubernetes/webhook-example/webhook.yaml
+++ b/deploy/kubernetes/webhook-example/webhook.yaml
@@ -15,6 +15,7 @@ spec:
       labels:
         app: snapshot-validation
     spec:
+      serviceAccountName: snapshot-webhook
       containers:
       - name: snapshot-validation
         image: k8s.gcr.io/sig-storage/snapshot-validation-webhook:v5.0.1 # change the image if you wish to use your own custom validation server image


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
/kind bug

**What this PR does / why we need it**:
Adds RBAC to the validating webhook example so that it can be deployed.
When installing the webhook through the example, currently the webhook will crash loop while not being able to get access to the volumesnapshotclass list/watch. With this change the example will get access.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #705 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Adding RBAC file to webhook example for updated validating webhook
```
