### PR TITLE
update client package with go 1.19 formatting changes

### DIFF
--- a/client/apis/volumesnapshot/v1/types.go
+++ b/client/apis/volumesnapshot/v1/types.go
@@ -123,11 +123,11 @@ type VolumeSnapshotSource struct {
 // VolumeSnapshotStatus and VolumeSnapshotContentStatus. Fields in VolumeSnapshotStatus
 // are updated based on fields in VolumeSnapshotContentStatus. They are eventual
 // consistency. These fields are duplicate in both objects due to the following reasons:
-// - Fields in VolumeSnapshotContentStatus can be used for filtering when importing a
-//   volumesnapshot.
-// - VolumsnapshotStatus is used by end users because they cannot see VolumeSnapshotContent.
-// - CSI snapshotter sidecar is light weight as it only watches VolumeSnapshotContent
-//   object, not VolumeSnapshot object.
+//   - Fields in VolumeSnapshotContentStatus can be used for filtering when importing a
+//     volumesnapshot.
+//   - VolumsnapshotStatus is used by end users because they cannot see VolumeSnapshotContent.
+//   - CSI snapshotter sidecar is light weight as it only watches VolumeSnapshotContent
+//     object, not VolumeSnapshot object.
 type VolumeSnapshotStatus struct {
 	// boundVolumeSnapshotContentName is the name of the VolumeSnapshotContent
 	// object to which this VolumeSnapshot object intends to bind to.
@@ -361,11 +361,11 @@ type VolumeSnapshotContentSource struct {
 // VolumeSnapshotStatus and VolumeSnapshotContentStatus. Fields in VolumeSnapshotStatus
 // are updated based on fields in VolumeSnapshotContentStatus. They are eventual
 // consistency. These fields are duplicate in both objects due to the following reasons:
-// - Fields in VolumeSnapshotContentStatus can be used for filtering when importing a
-//   volumesnapshot.
-// - VolumsnapshotStatus is used by end users because they cannot see VolumeSnapshotContent.
-// - CSI snapshotter sidecar is light weight as it only watches VolumeSnapshotContent
-//   object, not VolumeSnapshot object.
+//   - Fields in VolumeSnapshotContentStatus can be used for filtering when importing a
+//     volumesnapshot.
+//   - VolumsnapshotStatus is used by end users because they cannot see VolumeSnapshotContent.
+//   - CSI snapshotter sidecar is light weight as it only watches VolumeSnapshotContent
+//     object, not VolumeSnapshot object.
 type VolumeSnapshotContentStatus struct {
 	// snapshotHandle is the CSI "snapshot_id" of a snapshot on the underlying storage system.
 	// If not specified, it indicates that dynamic snapshot creation has either failed

--- a/client/clientset/versioned/fake/register.go
+++ b/client/clientset/versioned/fake/register.go
@@ -37,14 +37,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/client/clientset/versioned/scheme/register.go
+++ b/client/clientset/versioned/scheme/register.go
@@ -37,14 +37,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/pkg/common-controller/snapshot_controller.go
+++ b/pkg/common-controller/snapshot_controller.go
@@ -783,11 +783,11 @@ func (ctrl *csiSnapshotCommonController) storeContentUpdate(content interface{})
 // the status has actually changed from the version saved in API server.
 // Parameters:
 //
-// * snapshot - snapshot to update
-// * setReadyToFalse bool - indicates whether to set the snapshot's ReadyToUse status to false.
-//	                       if true, ReadyToUse will be set to false;
-//	                       otherwise, ReadyToUse will not be changed.
-// * eventtype, reason, message - event to send, see EventRecorder.Event()
+//   - snapshot - snapshot to update
+//   - setReadyToFalse bool - indicates whether to set the snapshot's ReadyToUse status to false.
+//     if true, ReadyToUse will be set to false;
+//     otherwise, ReadyToUse will not be changed.
+//   - eventtype, reason, message - event to send, see EventRecorder.Event()
 func (ctrl *csiSnapshotCommonController) updateSnapshotErrorStatusWithEvent(snapshot *crdv1.VolumeSnapshot, setReadyToFalse bool, eventtype, reason, message string) error {
 	klog.V(5).Infof("updateSnapshotErrorStatusWithEvent[%s]", utils.SnapshotKey(snapshot))
 


### PR DESCRIPTION
Signed-off-by: Humble Chirammal <hchiramm@redhat.com>


> /kind cleanup

```release-note
NONE
```
Additional Note for reviewer:
Eventhough we tried to minimize the changes for the unit test to pass with go 1.19 here https://github.com/kubernetes-csi/external-snapshotter/pull/758, it is not enough . 
The test is failing here https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-csi_csi-release-tools/203/pull-kubernetes-csi-release-tools-external-snapshotter/1569716664243589120 . This PR holds the required changes, however this has changes in client package too. Also the formatting we discussed here https://github.com/kubernetes-csi/external-snapshotter/pull/758#discussion_r964520500 getting adjusted to different representation by the gofmt tool as in this PR. 