### PR TITLE
Fix volumesnapshot webhook-example RBAC rules

### DIFF
--- a/deploy/kubernetes/webhook-example/rbac-snapshot-webhook.yaml
+++ b/deploy/kubernetes/webhook-example/rbac-snapshot-webhook.yaml
@@ -17,7 +17,7 @@ metadata:
   name: snapshot-webhook-runner
 rules:
   - apiGroups: ["snapshot.storage.k8s.io"]
-    resources: ["volumesnapshotclasses"]
+    resources: ["volumesnapshotclasses", "volumesnapshots", "volumesnapshotcontents"]
     verbs: ["get", "list", "watch"]
 ---
 kind: ClusterRoleBinding


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Adds RBAC `volumesnapshots` and `volumesnapshotcontents` to the validating webhook example, so that it can be deployed with proper access to the resources list/watch.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
