### PR TITLE
implement GroupSnapshotter.GetGroupSnapshotStatus()

### DIFF
--- a/pkg/sidecar-controller/groupsnapshot_helper.go
+++ b/pkg/sidecar-controller/groupsnapshot_helper.go
@@ -802,7 +802,8 @@ func (ctrl *csiSnapshotSideCarController) checkandUpdateGroupSnapshotContentStat
 			}
 		}
 
-		readyToUse, creationTime, err = ctrl.handler.GetGroupSnapshotStatus(groupSnapshotContent, snapshotterListCredentials)
+		snapshotIDs := groupSnapshotContent.Spec.Source.GroupSnapshotHandles.VolumeSnapshotHandles
+		readyToUse, creationTime, err = ctrl.handler.GetGroupSnapshotStatus(groupSnapshotContent, snapshotIDs, snapshotterListCredentials)
 		if err != nil {
 			klog.Errorf("checkandUpdateGroupSnapshotContentStatusOperation: failed to call get group snapshot status to check whether group snapshot is ready to use %q", err)
 			return groupSnapshotContent, err


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

GroupSnapshots are not fully implemented yet.

The commit in this PR makes it work nicely:

```yaml
---
apiVersion: groupsnapshot.storage.k8s.io/v1alpha1
kind: VolumeGroupSnapshotContent
metadata:
  name: manual-vgs-content
spec:
  deletionPolicy: Retain
  driver: hostpath.csi.k8s.io
  volumeGroupSnapshotRef:
    apiVersion: groupsnapshot.storage.k8s.io/v1alpha1
    kind: VolumeGroupSnapshot
    name: manual-vgs
    namespace: default
  volumeGroupSnapshotClassName: csi-hostpath-vgsc
  source:
    groupSnapshotHandles:
      volumeGroupSnapshotHandle: 41a78530-bb86-11ee-93b4-0a580a810320
      volumeSnapshotHandles:
        - 41a78c22-bb86-11ee-93b4-0a580a810320
---
apiVersion: groupsnapshot.storage.k8s.io/v1alpha1
kind: VolumeGroupSnapshot
metadata:
  name: manual-vgs
spec:
  volumeGroupSnapshotClassName: csi-hostpath-vgsc
  source:
    volumeGroupSnapshotContentName: manual-vgs-content
```

Results after applying the above YAML for the VolumeGroupSnapshotContent:
```console
$ kubectl get --show-managed-fields=false -oyaml volumegroupsnapshotcontent/manual-vgs-content
apiVersion: groupsnapshot.storage.k8s.io/v1alpha1
kind: VolumeGroupSnapshotContent
metadata:
  creationTimestamp: "2024-01-25T13:35:53Z"
  finalizers:
  - groupsnapshot.storage.kubernetes.io/volumegroupsnapshotcontent-bound-protection
  generation: 2
  name: manual-vgs-content
  resourceVersion: "1708778"
  uid: ca3b4443-1fdd-4a34-bb2f-eaa5db101439
spec:
  deletionPolicy: Retain
  driver: hostpath.csi.k8s.io
  source:
    groupSnapshotHandles:
      volumeGroupSnapshotHandle: 41a78530-bb86-11ee-93b4-0a580a810320
      volumeSnapshotHandles:
      - 41a78c22-bb86-11ee-93b4-0a580a810320
  volumeGroupSnapshotClassName: csi-hostpath-vgsc
  volumeGroupSnapshotRef:
    apiVersion: groupsnapshot.storage.k8s.io/v1alpha1
    kind: VolumeGroupSnapshot
    name: manual-vgs
    namespace: default
    uid: 1375795d-d13f-401f-8d77-069d38f4e1b7
status:
  creationTime: 1706189579657523493
  readyToUse: true
  volumeGroupSnapshotHandle: 41a78530-bb86-11ee-93b4-0a580a810320
```

And for the VolumeGroupSnapshot:
```console
$ kubectl get --show-managed-fields=false -oyaml volumegroupsnapshot/manual-vgs
apiVersion: groupsnapshot.storage.k8s.io/v1alpha1
kind: VolumeGroupSnapshot
metadata:
  creationTimestamp: "2024-01-25T17:18:24Z"
  generation: 1
  name: manual-vgs
  namespace: default
  resourceVersion: "1708781"
  uid: 1375795d-d13f-401f-8d77-069d38f4e1b7
spec:
  source:
    volumeGroupSnapshotContentName: manual-vgs-content
  volumeGroupSnapshotClassName: csi-hostpath-vgsc
status:
  boundVolumeGroupSnapshotContentName: manual-vgs-content
  creationTime: "2024-01-25T13:32:59Z"
  readyToUse: true
```

**Which issue(s) this PR fixes**:

Fixes #832

**Special notes for your reviewer**:

/cc @RaunakShah

**Does this PR introduce a user-facing change?**:

```release-note
Implement GetGroupSnapshotStatus so that pre-provisioned VolumeGroupSnapshots can be imported.
```
