### PR TITLE
use registry.k8s.io for deployment

### DIFF
--- a/deploy/kubernetes/csi-snapshotter/setup-csi-snapshotter.yaml
+++ b/deploy/kubernetes/csi-snapshotter/setup-csi-snapshotter.yaml
@@ -72,7 +72,7 @@ spec:
       serviceAccountName: csi-snapshotter
       containers:
         - name: csi-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v3.2.1
+          image: registry.k8s.io/sig-storage/csi-provisioner:v3.2.1
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -84,7 +84,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-snapshotter
-          image: gcr.io/k8s-staging-sig-storage/csi-snapshotter:v6.0.1
+          image: registry.k8s.io/sig-storage/csi-snapshotter:v6.0.1
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -97,7 +97,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: hostpath
-          image: k8s.gcr.io/sig-storage/hostpathplugin:v1.8.0
+          image: registry.k8s.io/sig-storage/hostpathplugin:v1.9.0
           args:
             - "--v=5"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml
+++ b/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml
@@ -33,7 +33,7 @@ spec:
       serviceAccountName: snapshot-controller
       containers:
         - name: snapshot-controller
-          image: gcr.io/k8s-staging-sig-storage/snapshot-controller:v6.0.1
+          image: registry.k8s.io/sig-storage/snapshot-controller:v6.0.1
           args:
             - "--v=5"
             - "--leader-election=true"

--- a/deploy/kubernetes/webhook-example/webhook.yaml
+++ b/deploy/kubernetes/webhook-example/webhook.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: snapshot-webhook
       containers:
       - name: snapshot-validation
-        image: k8s.gcr.io/sig-storage/snapshot-validation-webhook:v6.0.1 # change the image if you wish to use your own custom validation server image
+        image: registry.k8s.io/sig-storage/snapshot-validation-webhook:v6.0.1 # change the image if you wish to use your own custom validation server image
         imagePullPolicy: IfNotPresent
         args: ['--tls-cert-file=/etc/snapshot-validation-webhook/certs/cert.pem', '--tls-private-key-file=/etc/snapshot-validation-webhook/certs/key.pem']
         ports:


### PR DESCRIPTION
What type of PR is this?
/kind feature deprecation

What this PR does / why we need it:

Related to:
https://github.com/kubernetes-csi/external-snapshotter/pull/687
Switch to the new endpoint for container images. See: https://github.com/kubernetes/k8s.io/wiki/New-Registry-url-for-Kubernetes-(registry.k8s.io)

Special notes for your reviewer:
registry.k8s.io is currently a redirect to k8s.gcr.io. The change should be transparent to any pulling from k8s.gcr.io.

Does this PR introduce a user-facing change?:

NONE