### PR TITLE
csi-snapshotter changes for volume group snapshots 

### DIFF
--- a/cmd/csi-snapshotter/main.go
+++ b/cmd/csi-snapshotter/main.go
@@ -79,12 +79,13 @@ var (
 	kubeAPIQPS   = flag.Float64("kube-api-qps", 5, "QPS to use while communicating with the kubernetes apiserver. Defaults to 5.0.")
 	kubeAPIBurst = flag.Int("kube-api-burst", 10, "Burst to use while communicating with the kubernetes apiserver. Defaults to 10.")
 
-	metricsAddress       = flag.String("metrics-address", "", "(deprecated) The TCP network address where the prometheus metrics endpoint will listen (example: `:8080`). The default is empty string, which means metrics endpoint is disabled. Only one of `--metrics-address` and `--http-endpoint` can be set.")
-	httpEndpoint         = flag.String("http-endpoint", "", "The TCP network address where the HTTP server for diagnostics, including metrics and leader election health check, will listen (example: `:8080`). The default is empty string, which means the server is disabled. Only one of `--metrics-address` and `--http-endpoint` can be set.")
-	metricsPath          = flag.String("metrics-path", "/metrics", "The HTTP path where prometheus metrics will be exposed. Default is `/metrics`.")
-	retryIntervalStart   = flag.Duration("retry-interval-start", time.Second, "Initial retry interval of failed volume snapshot creation or deletion. It doubles with each failure, up to retry-interval-max. Default is 1 second.")
-	retryIntervalMax     = flag.Duration("retry-interval-max", 5*time.Minute, "Maximum retry interval of failed volume snapshot creation or deletion. Default is 5 minutes.")
-	enableNodeDeployment = flag.Bool("node-deployment", false, "Enables deploying the sidecar controller together with a CSI driver on nodes to manage snapshots for node-local volumes.")
+	metricsAddress             = flag.String("metrics-address", "", "(deprecated) The TCP network address where the prometheus metrics endpoint will listen (example: `:8080`). The default is empty string, which means metrics endpoint is disabled. Only one of `--metrics-address` and `--http-endpoint` can be set.")
+	httpEndpoint               = flag.String("http-endpoint", "", "The TCP network address where the HTTP server for diagnostics, including metrics and leader election health check, will listen (example: `:8080`). The default is empty string, which means the server is disabled. Only one of `--metrics-address` and `--http-endpoint` can be set.")
+	metricsPath                = flag.String("metrics-path", "/metrics", "The HTTP path where prometheus metrics will be exposed. Default is `/metrics`.")
+	retryIntervalStart         = flag.Duration("retry-interval-start", time.Second, "Initial retry interval of failed volume snapshot creation or deletion. It doubles with each failure, up to retry-interval-max. Default is 1 second.")
+	retryIntervalMax           = flag.Duration("retry-interval-max", 5*time.Minute, "Maximum retry interval of failed volume snapshot creation or deletion. Default is 5 minutes.")
+	enableNodeDeployment       = flag.Bool("node-deployment", false, "Enables deploying the sidecar controller together with a CSI driver on nodes to manage snapshots for node-local volumes.")
+	enableVolumeGroupSnapshots = flag.Bool("enable-volume-group-snapshots", false, "Enables the volume group snapshot feature, allowing the user to create snapshots of groups of volumes.")
 )
 
 var (
@@ -234,6 +235,10 @@ func main() {
 		*snapshotNamePrefix,
 		*snapshotNameUUIDLength,
 		*extraCreateMetadata,
+		workqueue.NewItemExponentialFailureRateLimiter(*retryIntervalStart, *retryIntervalMax),
+		*enableVolumeGroupSnapshots,
+		snapshotContentfactory.Groupsnapshot().V1alpha1().VolumeGroupSnapshotContents(),
+		snapshotContentfactory.Groupsnapshot().V1alpha1().VolumeGroupSnapshotClasses(),
 		workqueue.NewItemExponentialFailureRateLimiter(*retryIntervalStart, *retryIntervalMax),
 	)
 

--- a/pkg/sidecar-controller/framework_test.go
+++ b/pkg/sidecar-controller/framework_test.go
@@ -572,6 +572,10 @@ func newTestController(kubeClient kubernetes.Interface, clientset clientset.Inte
 		-1,
 		true,
 		workqueue.NewItemExponentialFailureRateLimiter(1*time.Millisecond, 1*time.Minute),
+		false,
+		informerFactory.Groupsnapshot().V1alpha1().VolumeGroupSnapshotContents(),
+		informerFactory.Groupsnapshot().V1alpha1().VolumeGroupSnapshotClasses(),
+		workqueue.NewItemExponentialFailureRateLimiter(1*time.Millisecond, 1*time.Minute),
 	)
 
 	ctrl.eventRecorder = record.NewFakeRecorder(1000)

--- a/pkg/sidecar-controller/groupsnapshot_helper.go
+++ b/pkg/sidecar-controller/groupsnapshot_helper.go
@@ -1,0 +1,170 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sidecar_controller
+
+import (
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/tools/cache"
+	klog "k8s.io/klog/v2"
+
+	crdv1alpha1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumegroupsnapshot/v1alpha1"
+	"github.com/kubernetes-csi/external-snapshotter/v6/pkg/utils"
+)
+
+func (ctrl *csiSnapshotSideCarController) storeGroupSnapshotContentUpdate(content interface{}) (bool, error) {
+	return utils.StoreObjectUpdate(ctrl.groupSnapshotContentStore, content, "groupsnapshotcontent")
+}
+
+// enqueueGroupSnapshotContentWork adds group snapshot content to given work queue.
+func (ctrl *csiSnapshotSideCarController) enqueueGroupSnapshotContentWork(obj interface{}) {
+	// Beware of "xxx deleted" events
+	if unknown, ok := obj.(cache.DeletedFinalStateUnknown); ok && unknown.Obj != nil {
+		obj = unknown.Obj
+	}
+	if content, ok := obj.(*crdv1alpha1.VolumeGroupSnapshotContent); ok {
+		objName, err := cache.DeletionHandlingMetaNamespaceKeyFunc(content)
+		if err != nil {
+			klog.Errorf("failed to get key from object: %v, %v", err, content)
+			return
+		}
+		klog.V(5).Infof("enqueued %q for sync", objName)
+		ctrl.groupSnapshotContentQueue.Add(objName)
+	}
+}
+
+// groupSnapshotContentWorker processes items from groupSnapshotContentQueue.
+// It must run only once, syncContent is not assured to be reentrant.
+func (ctrl *csiSnapshotSideCarController) groupSnapshotContentWorker() {
+	keyObj, quit := ctrl.groupSnapshotContentQueue.Get()
+	if quit {
+		return
+	}
+	defer ctrl.groupSnapshotContentQueue.Done(keyObj)
+
+	if err := ctrl.syncGroupSnapshotContentByKey(keyObj.(string)); err != nil {
+		// Rather than wait for a full resync, re-add the key to the
+		// queue to be processed.
+		ctrl.groupSnapshotContentQueue.AddRateLimited(keyObj)
+		klog.V(4).Infof("Failed to sync group snapshot content %q, will retry again: %v", keyObj.(string), err)
+		return
+	}
+
+	// Finally, if no error occurs we forget this item so it does not
+	// get queued again until another change happens.
+	ctrl.groupSnapshotContentQueue.Forget(keyObj)
+	return
+}
+
+func (ctrl *csiSnapshotSideCarController) syncGroupSnapshotContentByKey(key string) error {
+	klog.V(5).Infof("syncGroupSnapshotContentByKey[%s]", key)
+
+	_, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		klog.V(4).Infof("error getting name of groupSnapshotContent %q from informer: %v", key, err)
+		return nil
+	}
+	content, err := ctrl.groupSnapshotContentLister.Get(name)
+	// The group snapshot content still exists in informer cache, the event must
+	// have been add/update/sync
+	if err == nil {
+		if ctrl.isDriverMatch(content) {
+			err = ctrl.updateGroupSnapshotContentInInformerCache(content)
+		}
+		if err != nil {
+			// If error occurs we add this item back to the queue
+			return err
+		}
+		return nil
+	}
+	if !errors.IsNotFound(err) {
+		klog.V(2).Infof("error getting group snapshot content %q from informer: %v", key, err)
+		return nil
+	}
+
+	// The content is not in informer cache, the event must have been
+	// "delete"
+	contentObj, found, err := ctrl.groupSnapshotContentStore.GetByKey(key)
+	if err != nil {
+		klog.V(2).Infof("error getting group snapshot content %q from cache: %v", key, err)
+		return nil
+	}
+	if !found {
+		// The controller has already processed the delete event and
+		// deleted the group snapshot content from its cache
+		klog.V(2).Infof("deletion of group snapshot content %q was already processed", key)
+		return nil
+	}
+	content, ok := contentObj.(*crdv1alpha1.VolumeGroupSnapshotContent)
+	if !ok {
+		klog.Errorf("expected group snapshot content, got %+v", content)
+		return nil
+	}
+	ctrl.deleteGroupSnapshotContentInCacheStore(content)
+	return nil
+}
+
+// updateGroupSnapshotContentInInformerCache runs in worker thread and handles
+// "group snapshot content added", "group snapshot content updated" and "periodic
+// sync" events.
+func (ctrl *csiSnapshotSideCarController) updateGroupSnapshotContentInInformerCache(content *crdv1alpha1.VolumeGroupSnapshotContent) error {
+	// Store the new group snapshot content version in the cache and do not process
+	// it if this is an old version.
+	new, err := ctrl.storeGroupSnapshotContentUpdate(content)
+	if err != nil {
+		klog.Errorf("%v", err)
+	}
+	if !new {
+		return nil
+	}
+	err = ctrl.syncGroupSnapshotContent(content)
+	if err != nil {
+		if errors.IsConflict(err) {
+			// Version conflict error happens quite often and the controller
+			// recovers from it easily.
+			klog.V(3).Infof("could not sync group snapshot content %q: %+v", content.Name, err)
+		} else {
+			klog.Errorf("could not sync group snapshot content %q: %+v", content.Name, err)
+		}
+		return err
+	}
+	return nil
+}
+
+// deleteGroupSnapshotContentInCacheStore runs in worker thread and handles "group
+// snapshot content deleted" event.
+func (ctrl *csiSnapshotSideCarController) deleteGroupSnapshotContentInCacheStore(content *crdv1alpha1.VolumeGroupSnapshotContent) {
+	_ = ctrl.groupSnapshotContentStore.Delete(content)
+	klog.V(4).Infof("group snapshot content %q deleted", content.Name)
+}
+
+// syncGroupSnapshotContent deals with one key off the queue.  It returns false when it's time to quit.
+func (ctrl *csiSnapshotSideCarController) syncGroupSnapshotContent(content *crdv1alpha1.VolumeGroupSnapshotContent) error {
+	klog.V(5).Infof("synchronizing VolumeGroupSnapshotContent[%s]", content.Name)
+
+	/*
+		TODO: Check if the group snapshot content should be deleted
+	*/
+
+	/*
+		TODO: Check if a new group snapshot should be created by calling CreateGroupSnapshot
+	*/
+
+	/*
+		TODO: Check and update group snapshot content status
+	*/
+	return nil
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

This PR adds code for csi-snapshotter to handle volume group snapshots, including:
- Create a new feature flag, `enable-volume-group-snapshots`
- Introduce a group snapshot content queue to process events
- Listers, informers, cache and queues for csi-snapshotter

Most of this code is similar to the functions for volume snapshots, taken from https://github.com/kubernetes-csi/external-snapshotter/tree/master/pkg/sidecar-controller

KEP - https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/3476-volume-group-snapshot

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
