### PR TITLE
Add volume mode conversion flag to snapshot-controller manifest

### DIFF
--- a/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml
+++ b/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml
@@ -37,5 +37,7 @@ spec:
           args:
             - "--v=5"
             - "--leader-election=true"
+            # Add a marker to the snapshot-controller manifests. This is needed to enable feature gates in CSI prow jobs.
+            # For example, in https://github.com/kubernetes-csi/csi-release-tools/pull/209, the snapshot-controller YAML is updated to add --prevent-volume-mode-conversion=true so that the feature can be enabled for certain e2e tests.
             # end snapshot controller args
           imagePullPolicy: IfNotPresent

--- a/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml
+++ b/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml
@@ -37,4 +37,5 @@ spec:
           args:
             - "--v=5"
             - "--leader-election=true"
+            - "--prevent-volume-mode-conversion=false"
           imagePullPolicy: IfNotPresent

--- a/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml
+++ b/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml
@@ -37,5 +37,5 @@ spec:
           args:
             - "--v=5"
             - "--leader-election=true"
-            - "--prevent-volume-mode-conversion=false"
+            # end snapshot controller args
           imagePullPolicy: IfNotPresent


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR adds a marker to the snapshot-controller manifests. This is needed to enable feature gates in CSI prow jobs. In https://github.com/kubernetes-csi/csi-release-tools/pull/209, the snapshot-controller YAML is updated to add `--prevent-volume-mode-conversion=true` so that the feature can be enabled for certain e2e tests. 
Also related to https://github.com/kubernetes-csi/csi-driver-host-path/pull/379

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add a marker to the snapshot-controller manifests to enable feature gates in CSI prow jobs.
```
