### PR TITLE
fix certificate generation in webhook example

### DIFF
--- a/deploy/kubernetes/webhook-example/create-cert.sh
+++ b/deploy/kubernetes/webhook-example/create-cert.sh
@@ -120,8 +120,8 @@ echo ${serverCert} | openssl base64 -d -A -out ${tmpdir}/server-cert.pem
 
 
 # create the secret with CA cert and server cert/key
-kubectl create secret generic ${secret} \
-        --from-file=key.pem=${tmpdir}/server-key.pem \
-        --from-file=cert.pem=${tmpdir}/server-cert.pem \
+kubectl create secret tls ${secret} \
+        --key=${tmpdir}/server-key.pem \
+        --cert=${tmpdir}/server-cert.pem \
         --dry-run=client -o yaml |
     kubectl -n ${namespace} apply -f -


### PR DESCRIPTION
After bb957259da3b the script was broken. This commit fixes this by respecting the format of TLS-type secrets in the script, too.

 /kind bug

No release note needed as the breaking commit is not yet released.

```release-note
Fixes an issue introduced by PR 793 by respecting the format of TLS-type secrets in the script.
```
