### PR TITLE
Fix CRDs missing metadata fields

### DIFF
--- a/client/config/crd/groupsnapshot.storage.k8s.io_volumegroupsnapshotclasses.yaml
+++ b/client/config/crd/groupsnapshot.storage.k8s.io_volumegroupsnapshotclasses.yaml
@@ -3,8 +3,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.3
     api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/814"
+    controller-gen.kubebuilder.io/version: v0.12.0
   creationTimestamp: null
   name: volumegroupsnapshotclasses.groupsnapshot.storage.k8s.io
 spec:
@@ -53,6 +53,8 @@ spec:
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
+          metadata:
+            type: object
           parameters:
             additionalProperties:
               type: string

--- a/client/config/crd/groupsnapshot.storage.k8s.io_volumegroupsnapshotcontents.yaml
+++ b/client/config/crd/groupsnapshot.storage.k8s.io_volumegroupsnapshotcontents.yaml
@@ -3,8 +3,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.3
     api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/814"
+    controller-gen.kubebuilder.io/version: v0.12.0
   creationTimestamp: null
   name: volumegroupsnapshotcontents.groupsnapshot.storage.k8s.io
 spec:
@@ -35,6 +35,8 @@ spec:
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
+          metadata:
+            type: object
           spec:
             description: Spec defines properties of a VolumeGroupSnapshotContent created
               by the underlying storage system. Required.

--- a/client/config/crd/groupsnapshot.storage.k8s.io_volumegroupsnapshots.yaml
+++ b/client/config/crd/groupsnapshot.storage.k8s.io_volumegroupsnapshots.yaml
@@ -3,8 +3,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.3
     api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/814"
+    controller-gen.kubebuilder.io/version: v0.12.0
   creationTimestamp: null
   name: volumegroupsnapshots.groupsnapshot.storage.k8s.io
 spec:
@@ -34,6 +34,8 @@ spec:
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
+          metadata:
+            type: object
           spec:
             description: Spec defines the desired characteristics of a group snapshot
               requested by a user. Required.

--- a/client/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml
+++ b/client/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml
@@ -3,8 +3,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.3
     api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/814"
+    controller-gen.kubebuilder.io/version: v0.12.0
   creationTimestamp: null
   name: volumesnapshotclasses.snapshot.storage.k8s.io
 spec:
@@ -65,6 +65,8 @@ spec:
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
+          metadata:
+            type: object
           parameters:
             additionalProperties:
               type: string

--- a/client/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml
+++ b/client/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml
@@ -3,8 +3,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.3
     api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/814"
+    controller-gen.kubebuilder.io/version: v0.12.0
   creationTimestamp: null
   name: volumesnapshotcontents.snapshot.storage.k8s.io
 spec:
@@ -71,6 +71,8 @@ spec:
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
+          metadata:
+            type: object
           spec:
             description: spec defines properties of a VolumeSnapshotContent created
               by the underlying storage system. Required.

--- a/client/config/crd/snapshot.storage.k8s.io_volumesnapshots.yaml
+++ b/client/config/crd/snapshot.storage.k8s.io_volumesnapshots.yaml
@@ -3,8 +3,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.3
     api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/814"
+    controller-gen.kubebuilder.io/version: v0.12.0
   creationTimestamp: null
   name: volumesnapshots.snapshot.storage.k8s.io
 spec:
@@ -74,6 +74,8 @@ spec:
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
+          metadata:
+            type: object
           spec:
             description: 'spec defines the desired characteristics of a snapshot requested
               by a user. More info: https://kubernetes.io/docs/concepts/storage/volume-snapshots#volumesnapshots

--- a/client/hack/README.md
+++ b/client/hack/README.md
@@ -66,16 +66,6 @@ Follow these steps to update the CRD:
 
 * Add api-approved.kubernetes.io annotation value in all yaml files in the metadata section with the PR where the API is approved by the API reviewers. The current approved PR for snapshot v1 API is https://github.com/kubernetes-csi/external-snapshotter/pull/419. Refer to https://github.com/kubernetes/enhancements/pull/1111 for details about this annotation.
 
-* Remove any metadata sections from the yaml file which does not belong to the generated type.
-For example, the following command will add a metadata section for a nested object, remove any newly added metadata sections. TODO(xiangqian): this is to make sure the generated CRD is compatible with apiextensions.k8s.io/v1. Once controller-gen supports generating CRD with apiextensions.k8s.io/v1, switch to use the correct version of controller-gen and remove the last step from this README.
-
-```bash
-./hack/update-crd.sh; git diff
-+        metadata:
-+          description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
-           type: object
-```
-
 * Update the restoreSize property to string in snapshot.storage.k8s.io_volumesnapshots.yaml
 
 The generated yaml file contains restoreSize property anyOf as described below: 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The CRD yaml files in client/config/crd ([e.g.](https://github.com/kubernetes-csi/external-snapshotter/blob/master/client/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml)) do not allow for standard metadata, according to their schemae.

However, looking at the struct definitions under client/apis ([e.g.](https://github.com/kubernetes-csi/external-snapshotter/blob/master/client/apis/volumesnapshot/v1/types.go#LL211C4-L211C4)), they correctly embed (and thus support) metav1.ObjectMeta -- and the docs reflect this as well.

This isn't problematic at first glance, because the controller recognizes and knows how to handle ObjectMeta in an applied resource. We only noticed it because we have a CI linter that validates applied resources against the schema as defined in the CRD, with strict validation enabled.

**Which issue(s) this PR fixes**:

Fixes #845 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
