### PR TITLE
Make webhook example compatible with TLS secrets

### DIFF
--- a/deploy/kubernetes/webhook-example/webhook.yaml
+++ b/deploy/kubernetes/webhook-example/webhook.yaml
@@ -20,7 +20,7 @@ spec:
       - name: snapshot-validation
         image: registry.k8s.io/sig-storage/snapshot-validation-webhook:v6.1.0 # change the image if you wish to use your own custom validation server image
         imagePullPolicy: IfNotPresent
-        args: ['--tls-cert-file=/etc/snapshot-validation-webhook/certs/cert.pem', '--tls-private-key-file=/etc/snapshot-validation-webhook/certs/key.pem']
+        args: ['--tls-cert-file=/etc/snapshot-validation-webhook/certs/tls.crt', '--tls-private-key-file=/etc/snapshot-validation-webhook/certs/tls.key']
         ports:
         - containerPort: 443 # change the port as needed
         volumeMounts:


### PR DESCRIPTION
Kubernetes has a builtin Secret type `kubernetes.io/tls` which uses the keys `tls.crt` and `tls.key`.

With this change, when you download the example `webhook.yaml`, it's immediately compatible with secrets created e.g. by cert-manager. The downloaded file can be integrated into kustomize projects without further modification or patches.

 /kind documentation

```release-note
Change webhook example to be compatible with TLS-type secrets.
```
