### PR TITLE
k8s-infra: Use registry.k8s.io for deployment

### DIFF
--- a/deploy/kubernetes/csi-snapshotter/setup-csi-snapshotter.yaml
+++ b/deploy/kubernetes/csi-snapshotter/setup-csi-snapshotter.yaml
@@ -72,7 +72,7 @@ spec:
       serviceAccountName: csi-snapshotter
       containers:
         - name: csi-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v3.2.1
+          image: registry.k8s.io/sig-storage/csi-provisioner:v3.2.1
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -84,7 +84,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-snapshotter
-          image: gcr.io/k8s-staging-sig-storage/csi-snapshotter:v6.0.1
+          image: registry.k8s.io/k8s-staging-sig-storage/csi-snapshotter:v6.0.1
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -97,7 +97,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: hostpath
-          image: k8s.gcr.io/sig-storage/hostpathplugin:v1.8.0
+          image: registry.k8s.io/sig-storage/hostpathplugin:v1.8.0
           args:
             - "--v=5"
             - "--endpoint=$(CSI_ENDPOINT)"


### PR DESCRIPTION
What type of PR is this?
/kind feature deprecation

What this PR does / why we need it:

Related to:
   [PR 687](https://github.com/kubernetes-csi/external-snapshotter/pull/687)

Switch to the new endpoint for container images. See: https://github.com/kubernetes/k8s.io/wiki/New-Registry-url-for-Kubernetes-(registry.k8s.io)

Special notes for your reviewer:
registry.k8s.io is currently a redirect to k8s.gcr.io. The change should be transparent to any pulling from k8s.gcr.io.

Does this PR introduce a user-facing change?:

NONE