### PR TITLE
Add more detail in vgs/vgsc/vgsclass printed columns

### DIFF
--- a/client/apis/volumegroupsnapshot/v1alpha1/types.go
+++ b/client/apis/volumegroupsnapshot/v1alpha1/types.go
@@ -88,7 +88,7 @@ type VolumeGroupSnapshotStatus struct {
 	CreationTime *metav1.Time `json:"creationTime,omitempty" protobuf:"bytes,2,opt,name=creationTime"`
 
 	// ReadyToUse indicates if all the individual snapshots in the group are ready
-	// to be used to restore a volume.
+	// to be used to restore a group of volumes.
 	// ReadyToUse becomes true when ReadyToUse of all individual snapshots become true.
 	// If not specified, it means the readiness of a group snapshot is unknown.
 	// +optional
@@ -118,6 +118,11 @@ type VolumeGroupSnapshotStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:scope=Namespaced,shortName=vgs
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="ReadyToUse",type=boolean,JSONPath=`.status.readyToUse`,description="Indicates if all the individual snapshots in the group are ready to be used to restore a group of volumes."
+// +kubebuilder:printcolumn:name="VolumeGroupSnapshotClass",type=string,JSONPath=`.spec.volumeGroupSnapshotClassName`,description="The name of the VolumeGroupSnapshotClass requested by the VolumeGroupSnapshot."
+// +kubebuilder:printcolumn:name="VolumeGroupSnapshotContent",type=string,JSONPath=`.status.boundVolumeGroupSnapshotContentName`,description="Name of the VolumeGroupSnapshotContent object to which the VolumeGroupSnapshot object intends to bind to. Please note that verification of binding actually requires checking both VolumeGroupSnapshot and VolumeGroupSnapshotContent to ensure both are pointing at each other. Binding MUST be verified prior to usage of this object."
+// +kubebuilder:printcolumn:name="CreationTime",type=date,JSONPath=`.status.creationTime`,description="Timestamp when the point-in-time group snapshot was taken by the underlying storage system."
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 type VolumeGroupSnapshot struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.
@@ -157,6 +162,9 @@ type VolumeGroupSnapshotList struct {
 // VolumeGroupSnapshotClasses are non-namespaced.
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:scope=Cluster,shortName=vgsclass;vgsclasses
+// +kubebuilder:printcolumn:name="Driver",type=string,JSONPath=`.driver`
+// +kubebuilder:printcolumn:name="DeletionPolicy",type=string,JSONPath=`.deletionPolicy`,description="Determines whether a VolumeGroupSnapshotContent created through the VolumeGroupSnapshotClass should be deleted when its bound VolumeGroupSnapshot is deleted."
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 type VolumeGroupSnapshotClass struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.
@@ -210,6 +218,13 @@ type VolumeGroupSnapshotClassList struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:scope=Cluster,shortName=vgsc;vgscs
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="ReadyToUse",type=boolean,JSONPath=`.status.readyToUse`,description="Indicates if all the individual snapshots in the group are ready to be used to restore a group of volumes."
+// +kubebuilder:printcolumn:name="DeletionPolicy",type=string,JSONPath=`.spec.deletionPolicy`,description="Determines whether this VolumeGroupSnapshotContent and its physical group snapshot on the underlying storage system should be deleted when its bound VolumeGroupSnapshot is deleted."
+// +kubebuilder:printcolumn:name="Driver",type=string,JSONPath=`.spec.driver`,description="Name of the CSI driver used to create the physical group snapshot on the underlying storage system."
+// +kubebuilder:printcolumn:name="VolumeGroupSnapshotClass",type=string,JSONPath=`.spec.volumeGroupSnapshotClassName`,description="Name of the VolumeGroupSnapshotClass from which this group snapshot was (or will be) created."
+// +kubebuilder:printcolumn:name="VolumeGroupSnapshotNamespace",type=string,JSONPath=`.spec.volumeGroupSnapshotRef.namespace`,description="Namespace of the VolumeGroupSnapshot object to which this VolumeGroupSnapshotContent object is bound."
+// +kubebuilder:printcolumn:name="VolumeGroupSnapshot",type=string,JSONPath=`.spec.volumeGroupSnapshotRef.name`,description="Name of the VolumeGroupSnapshot object to which this VolumeGroupSnapshotContent object is bound."
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 type VolumeGroupSnapshotContent struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard list metadata
@@ -312,7 +327,7 @@ type VolumeGroupSnapshotContentStatus struct {
 	CreationTime *int64 `json:"creationTime,omitempty" protobuf:"varint,2,opt,name=creationTime"`
 
 	// ReadyToUse indicates if all the individual snapshots in the group are ready to be
-	// used to restore a volume.
+	// used to restore a group of volumes.
 	// ReadyToUse becomes true when ReadyToUse of all individual snapshots become true.
 	// +optional
 	ReadyToUse *bool `json:"readyToUse,omitempty" protobuf:"varint,3,opt,name=readyToUse"`

--- a/client/config/crd/groupsnapshot.storage.k8s.io_volumegroupsnapshotclasses.yaml
+++ b/client/config/crd/groupsnapshot.storage.k8s.io_volumegroupsnapshotclasses.yaml
@@ -19,7 +19,20 @@ spec:
     singular: volumegroupsnapshotclass
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .driver
+      name: Driver
+      type: string
+    - description: Determines whether a VolumeGroupSnapshotContent created through
+        the VolumeGroupSnapshotClass should be deleted when its bound VolumeGroupSnapshot
+        is deleted.
+      jsonPath: .deletionPolicy
+      name: DeletionPolicy
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: VolumeGroupSnapshotClass specifies parameters that a underlying
@@ -66,3 +79,4 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}

--- a/client/config/crd/groupsnapshot.storage.k8s.io_volumegroupsnapshotcontents.yaml
+++ b/client/config/crd/groupsnapshot.storage.k8s.io_volumegroupsnapshotcontents.yaml
@@ -19,7 +19,42 @@ spec:
     singular: volumegroupsnapshotcontent
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Indicates if all the individual snapshots in the group are ready
+        to be used to restore a group of volumes.
+      jsonPath: .status.readyToUse
+      name: ReadyToUse
+      type: boolean
+    - description: Determines whether this VolumeGroupSnapshotContent and its physical
+        group snapshot on the underlying storage system should be deleted when its
+        bound VolumeGroupSnapshot is deleted.
+      jsonPath: .spec.deletionPolicy
+      name: DeletionPolicy
+      type: string
+    - description: Name of the CSI driver used to create the physical group snapshot
+        on the underlying storage system.
+      jsonPath: .spec.driver
+      name: Driver
+      type: string
+    - description: Name of the VolumeGroupSnapshotClass from which this group snapshot
+        was (or will be) created.
+      jsonPath: .spec.volumeGroupSnapshotClassName
+      name: VolumeGroupSnapshotClass
+      type: string
+    - description: Namespace of the VolumeGroupSnapshot object to which this VolumeGroupSnapshotContent
+        object is bound.
+      jsonPath: .spec.volumeGroupSnapshotRef.namespace
+      name: VolumeGroupSnapshotNamespace
+      type: string
+    - description: Name of the VolumeGroupSnapshot object to which this VolumeGroupSnapshotContent
+        object is bound.
+      jsonPath: .spec.volumeGroupSnapshotRef.name
+      name: VolumeGroupSnapshot
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: VolumeGroupSnapshotContent represents the actual "on-disk" group
@@ -173,9 +208,9 @@ spec:
                 type: object
               readyToUse:
                 description: ReadyToUse indicates if all the individual snapshots
-                  in the group are ready to be used to restore a volume. ReadyToUse
-                  becomes true when ReadyToUse of all individual snapshots become
-                  true.
+                  in the group are ready to be used to restore a group of volumes.
+                  ReadyToUse becomes true when ReadyToUse of all individual snapshots
+                  become true.
                 type: boolean
               volumeGroupSnapshotHandle:
                 description: VolumeGroupSnapshotHandle is a unique id returned by
@@ -183,7 +218,7 @@ spec:
                   system. If a storage system does not provide such an id, the CSI
                   driver can choose to return the VolumeGroupSnapshot name.
                 type: string
-              volumeSnapshotRefList:
+              volumeSnapshotContentRefList:
                 description: VolumeSnapshotContentRefList is the list of volume snapshot
                   content references for this group snapshot. The maximum number of
                   allowed snapshots in the group is 100.

--- a/client/config/crd/groupsnapshot.storage.k8s.io_volumegroupsnapshots.yaml
+++ b/client/config/crd/groupsnapshot.storage.k8s.io_volumegroupsnapshots.yaml
@@ -18,7 +18,33 @@ spec:
     singular: volumegroupsnapshot
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Indicates if all the individual snapshots in the group are ready
+        to be used to restore a group of volumes.
+      jsonPath: .status.readyToUse
+      name: ReadyToUse
+      type: boolean
+    - description: The name of the VolumeGroupSnapshotClass requested by the VolumeGroupSnapshot.
+      jsonPath: .spec.volumeGroupSnapshotClassName
+      name: VolumeGroupSnapshotClass
+      type: string
+    - description: Name of the VolumeGroupSnapshotContent object to which the VolumeGroupSnapshot
+        object intends to bind to. Please note that verification of binding actually
+        requires checking both VolumeGroupSnapshot and VolumeGroupSnapshotContent
+        to ensure both are pointing at each other. Binding MUST be verified prior
+        to usage of this object.
+      jsonPath: .status.boundVolumeGroupSnapshotContentName
+      name: VolumeGroupSnapshotContent
+      type: string
+    - description: Timestamp when the point-in-time group snapshot was taken by the
+        underlying storage system.
+      jsonPath: .status.creationTime
+      name: CreationTime
+      type: date
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: VolumeGroupSnapshot is a user's request for creating either a
@@ -160,10 +186,10 @@ spec:
                 type: object
               readyToUse:
                 description: ReadyToUse indicates if all the individual snapshots
-                  in the group are ready to be used to restore a volume. ReadyToUse
-                  becomes true when ReadyToUse of all individual snapshots become
-                  true. If not specified, it means the readiness of a group snapshot
-                  is unknown.
+                  in the group are ready to be used to restore a group of volumes.
+                  ReadyToUse becomes true when ReadyToUse of all individual snapshots
+                  become true. If not specified, it means the readiness of a group
+                  snapshot is unknown.
                 type: boolean
               volumeSnapshotRefList:
                 description: VolumeSnapshotRefList is the list of volume snapshot


### PR DESCRIPTION

**What type of PR is this?**

/kind feature


**What this PR does / why we need it**:

add more detail printed columns when exec kubectl get vgs | vgsc | vgsclass  

before
<pre>
[root@node-1 deploy]# kubectl get vgsc
NAME                                                    AGE
groupsnapcontent-03314fd3-faa5-4aea-a14b-416b8b47ba86   4h24m

[root@node-1 deploy]# kubectl get vgs
NAME                AGE
hostpath-mock-vgs   4h24m

[root@node-1 deploy]# kubectl get vgsc
NAME                                                    AGE
groupsnapcontent-03314fd3-faa5-4aea-a14b-416b8b47ba86   4h24m

</pre>

after
<pre>
[root@node-1 new-crd]# kubectl get vgsclass
NAME                 DRIVER                DELETIONPOLICY   AGE
hostpath-mock-vgsc   hostpath.csi.ake.io   Delete           4d6h


[root@node-1 new-crd]# kubectl get vgs
NAME                READYTOUSE   VOLUMEGROUPSNAPSHOTCLASS   VOLUMEGROUPSNAPSHOTCONTENT                              CREATIONTIME   AGE
hostpath-mock-vgs   true         hostpath-mock-vgsc         groupsnapcontent-03314fd3-faa5-4aea-a14b-416b8b47ba86   4h19m          4h19m


[root@node-1 new-crd]# kubectl get vgsc
NAME                                                    READYTOUSE   DELETIONPOLICY   DRIVER                VOLUMEGROUPSNAPSHOTCLASS   VOLUMEGROUPSNAPSHOTNAMESPACE   VOLUMEGROUPSNAPSHOT   AGE
groupsnapcontent-03314fd3-faa5-4aea-a14b-416b8b47ba86   true         Delete           hostpath.csi.ake.io   hostpath-mock-vgsc         default                        hostpath-mock-vgs     4h20m

</pre>



**Which issue(s) this PR fixes**:

Fixes # 

**Special notes for your reviewer**:

@xing-yang  @RaunakShah 

 help me check the feature is ok, thanks

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
More detail printed columns output when get vgs/vgsc/vgsclass with kubectl
```
