### PR TITLE
Fix typo validating webhook message `exits` -> `exists`

### DIFF
--- a/pkg/validation-webhook/snapshot.go
+++ b/pkg/validation-webhook/snapshot.go
@@ -190,7 +190,7 @@ func decideSnapshotClassV1(snapClass, oldSnapClass *volumesnapshotv1.VolumeSnaps
 		}
 		if snapshotClass.Driver == snapClass.Driver {
 			reviewResponse.Allowed = false
-			reviewResponse.Result.Message = fmt.Sprintf("default snapshot class: %v already exits for driver: %v", snapshotClass.Name, snapClass.Driver)
+			reviewResponse.Result.Message = fmt.Sprintf("default snapshot class: %v already exists for driver: %v", snapshotClass.Name, snapClass.Driver)
 			return reviewResponse
 		}
 	}

--- a/pkg/validation-webhook/snapshot_test.go
+++ b/pkg/validation-webhook/snapshot_test.go
@@ -444,7 +444,7 @@ func TestAdmitVolumeSnapshotClassV1(t *testing.T) {
 			},
 			oldVolumeSnapshotClass: &volumesnapshotv1.VolumeSnapshotClass{},
 			shouldAdmit:            false,
-			msg:                    "default snapshot class: driver-a already exits for driver: test.csi.io",
+			msg:                    "default snapshot class: driver-a already exists for driver: test.csi.io",
 			operation:              v1.Create,
 			lister: &fakeSnapshotLister{values: []*volumesnapshotv1.VolumeSnapshotClass{
 				{
@@ -530,7 +530,7 @@ func TestAdmitVolumeSnapshotClassV1(t *testing.T) {
 			},
 			oldVolumeSnapshotClass: &volumesnapshotv1.VolumeSnapshotClass{},
 			shouldAdmit:            false,
-			msg:                    "default snapshot class: driver-is-default already exits for driver: test.csi.io",
+			msg:                    "default snapshot class: driver-is-default already exists for driver: test.csi.io",
 			operation:              v1.Create,
 			lister: &fakeSnapshotLister{values: []*volumesnapshotv1.VolumeSnapshotClass{
 				{
@@ -575,7 +575,7 @@ func TestAdmitVolumeSnapshotClassV1(t *testing.T) {
 				Driver: "test.csi.io",
 			},
 			shouldAdmit: false,
-			msg:         "default snapshot class: driver-test-default already exits for driver: driver.test.csi.io",
+			msg:         "default snapshot class: driver-test-default already exists for driver: driver.test.csi.io",
 			operation:   v1.Update,
 			lister: &fakeSnapshotLister{values: []*volumesnapshotv1.VolumeSnapshotClass{
 				{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This PR fixes typo.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #745 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
