### PR TITLE
external-snapshotter constantly retrying CreateSnapshot calls on error w/o backoff

### DIFF
--- a/pkg/sidecar-controller/snapshot_controller_base.go
+++ b/pkg/sidecar-controller/snapshot_controller_base.go
@@ -115,14 +115,9 @@ func NewCSISnapshotSideCarController(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) { ctrl.enqueueContentWork(obj) },
 			UpdateFunc: func(oldObj, newObj interface{}) {
-				// If the CSI driver fails to create a snapshot and returns a failure (indicated by content.Status.Error), the
-				// CSI Snapshotter sidecar will remove the "AnnVolumeSnapshotBeingCreated" annotation from the
-				// VolumeSnapshotContent.
-				// This will trigger a VolumeSnapshotContent update and it will cause the obj to be re-queued immediately
-				// and CSI CreateSnapshot will be called again without exponential backoff.
-				// Considering the object is modified more than once during the workflow we are not relying on the annoations of oldobj and newobj.
-				// We will just check if newobj status has error and avoid re-queue.
-				// So we are skipping the re-queue here to avoid CreateSnapshot being called without exponential backoff.
+				// Considering the object is modified more than once during the workflow we are not relying on the
+				// "AnnVolumeSnapshotBeingCreated" annotation. Instead we will just check if newobj status has error
+				// and avoid the immediate re-queue. This allows the retry to happen with exponential backoff.
 				newSnapContent := newObj.(*crdv1.VolumeSnapshotContent)
 				if newSnapContent.Status != nil && newSnapContent.Status.Error != nil {
 					return

--- a/pkg/sidecar-controller/snapshot_controller_base.go
+++ b/pkg/sidecar-controller/snapshot_controller_base.go
@@ -124,12 +124,7 @@ func NewCSISnapshotSideCarController(
 				// So we are skipping the re-queue here to avoid CreateSnapshot being called without exponential backoff.
 				newSnapContent := newObj.(*crdv1.VolumeSnapshotContent)
 				if newSnapContent.Status != nil && newSnapContent.Status.Error != nil {
-					oldSnapContent := oldObj.(*crdv1.VolumeSnapshotContent)
-					_, newExists := newSnapContent.ObjectMeta.Annotations[utils.AnnVolumeSnapshotBeingCreated]
-					_, oldExists := oldSnapContent.ObjectMeta.Annotations[utils.AnnVolumeSnapshotBeingCreated]
-					if !newExists && oldExists {
 						return
-					}
 				}
 				ctrl.enqueueContentWork(newObj)
 			},

--- a/pkg/sidecar-controller/snapshot_controller_base.go
+++ b/pkg/sidecar-controller/snapshot_controller_base.go
@@ -123,7 +123,7 @@ func NewCSISnapshotSideCarController(
 				// So we are skipping the re-queue here to avoid CreateSnapshot being called without exponential backoff.
 				newSnapContent := newObj.(*crdv1.VolumeSnapshotContent)
 				if newSnapContent.Status != nil && newSnapContent.Status.Error != nil {
-						return
+					return
 				}
 				ctrl.enqueueContentWork(newObj)
 			},

--- a/pkg/sidecar-controller/snapshot_controller_base.go
+++ b/pkg/sidecar-controller/snapshot_controller_base.go
@@ -41,7 +41,6 @@ import (
 	groupsnapshotlisters "github.com/kubernetes-csi/external-snapshotter/client/v6/listers/volumegroupsnapshot/v1alpha1"
 	snapshotlisters "github.com/kubernetes-csi/external-snapshotter/client/v6/listers/volumesnapshot/v1"
 	"github.com/kubernetes-csi/external-snapshotter/v6/pkg/snapshotter"
-	"github.com/kubernetes-csi/external-snapshotter/v6/pkg/utils"
 )
 
 type csiSnapshotSideCarController struct {

--- a/pkg/sidecar-controller/snapshot_controller_base.go
+++ b/pkg/sidecar-controller/snapshot_controller_base.go
@@ -120,6 +120,8 @@ func NewCSISnapshotSideCarController(
 				// VolumeSnapshotContent.
 				// This will trigger a VolumeSnapshotContent update and it will cause the obj to be re-queued immediately
 				// and CSI CreateSnapshot will be called again without exponential backoff.
+				// Considering the object is modified more than once during the workflow we are not relying on the annoations of oldobj and newobj.
+				// We will just check if newobj status has error and avoid re-queue.
 				// So we are skipping the re-queue here to avoid CreateSnapshot being called without exponential backoff.
 				newSnapContent := newObj.(*crdv1.VolumeSnapshotContent)
 				if newSnapContent.Status != nil && newSnapContent.Status.Error != nil {


### PR DESCRIPTION
Signed-off-by: Sameer Shaikh [sameer.shaikh@ibm.com](mailto:sameer.shaikh@ibm.com)

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
external-snapshotter constantly retrying CreateSnapshot calls on error w/o backoff

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #778

**Special notes for your reviewer**:
@xing-yang @zhucan @pwschuurman 

ResourceEventHandlerFuncs is a implementation of ResourceEventHandler, whose method OnUpdate has the following documentation:

[external-snapshotter/vendor/k8s.io/client-go/tools/cache/controller.go](https://github.com/kubernetes-csi/external-snapshotter/blob/e746d0717a32109d8c57cb76a70b299ec849f54d/vendor/k8s.io/client-go/tools/cache/controller.go#L203-L208)

```
 //  * OnUpdate is called when an object is modified. Note that oldObj is the 
 //      last known state of the object-- it is possible that several changes 
 //      were combined together, so you can't use this to see every single 
 //      change. OnUpdate is also called when a re-list happens, and it will 
 //      get called even if nothing changed. This is useful for periodically 
 //      evaluating or syncing something. 
```
Considering the object is modified more than once during the workflow (for example when there is an error), it might be possible that oldObj doesn't have the annotation set anymore and the check in line 111 doesn't really work.

 Hence we don't really need to worry about this annotation. Can we not just rely on error object ? If there is failure lets not re-queue it 

[external-snapshotter/pkg/sidecar-controller/snapshot_controller_base.go](https://github.com/kubernetes-csi/external-snapshotter/blob/e746d0717a32109d8c57cb76a70b299ec849f54d/pkg/sidecar-controller/snapshot_controller_base.go#L111)

I will attach more logs and scenarios that proves that we cant rely on this old and new object annotations rather we should just rely if error then dont requeue

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix a problem in CSI snapshotter sidecar that constantly retries CreateSnapshot call on error without exponential backoff. Comparing old and new object is not working as expected
```
