### PR TITLE
release-6.0: update release-tools

### DIFF
--- a/release-tools/prow.sh
+++ b/release-tools/prow.sh
@@ -811,7 +811,7 @@ install_snapshot_controller() {
           modified="$(cat "$i" | while IFS= read -r line; do
               nocomments="$(echo "$line" | sed -e 's/ *#.*$//')"
               if echo "$nocomments" | grep -q '^[[:space:]]*image:[[:space:]]*'; then
-                  # Split 'image: k8s.gcr.io/sig-storage/snapshot-controller:v3.0.0'
+                  # Split 'image: registry.k8s.io/sig-storage/snapshot-controller:v3.0.0'
                   # into image (snapshot-controller:v3.0.0),
                   # name (snapshot-controller),
                   # tag (v3.0.0).
@@ -912,11 +912,11 @@ patch_kubernetes () {
     local source="$1" target="$2"
 
     if [ "${CSI_PROW_DRIVER_CANARY}" = "canary" ]; then
-        # We cannot replace k8s.gcr.io/sig-storage with gcr.io/k8s-staging-sig-storage because
+        # We cannot replace registry.k8s.io/sig-storage with gcr.io/k8s-staging-sig-storage because
         # e2e.test does not support it (see test/utils/image/manifest.go). Instead we
         # invoke the e2e.test binary with KUBE_TEST_REPO_LIST set to a file that
         # overrides that registry.
-        find "$source/test/e2e/testing-manifests/storage-csi/mock" -name '*.yaml' -print0 | xargs -0 sed -i -e 's;k8s.gcr.io/sig-storage/\(.*\):v.*;k8s.gcr.io/sig-storage/\1:canary;'
+        find "$source/test/e2e/testing-manifests/storage-csi/mock" -name '*.yaml' -print0 | xargs -0 sed -i -e 's;registry.k8s.io/sig-storage/\(.*\):v.*;registry.k8s.io/sig-storage/\1:canary;'
         cat >"$target/e2e-repo-list" <<EOF
 sigStorageRegistry: gcr.io/k8s-staging-sig-storage
 EOF


### PR DESCRIPTION
Squashed 'release-tools/' changes from 37d11049..e4dab7ff

[e4dab7ff](https://github.com/kubernetes-csi/csi-release-tools/commit/e4dab7ff) Merge [pull request #194](https://github.com/kubernetes-csi/csi-release-tools/pull/194) from yselkowitz/registry-k8s-io
[84a4d5a1](https://github.com/kubernetes-csi/csi-release-tools/commit/84a4d5a1) Move from k8s.gcr.io to registry.k8s.io

git-subtree-dir: release-tools
git-subtree-split: e4dab7ff57c24cf3e8d37cd3365636fddaff7e0a

```release-note
NONE
```