### PR TITLE
chore: Adopt kubernetes recommand label

### DIFF
--- a/deploy/kubernetes/csi-snapshotter/setup-csi-snapshotter.yaml
+++ b/deploy/kubernetes/csi-snapshotter/setup-csi-snapshotter.yaml
@@ -45,10 +45,10 @@ apiVersion: v1
 metadata:
   name: csi-snapshotter
   labels:
-    app: csi-snapshotter
+    app.kubernetes.io/name: csi-snapshotter
 spec:
   selector:
-    app: csi-snapshotter
+    app.kubernetes.io/name: csi-snapshotter
   ports:
     - name: dummy
       port: 12345
@@ -63,11 +63,11 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: csi-snapshotter
+      app.kubernetes.io/name: csi-snapshotter
   template:
     metadata:
       labels:
-        app: csi-snapshotter
+        app.kubernetes.io/name: csi-snapshotter
     spec:
       serviceAccountName: csi-snapshotter
       containers:

--- a/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml
+++ b/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml
@@ -15,7 +15,7 @@ spec:
   replicas: 2
   selector:
     matchLabels:
-      app: snapshot-controller
+      app.kubernetes.io/name: snapshot-controller
   # the snapshot controller won't be marked as ready if the v1 CRDs are unavailable
   # in #504 the snapshot-controller will exit after around 7.5 seconds if it
   # can't find the v1 CRDs so this value should be greater than that
@@ -28,7 +28,7 @@ spec:
   template:
     metadata:
       labels:
-        app: snapshot-controller
+        app.kubernetes.io/name: snapshot-controller
     spec:
       serviceAccountName: snapshot-controller
       containers:

--- a/deploy/kubernetes/webhook-example/webhook.yaml
+++ b/deploy/kubernetes/webhook-example/webhook.yaml
@@ -5,16 +5,16 @@ metadata:
   name: snapshot-validation-deployment
   namespace: default # NOTE: change the namespace
   labels:
-    app: snapshot-validation
+    app.kubernetes.io/name: snapshot-validation
 spec:
   replicas: 3
   selector:
     matchLabels:
-      app: snapshot-validation
+      app.kubernetes.io/name: snapshot-validation
   template:
     metadata:
       labels:
-        app: snapshot-validation
+        app.kubernetes.io/name: snapshot-validation
     spec:
       serviceAccountName: snapshot-webhook
       containers:
@@ -40,7 +40,7 @@ metadata:
   namespace: default # NOTE: change the namespace
 spec:
   selector:
-    app: snapshot-validation
+    app.kubernetes.io/name: snapshot-validation
   ports:
     - protocol: TCP
       port: 443 # Change if needed


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

/kind cleanup

**What this PR does / why we need it**:
Adopt kubernetes recommand label

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #843

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Adopt Kubernetes recommended label "app.kubernetes.io/name" when deploying csi-snapshotter, snapshot-controller, and snapshot-validation-webhook.
```