### PR TITLE
Update VolumeSnapshot and VolumeSnapshotContent using JSON patch

### DIFF
--- a/pkg/common-controller/snapshot_finalizer_test.go
+++ b/pkg/common-controller/snapshot_finalizer_test.go
@@ -17,10 +17,9 @@ limitations under the License.
 package common_controller
 
 import (
-	"testing"
-
 	"github.com/kubernetes-csi/external-snapshotter/v6/pkg/utils"
 	v1 "k8s.io/api/core/v1"
+	"testing"
 )
 
 // Test single call to ensurePVCFinalizer, checkandRemovePVCFinalizer, addSnapshotFinalizer, removeSnapshotFinalizer


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
 /kind bug

**What this PR does / why we need it**:
This PR replaces the Update calls for VolumeSnapshot and VolumeSnapshotContent with JSON patch calls. Addresses the "object has been modified" issue we see a lot in the snapshot-controller/snapshotter.

**Which issue(s) this PR fixes**:

Partial fix (only for Update() calls) https://github.com/kubernetes-csi/external-snapshotter/issues/748

**Special notes for your reviewer**:
N/A

**Does this PR introduce a user-facing change?**:

```release-note
Update VolumeSnapshot and VolumeSnapshotContent using JSON patch
```
