### PR TITLE
deploy/kubernetes: Update snapshot-validation-webhook

### DIFF
--- a/deploy/kubernetes/csi-snapshotter/setup-csi-snapshotter.yaml
+++ b/deploy/kubernetes/csi-snapshotter/setup-csi-snapshotter.yaml
@@ -72,7 +72,7 @@ spec:
       serviceAccountName: csi-snapshotter
       containers:
         - name: csi-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v3.0.0
+          image: k8s.gcr.io/sig-storage/csi-provisioner:v3.2.1
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -84,7 +84,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-snapshotter
-          image: gcr.io/k8s-staging-sig-storage/csi-snapshotter:v5.0.1
+          image: gcr.io/k8s-staging-sig-storage/csi-snapshotter:v6.0.1
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -97,7 +97,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: hostpath
-          image: k8s.gcr.io/sig-storage/hostpathplugin:v1.7.2
+          image: k8s.gcr.io/sig-storage/hostpathplugin:v1.8.0
           args:
             - "--v=5"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml
+++ b/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml
@@ -33,7 +33,7 @@ spec:
       serviceAccountName: snapshot-controller
       containers:
         - name: snapshot-controller
-          image: gcr.io/k8s-staging-sig-storage/snapshot-controller:v5.0.1
+          image: gcr.io/k8s-staging-sig-storage/snapshot-controller:v6.0.1
           args:
             - "--v=5"
             - "--leader-election=true"

--- a/deploy/kubernetes/webhook-example/webhook.yaml
+++ b/deploy/kubernetes/webhook-example/webhook.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: snapshot-webhook
       containers:
       - name: snapshot-validation
-        image: k8s.gcr.io/sig-storage/snapshot-validation-webhook:v5.0.1 # change the image if you wish to use your own custom validation server image
+        image: k8s.gcr.io/sig-storage/snapshot-validation-webhook:v6.0.1 # change the image if you wish to use your own custom validation server image
         imagePullPolicy: IfNotPresent
         args: ['--tls-cert-file=/etc/snapshot-validation-webhook/certs/cert.pem', '--tls-private-key-file=/etc/snapshot-validation-webhook/certs/key.pem']
         ports:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

/kind bug

**What this PR does / why we need it**:

Since 4f783f10f added validation for `volumesnapshotclasses`, the
`snapshot-validation-webhook` needs to handle this kind of resource. But
version 5.0.1 doesn't, which leads to failures when updating or creating
`volumesnapshotclasses`.

This commit updates the `snapshot-validation-webhook` version to 6.0.1 in
`deploy/kubernetes/webhook-example/admission-configuration-template`.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

This is a fairly trivial change, in a directory labeled as an example, so I don't think it warrants a release note.