### PR TITLE
make the formatting errors based on go 1.19

### DIFF
--- a/pkg/common-controller/framework_test.go
+++ b/pkg/common-controller/framework_test.go
@@ -78,9 +78,10 @@ import (
 // function to call as the actual test. Available functions are:
 //   - testSyncSnapshot - calls syncSnapshot on the first snapshot in initialSnapshots.
 //   - testSyncSnapshotError - calls syncSnapshot on the first snapshot in initialSnapshots
-//                          and expects an error to be returned.
+//     and expects an error to be returned.
 //   - testSyncContent - calls syncContent on the first content in initialContents.
 //   - any custom function for specialized tests.
+//
 // The test then contains list of contents/snapshots that are expected at the end
 // of the test and list of generated events.
 type controllerTest struct {
@@ -127,21 +128,21 @@ var (
 
 // snapshotReactor is a core.Reactor that simulates etcd and API server. It
 // stores:
-// - Latest version of snapshots contents saved by the controller.
-// - Queue of all saves (to simulate "content/snapshot updated" events). This queue
-//   contains all intermediate state of an object - e.g. a snapshot.VolumeName
-//   is updated first and snapshot.Phase second. This queue will then contain both
-//   updates as separate entries.
-// - Number of changes since the last call to snapshotReactor.syncAll().
-// - Optionally, content and snapshot fake watchers which should be the same ones
-//   used by the controller. Any time an event function like deleteContentEvent
-//   is called to simulate an event, the reactor's stores are updated and the
-//   controller is sent the event via the fake watcher.
-// - Optionally, list of error that should be returned by reactor, simulating
-//   etcd / API server failures. These errors are evaluated in order and every
-//   error is returned only once. I.e. when the reactor finds matching
-//   reactorError, it return appropriate error and removes the reactorError from
-//   the list.
+//   - Latest version of snapshots contents saved by the controller.
+//   - Queue of all saves (to simulate "content/snapshot updated" events). This queue
+//     contains all intermediate state of an object - e.g. a snapshot.VolumeName
+//     is updated first and snapshot.Phase second. This queue will then contain both
+//     updates as separate entries.
+//   - Number of changes since the last call to snapshotReactor.syncAll().
+//   - Optionally, content and snapshot fake watchers which should be the same ones
+//     used by the controller. Any time an event function like deleteContentEvent
+//     is called to simulate an event, the reactor's stores are updated and the
+//     controller is sent the event via the fake watcher.
+//   - Optionally, list of error that should be returned by reactor, simulating
+//     etcd / API server failures. These errors are evaluated in order and every
+//     error is returned only once. I.e. when the reactor finds matching
+//     reactorError, it return appropriate error and removes the reactorError from
+//     the list.
 type snapshotReactor struct {
 	secrets              map[string]*v1.Secret
 	volumes              map[string]*v1.PersistentVolume
@@ -1301,11 +1302,11 @@ var (
 )
 
 // wrapTestWithInjectedOperation returns a testCall that:
-// - starts the controller and lets it run original testCall until
-//   scheduleOperation() call. It blocks the controller there and calls the
-//   injected function to simulate that something is happening when the
-//   controller waits for the operation lock. Controller is then resumed and we
-//   check how it behaves.
+//   - starts the controller and lets it run original testCall until
+//     scheduleOperation() call. It blocks the controller there and calls the
+//     injected function to simulate that something is happening when the
+//     controller waits for the operation lock. Controller is then resumed and we
+//     check how it behaves.
 func wrapTestWithInjectedOperation(toWrap testCall, injectBeforeOperation func(ctrl *csiSnapshotCommonController, reactor *snapshotReactor)) testCall {
 	return func(ctrl *csiSnapshotCommonController, reactor *snapshotReactor, test controllerTest) error {
 		// Inject a hook before async operation starts
@@ -1348,10 +1349,10 @@ func evaluateTestResults(ctrl *csiSnapshotCommonController, reactor *snapshotRea
 
 // Test single call to syncSnapshot and syncContent methods.
 // For all tests:
-// 1. Fill in the controller with initial data
-// 2. Call the tested function (syncSnapshot/syncContent) via
-//    controllerTest.testCall *once*.
-// 3. Compare resulting contents and snapshots with expected contents and snapshots.
+//  1. Fill in the controller with initial data
+//  2. Call the tested function (syncSnapshot/syncContent) via
+//     controllerTest.testCall *once*.
+//  3. Compare resulting contents and snapshots with expected contents and snapshots.
 func runSyncTests(t *testing.T, tests []controllerTest, snapshotClasses []*crdv1.VolumeSnapshotClass) {
 	snapshotscheme.AddToScheme(scheme.Scheme)
 	for _, test := range tests {

--- a/pkg/common-controller/snapshot_controller.go
+++ b/pkg/common-controller/snapshot_controller.go
@@ -782,11 +782,12 @@ func (ctrl *csiSnapshotCommonController) storeContentUpdate(content interface{})
 // given event on the snapshot. It saves the status and emits the event only when
 // the status has actually changed from the version saved in API server.
 // Parameters:
-//   snapshot - snapshot to update
-//   setReadyToFalse bool - indicates whether to set the snapshot's ReadyToUse status to false.
-//                          if true, ReadyToUse will be set to false;
-//                          otherwise, ReadyToUse will not be changed.
-//   eventtype, reason, message - event to send, see EventRecorder.Event()
+//
+// * snapshot - snapshot to update
+// * setReadyToFalse bool - indicates whether to set the snapshot's ReadyToUse status to false.
+//	                       if true, ReadyToUse will be set to false;
+//	                       otherwise, ReadyToUse will not be changed.
+// * eventtype, reason, message - event to send, see EventRecorder.Event()
 func (ctrl *csiSnapshotCommonController) updateSnapshotErrorStatusWithEvent(snapshot *crdv1.VolumeSnapshot, setReadyToFalse bool, eventtype, reason, message string) error {
 	klog.V(5).Infof("updateSnapshotErrorStatusWithEvent[%s]", utils.SnapshotKey(snapshot))
 

--- a/pkg/common-controller/snapshot_update_test.go
+++ b/pkg/common-controller/snapshot_update_test.go
@@ -34,10 +34,10 @@ var metaTimeNow = &metav1.Time{
 var emptyString = ""
 
 // Test single call to syncSnapshot and syncContent methods.
-// 1. Fill in the controller with initial data
-// 2. Call the tested function (syncSnapshot/syncContent) via
-//    controllerTest.testCall *once*.
-// 3. Compare resulting contents and snapshots with expected contents and snapshots.
+//  1. Fill in the controller with initial data
+//  2. Call the tested function (syncSnapshot/syncContent) via
+//     controllerTest.testCall *once*.
+//  3. Compare resulting contents and snapshots with expected contents and snapshots.
 func TestSync(t *testing.T) {
 	size := int64(1)
 	snapshotErr := newVolumeError("Mock content error")

--- a/pkg/common-controller/snapshotclass_test.go
+++ b/pkg/common-controller/snapshotclass_test.go
@@ -22,10 +22,10 @@ import (
 )
 
 // Test single call to checkAndUpdateSnapshotClass.
-// 1. Fill in the controller with initial data
-// 2. Call the tested function checkAndUpdateSnapshotClass via
-//    controllerTest.testCall *once*.
-// 3. Compare resulting snapshotclass.
+//  1. Fill in the controller with initial data
+//  2. Call the tested function checkAndUpdateSnapshotClass via
+//     controllerTest.testCall *once*.
+//  3. Compare resulting snapshotclass.
 func TestUpdateSnapshotClass(t *testing.T) {
 	tests := []controllerTest{
 		{

--- a/pkg/sidecar-controller/framework_test.go
+++ b/pkg/sidecar-controller/framework_test.go
@@ -71,6 +71,7 @@ import (
 // function to call as the actual test. Available functions are:
 //   - testSyncContent - calls syncContent on the first content in initialContents.
 //   - any custom function for specialized tests.
+//
 // The test then contains list of contents that are expected at the end
 // of the test and list of generated events.
 type controllerTest struct {
@@ -114,20 +115,20 @@ var (
 
 // snapshotReactor is a core.Reactor that simulates etcd and API server. It
 // stores:
-// - Latest version of snapshots contents saved by the controller.
-// - Queue of all saves (to simulate "content updated" events). This queue
-//   contains all intermediate state of an object. This queue will then contain both
-//   updates as separate entries.
-// - Number of changes since the last call to snapshotReactor.syncAll().
-// - Optionally, content watcher which should be the same ones
-//   used by the controller. Any time an event function like deleteContentEvent
-//   is called to simulate an event, the reactor's stores are updated and the
-//   controller is sent the event via the fake watcher.
-// - Optionally, list of error that should be returned by reactor, simulating
-//   etcd / API server failures. These errors are evaluated in order and every
-//   error is returned only once. I.e. when the reactor finds matching
-//   reactorError, it return appropriate error and removes the reactorError from
-//   the list.
+//   - Latest version of snapshots contents saved by the controller.
+//   - Queue of all saves (to simulate "content updated" events). This queue
+//     contains all intermediate state of an object. This queue will then contain both
+//     updates as separate entries.
+//   - Number of changes since the last call to snapshotReactor.syncAll().
+//   - Optionally, content watcher which should be the same ones
+//     used by the controller. Any time an event function like deleteContentEvent
+//     is called to simulate an event, the reactor's stores are updated and the
+//     controller is sent the event via the fake watcher.
+//   - Optionally, list of error that should be returned by reactor, simulating
+//     etcd / API server failures. These errors are evaluated in order and every
+//     error is returned only once. I.e. when the reactor finds matching
+//     reactorError, it return appropriate error and removes the reactorError from
+//     the list.
 type snapshotReactor struct {
 	secrets              map[string]*v1.Secret
 	snapshotClasses      map[string]*crdv1.VolumeSnapshotClass
@@ -711,11 +712,11 @@ var (
 )
 
 // wrapTestWithInjectedOperation returns a testCall that:
-// - starts the controller and lets it run original testCall until
-//   scheduleOperation() call. It blocks the controller there and calls the
-//   injected function to simulate that something is happening when the
-//   controller waits for the operation lock. Controller is then resumed and we
-//   check how it behaves.
+//   - starts the controller and lets it run original testCall until
+//     scheduleOperation() call. It blocks the controller there and calls the
+//     injected function to simulate that something is happening when the
+//     controller waits for the operation lock. Controller is then resumed and we
+//     check how it behaves.
 func wrapTestWithInjectedOperation(toWrap testCall, injectBeforeOperation func(ctrl *csiSnapshotSideCarController, reactor *snapshotReactor)) testCall {
 	return func(ctrl *csiSnapshotSideCarController, reactor *snapshotReactor, test controllerTest) error {
 		// Inject a hook before async operation starts
@@ -757,10 +758,10 @@ func evaluateTestResults(ctrl *csiSnapshotSideCarController, reactor *snapshotRe
 
 // Test single call to syncContent methods.
 // For all tests:
-// 1. Fill in the controller with initial data
-// 2. Call the tested function (syncContent) via
-//    controllerTest.testCall *once*.
-// 3. Compare resulting contents and snapshots with expected contents and snapshots.
+//  1. Fill in the controller with initial data
+//  2. Call the tested function (syncContent) via
+//     controllerTest.testCall *once*.
+//  3. Compare resulting contents and snapshots with expected contents and snapshots.
 func runSyncContentTests(t *testing.T, tests []controllerTest, snapshotClasses []*crdv1.VolumeSnapshotClass) {
 	snapshotscheme.AddToScheme(scheme.Scheme)
 	for _, test := range tests {

--- a/pkg/sidecar-controller/snapshot_controller.go
+++ b/pkg/sidecar-controller/snapshot_controller.go
@@ -137,8 +137,9 @@ func (ctrl *csiSnapshotSideCarController) checkandUpdateContentStatus(content *c
 // given event on the content. It saves the status and emits the event only when
 // the status has actually changed from the version saved in API server.
 // Parameters:
-//   content - content to update
-//   eventtype, reason, message - event to send, see EventRecorder.Event()
+//
+// * content - content to update
+// * eventtype, reason, message - event to send, see EventRecorder.Event()
 func (ctrl *csiSnapshotSideCarController) updateContentErrorStatusWithEvent(content *crdv1.VolumeSnapshotContent, eventtype, reason, message string) error {
 	klog.V(5).Infof("updateContentStatusWithEvent[%s]", content.Name)
 

--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -268,7 +268,7 @@ func verifyAndGetSecretNameAndNamespaceTemplate(secret secretParamsMap, snapshot
 }
 
 // getSecretReference returns a reference to the secret specified in the given nameTemplate
-//  and namespaceTemplate, or an error if the templates are not specified correctly.
+// and namespaceTemplate, or an error if the templates are not specified correctly.
 // No lookup of the referenced secret is performed, and the secret may or may not exist.
 //
 // supported tokens for name resolution:


### PR DESCRIPTION
Signed-off-by: Humble Chirammal <hchiramm@redhat.com>


> /kind cleanup

```release-note
NONE
```

Additional Note for reviewer:

The errors in absence of this PR cause tests to fail in https://github.com/kubernetes-csi/csi-release-tools/pull/203
