### PR TITLE
DeleteVolumeGroupSnapshot API - part 1

### DIFF
--- a/deploy/kubernetes/csi-snapshotter/rbac-csi-snapshotter.yaml
+++ b/deploy/kubernetes/csi-snapshotter/rbac-csi-snapshotter.yaml
@@ -36,11 +36,19 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents"]
-    verbs: ["get", "list", "watch", "update", "patch"]
+    verbs: ["get", "list", "watch", "update", "patch", "create"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents/status"]
     verbs: ["update", "patch"]
-
+  - apiGroups: ["groupsnapshot.storage.k8s.io"]
+    resources: ["volumegroupsnapshotclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["groupsnapshot.storage.k8s.io"]
+    resources: ["volumegroupsnapshotcontents"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["groupsnapshot.storage.k8s.io"]
+    resources: ["volumegroupsnapshotcontents/status"]
+    verbs: ["update", "patch"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/kubernetes/snapshot-controller/rbac-snapshot-controller.yaml
+++ b/deploy/kubernetes/snapshot-controller/rbac-snapshot-controller.yaml
@@ -42,6 +42,23 @@ rules:
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshots/status"]
     verbs: ["update", "patch"]
+
+  - apiGroups: ["groupsnapshot.storage.k8s.io"]
+    resources: ["volumegroupsnapshotclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["groupsnapshot.storage.k8s.io"]
+    resources: ["volumegroupsnapshotcontents"]
+    verbs: ["create", "get", "list", "watch", "update", "delete", "patch"]
+  - apiGroups: ["groupsnapshot.storage.k8s.io"]
+    resources: ["volumegroupsnapshotcontents/status"]
+    verbs: ["patch"]
+  - apiGroups: ["groupsnapshot.storage.k8s.io"]
+    resources: ["volumegroupsnapshots"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["groupsnapshot.storage.k8s.io"]
+    resources: ["volumegroupsnapshots/status"]
+    verbs: ["update", "patch"]
+
   # Enable this RBAC rule only when using distributed snapshotting, i.e. when the enable-distributed-snapshotting flag is set to true
   # - apiGroups: [""]
   #   resources: ["nodes"]

--- a/pkg/common-controller/snapshot_controller.go
+++ b/pkg/common-controller/snapshot_controller.go
@@ -1165,7 +1165,6 @@ func (ctrl *csiSnapshotCommonController) updateSnapshotStatus(snapshot *crdv1.Vo
 		updated = true
 	} else {
 		newStatus = snapshotObj.Status.DeepCopy()
-		klog.Infof("Raunak 1 %s", newStatus.VolumeGroupSnapshotName)
 		if newStatus.BoundVolumeSnapshotContentName == nil {
 			newStatus.BoundVolumeSnapshotContentName = &boundContentName
 			updated = true

--- a/pkg/common-controller/snapshot_controller_base.go
+++ b/pkg/common-controller/snapshot_controller_base.go
@@ -836,7 +836,7 @@ func (ctrl *csiSnapshotCommonController) updateGroupSnapshotContent(content *crd
 
 // deleteGroupSnapshotContent runs in worker thread and handles "groupsnapshotcontent deleted" event.
 func (ctrl *csiSnapshotCommonController) deleteGroupSnapshotContent(content *crdv1alpha1.VolumeGroupSnapshotContent) {
-	_ = ctrl.contentStore.Delete(content)
+	_ = ctrl.groupSnapshotContentStore.Delete(content)
 	klog.V(4).Infof("group snapshot content %q deleted", content.Name)
 
 	groupSnapshotName := utils.GroupSnapshotRefKey(&content.Spec.VolumeGroupSnapshotRef)

--- a/pkg/group_snapshotter/group_snapshotter.go
+++ b/pkg/group_snapshotter/group_snapshotter.go
@@ -18,11 +18,12 @@ package group_snapshotter
 
 import (
 	"context"
+	"time"
+
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	csirpc "github.com/kubernetes-csi/csi-lib-utils/rpc"
 	"google.golang.org/grpc"
 	klog "k8s.io/klog/v2"
-	"time"
 )
 
 // GroupSnapshotter implements CreateGroupSnapshot/DeleteGroupSnapshot operations against a CSI driver.
@@ -31,7 +32,7 @@ type GroupSnapshotter interface {
 	CreateGroupSnapshot(ctx context.Context, groupSnapshotName string, volumeIDs []string, parameters map[string]string, snapshotterCredentials map[string]string) (driverName string, groupSnapshotId string, snapshots []*csi.Snapshot, timestamp time.Time, readyToUse bool, err error)
 
 	// DeleteGroupSnapshot deletes a group snapshot of multiple volumes
-	DeleteGroupSnapshot(ctx context.Context, groupSnapshotID string, snapshotterCredentials map[string]string) (err error)
+	DeleteGroupSnapshot(ctx context.Context, groupSnapshotID string, snapshotIDs []string, snapshotterCredentials map[string]string) (err error)
 
 	// GetGroupSnapshotStatus returns if a group snapshot is ready to use, its creation time, etc
 	GetGroupSnapshotStatus(ctx context.Context, groupSnapshotID string, snapshotterListCredentials map[string]string) (bool, time.Time, error)
@@ -74,8 +75,20 @@ func (gs *groupSnapshot) CreateGroupSnapshot(ctx context.Context, groupSnapshotN
 
 }
 
-func (gs *groupSnapshot) DeleteGroupSnapshot(ctx context.Context, groupSnapshotID string, snapshotterCredentials map[string]string) error {
-	// TODO: Implement DeleteGroupSnapshot
+func (gs *groupSnapshot) DeleteGroupSnapshot(ctx context.Context, groupSnapshotID string, snapshotIds []string, snapshotterCredentials map[string]string) error {
+	client := csi.NewGroupControllerClient(gs.conn)
+
+	req := csi.DeleteVolumeGroupSnapshotRequest{
+		Secrets:         snapshotterCredentials,
+		GroupSnapshotId: groupSnapshotID,
+		SnapshotIds:     snapshotIds,
+	}
+
+	_, err := client.DeleteVolumeGroupSnapshot(ctx, &req)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/sidecar-controller/csi_handler.go
+++ b/pkg/sidecar-controller/csi_handler.go
@@ -19,11 +19,12 @@ package sidecar_controller
 import (
 	"context"
 	"fmt"
+	"strings"
+	"time"
+
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	crdv1alpha1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumegroupsnapshot/v1alpha1"
 	"github.com/kubernetes-csi/external-snapshotter/v6/pkg/group_snapshotter"
-	"strings"
-	"time"
 
 	crdv1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
 	"github.com/kubernetes-csi/external-snapshotter/v6/pkg/snapshotter"
@@ -36,6 +37,7 @@ type Handler interface {
 	GetSnapshotStatus(content *crdv1.VolumeSnapshotContent, snapshotterListCredentials map[string]string) (bool, time.Time, int64, error)
 	CreateGroupSnapshot(content *crdv1alpha1.VolumeGroupSnapshotContent, volumeIDs []string, parameters map[string]string, snapshotterCredentials map[string]string) (string, string, []*csi.Snapshot, time.Time, bool, error)
 	GetGroupSnapshotStatus(content *crdv1alpha1.VolumeGroupSnapshotContent, snapshotterListCredentials map[string]string) (bool, time.Time, error)
+	DeleteGroupSnapshot(content *crdv1alpha1.VolumeGroupSnapshotContent, SnapshotID []string, snapshotterCredentials map[string]string) error
 }
 
 // csiHandler is a handler that calls CSI to create/delete volume snapshot.
@@ -163,6 +165,27 @@ func (handler *csiHandler) CreateGroupSnapshot(content *crdv1alpha1.VolumeGroupS
 		return "", "", nil, time.Time{}, false, err
 	}
 	return handler.groupSnapshotter.CreateGroupSnapshot(ctx, groupSnapshotName, volumeIDs, parameters, snapshotterCredentials)
+}
+
+func (handler *csiHandler) DeleteGroupSnapshot(content *crdv1alpha1.VolumeGroupSnapshotContent, snapshotIDs []string, snapshotterCredentials map[string]string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), handler.timeout)
+	defer cancel()
+
+	// NOTE: snapshotIDs are required for DeleteGroupSnapshot
+	if len(snapshotIDs) == 0 {
+		return fmt.Errorf("cannot delete group snapshot content %s. No snapshots found in the group snapshot", content.Name)
+	}
+	var groupSnapshotHandle string
+
+	if content.Status != nil && content.Status.VolumeGroupSnapshotHandle != nil {
+		groupSnapshotHandle = *content.Status.VolumeGroupSnapshotHandle
+	} else if content.Spec.Source.VolumeGroupSnapshotHandle != nil {
+		groupSnapshotHandle = *content.Spec.Source.VolumeGroupSnapshotHandle
+	} else {
+		return fmt.Errorf("failed to delete group snapshot content %s: groupsnapshotHandle is missing", content.Name)
+	}
+
+	return handler.groupSnapshotter.DeleteGroupSnapshot(ctx, groupSnapshotHandle, snapshotIDs, snapshotterCredentials)
 }
 
 func (handler *csiHandler) GetGroupSnapshotStatus(groupSnapshotContent *crdv1alpha1.VolumeGroupSnapshotContent, snapshotterListCredentials map[string]string) (bool, time.Time, error) {

--- a/pkg/utils/patch.go
+++ b/pkg/utils/patch.go
@@ -58,6 +58,26 @@ func PatchVolumeSnapshot(
 	return newSnapshot, nil
 }
 
+// PatchVolumeGroupSnapshot patches a volume group snapshot object
+func PatchVolumeGroupSnapshot(
+	existingGroupSnapshot *crdv1alpha1.VolumeGroupSnapshot,
+	patch []PatchOp,
+	client clientset.Interface,
+	subresources ...string,
+) (*crdv1alpha1.VolumeGroupSnapshot, error) {
+	data, err := json.Marshal(patch)
+	if nil != err {
+		return existingGroupSnapshot, err
+	}
+
+	newGroupSnapshot, err := client.GroupsnapshotV1alpha1().VolumeGroupSnapshots(existingGroupSnapshot.Namespace).Patch(context.TODO(), existingGroupSnapshot.Name, types.JSONPatchType, data, metav1.PatchOptions{}, subresources...)
+	if err != nil {
+		return existingGroupSnapshot, err
+	}
+
+	return newGroupSnapshot, nil
+}
+
 // PatchVolumeGroupSnapshotContent patches a volume group snapshot content object
 func PatchVolumeGroupSnapshotContent(
 	existingGroupSnapshotContent *crdv1alpha1.VolumeGroupSnapshotContent,

--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -76,6 +76,10 @@ const (
 	VolumeSnapshotAsSourceFinalizer = "snapshot.storage.kubernetes.io/volumesnapshot-as-source-protection"
 	// Name of finalizer on PVCs that is being used as a source to create VolumeSnapshots
 	PVCFinalizer = "snapshot.storage.kubernetes.io/pvc-as-source-protection"
+	// Name of finalizer on VolumeGroupSnapshotContents that are bound by VolumeGroupSnapshots
+	VolumeGroupSnapshotContentFinalizer = "groupsnapshot.storage.kubernetes.io/volumegroupsnapshotcontent-bound-protection"
+	// Name of finalizer on VolumeGroupSnapshots that are bound to VolumeGroupSnapshotContents
+	VolumeGroupSnapshotBoundFinalizer = "groupsnapshot.storage.kubernetes.io/volumegroupsnapshot-bound-protection"
 
 	IsDefaultSnapshotClassAnnotation      = "snapshot.storage.kubernetes.io/is-default-class"
 	IsDefaultGroupSnapshotClassAnnotation = "groupsnapshot.storage.kubernetes.io/is-default-class"
@@ -113,6 +117,14 @@ const (
 	// the create group snapshot CSI method will not be called for pre-provisioned
 	// group snapshots.
 	AnnVolumeGroupSnapshotBeingCreated = "groupsnapshot.storage.kubernetes.io/volumegroupsnapshot-being-created"
+
+	// AnnVolumeGroupSnapshotBeingDeleted annotation applies to VolumeGroupSnapshotContents.
+	// It indicates that the common snapshot controller has verified that volume
+	// group snapshot has a deletion timestamp and is being deleted.
+	// Sidecar controller needs to check the deletion policy on the
+	// VolumeGroupSnapshotContent and decide whether to delete the volume group snapshot
+	// backing the group snapshot content.
+	AnnVolumeGroupSnapshotBeingDeleted = "groupsnapshot.storage.kubernetes.io/volumegroupsnapshot-being-deleted"
 
 	// Annotation for secret name and namespace will be added to the content
 	// and used at snapshot content deletion time.
@@ -406,10 +418,21 @@ func NeedToAddContentFinalizer(content *crdv1.VolumeSnapshotContent) bool {
 	return content.ObjectMeta.DeletionTimestamp == nil && !ContainsString(content.ObjectMeta.Finalizers, VolumeSnapshotContentFinalizer)
 }
 
+// NeedToAddGroupSnapshotContentFinalizer checks if a Finalizer needs to be added for the volume group snapshot content.
+func NeedToAddGroupSnapshotContentFinalizer(groupSnapshotContent *crdv1alpha1.VolumeGroupSnapshotContent) bool {
+	return groupSnapshotContent.ObjectMeta.DeletionTimestamp == nil && !ContainsString(groupSnapshotContent.ObjectMeta.Finalizers, VolumeGroupSnapshotContentFinalizer)
+}
+
 // IsSnapshotDeletionCandidate checks if a volume snapshot deletionTimestamp
 // is set and any finalizer is on the snapshot.
 func IsSnapshotDeletionCandidate(snapshot *crdv1.VolumeSnapshot) bool {
 	return snapshot.ObjectMeta.DeletionTimestamp != nil && (ContainsString(snapshot.ObjectMeta.Finalizers, VolumeSnapshotAsSourceFinalizer) || ContainsString(snapshot.ObjectMeta.Finalizers, VolumeSnapshotBoundFinalizer))
+}
+
+// IsGroupSnapshotDeletionCandidate checks if a volume group snapshot deletionTimestamp
+// is set and any finalizer is on the group snapshot.
+func IsGroupSnapshotDeletionCandidate(groupSnapshot *crdv1alpha1.VolumeGroupSnapshot) bool {
+	return groupSnapshot.ObjectMeta.DeletionTimestamp != nil && ContainsString(groupSnapshot.ObjectMeta.Finalizers, VolumeGroupSnapshotBoundFinalizer)
 }
 
 // NeedToAddSnapshotAsSourceFinalizer checks if a Finalizer needs to be added for the volume snapshot as a source for PVC.
@@ -420,6 +443,11 @@ func NeedToAddSnapshotAsSourceFinalizer(snapshot *crdv1.VolumeSnapshot) bool {
 // NeedToAddSnapshotBoundFinalizer checks if a Finalizer needs to be added for the bound volume snapshot.
 func NeedToAddSnapshotBoundFinalizer(snapshot *crdv1.VolumeSnapshot) bool {
 	return snapshot.ObjectMeta.DeletionTimestamp == nil && !ContainsString(snapshot.ObjectMeta.Finalizers, VolumeSnapshotBoundFinalizer) && IsBoundVolumeSnapshotContentNameSet(snapshot)
+}
+
+// NeedToAddGroupSnapshotBoundFinalizer checks if a Finalizer needs to be added for the bound volume group snapshot.
+func NeedToAddGroupSnapshotBoundFinalizer(groupSnapshot *crdv1alpha1.VolumeGroupSnapshot) bool {
+	return groupSnapshot.ObjectMeta.DeletionTimestamp == nil && !ContainsString(groupSnapshot.ObjectMeta.Finalizers, VolumeGroupSnapshotBoundFinalizer) && IsBoundVolumeGroupSnapshotContentNameSet(groupSnapshot)
 }
 
 func deprecationWarning(deprecatedParam, newParam, removalVersion string) string {
@@ -466,6 +494,18 @@ func GetSnapshotStatusForLogging(snapshot *crdv1.VolumeSnapshot) string {
 		ready = *snapshot.Status.ReadyToUse
 	}
 	return fmt.Sprintf("bound to: %q, Completed: %v", snapshotContentName, ready)
+}
+
+func GetGroupSnapshotStatusForLogging(groupSnapshot *crdv1alpha1.VolumeGroupSnapshot) string {
+	groupSnapshotContentName := ""
+	if groupSnapshot.Status != nil && groupSnapshot.Status.BoundVolumeGroupSnapshotContentName != nil {
+		groupSnapshotContentName = *groupSnapshot.Status.BoundVolumeGroupSnapshotContentName
+	}
+	ready := false
+	if groupSnapshot.Status != nil && groupSnapshot.Status.ReadyToUse != nil {
+		ready = *groupSnapshot.Status.ReadyToUse
+	}
+	return fmt.Sprintf("bound to: %q, Completed: %v", groupSnapshotContentName, ready)
 }
 
 func IsVolumeSnapshotRefSet(snapshot *crdv1.VolumeSnapshot, content *crdv1.VolumeSnapshotContent) bool {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature


**What this PR does / why we need it**:

This PR adds logic to delete volume group snapshots. 

Currently, Only the volume group snapshots and corresponding volume group snapshot contents are deleted. The logic to delete individual snapshots will be added in a separate PR.

**Testing**

1. Dynamically volume group snapshot:

- Create a volume group snapshot 
```
% kubectl create -f volumegroupsnapshot-example.yaml 
volumegroupsnapshot.groupsnapshot.storage.k8s.io/my-group-snapshot created
% kubectl get vgsc
NAME                                                    READYTOUSE   DELETIONPOLICY   DRIVER                VOLUMEGROUPSNAPSHOTCLASS   VOLUMEGROUPSNAPSHOTNAMESPACE   VOLUMEGROUPSNAPSHOT   AGE
groupsnapcontent-29f97dbc-d2a7-4204-b356-98a8c29870fb   true         Delete           hostpath.csi.k8s.io   vgs-class                  default                        my-group-snapshot     10s
% kubectl get vgs 
NAME                READYTOUSE   VOLUMEGROUPSNAPSHOTCLASS   VOLUMEGROUPSNAPSHOTCONTENT                              CREATIONTIME   AGE
my-group-snapshot   true         vgs-class                  groupsnapcontent-29f97dbc-d2a7-4204-b356-98a8c29870fb   11s            11s
% kubectl get vs  
NAME                                                                                           READYTOUSE   SOURCEPVC   SOURCESNAPSHOTCONTENT                                                                             RESTORESIZE   SNAPSHOTCLASS   SNAPSHOTCONTENT                                                                                   CREATIONTIME   AGE
snapshot-0a89a20f6f519bbb505bd29e6e8651e50319d3e527705239f9687d1fbce1a8a6-2023-10-13-8.50.54   true                     snapcontent-0a89a20f6f519bbb505bd29e6e8651e50319d3e527705239f9687d1fbce1a8a6-2023-10-13-8.50.54   1Gi                           snapcontent-0a89a20f6f519bbb505bd29e6e8651e50319d3e527705239f9687d1fbce1a8a6-2023-10-13-8.50.54   19s            19s
snapshot-4c6d03c90c122b50363288a808f0e784469b9730117fa028df007967a6b19359-2023-10-13-8.50.54   true                     snapcontent-4c6d03c90c122b50363288a808f0e784469b9730117fa028df007967a6b19359-2023-10-13-8.50.54   1Gi                           snapcontent-4c6d03c90c122b50363288a808f0e784469b9730117fa028df007967a6b19359-2023-10-13-8.50.54   19s            19s
% kubectl get vsc
NAME                                                                                              READYTOUSE   RESTORESIZE   DELETIONPOLICY   DRIVER                VOLUMESNAPSHOTCLASS   VOLUMESNAPSHOT                                                                                 VOLUMESNAPSHOTNAMESPACE   AGE
snapcontent-0a89a20f6f519bbb505bd29e6e8651e50319d3e527705239f9687d1fbce1a8a6-2023-10-13-8.50.54   true         1073741824    Delete           hostpath.csi.k8s.io                         snapshot-0a89a20f6f519bbb505bd29e6e8651e50319d3e527705239f9687d1fbce1a8a6-2023-10-13-8.50.54   default                   20s
snapcontent-4c6d03c90c122b50363288a808f0e784469b9730117fa028df007967a6b19359-2023-10-13-8.50.54   true         1073741824    Delete           hostpath.csi.k8s.io                         snapshot-4c6d03c90c122b50363288a808f0e784469b9730117fa028df007967a6b19359-2023-10-13-8.50.54   default                   20s
```

- Delete the volume group snapshot and verify that objects are deleted from API server:
```
% kubectl delete -f volumegroupsnapshot-example.yaml 
volumegroupsnapshot.groupsnapshot.storage.k8s.io "my-group-snapshot" deleted
% kubectl get vgs
No resources found in default namespace.
% kubectl get vgsc
No resources found
```

- Verify that VS and VSC still exist:
```
% kubectl get vs  
NAME                                                                                           READYTOUSE   SOURCEPVC   SOURCESNAPSHOTCONTENT                                                                             RESTORESIZE   SNAPSHOTCLASS   SNAPSHOTCONTENT                                                                                   CREATIONTIME   AGE
snapshot-0a89a20f6f519bbb505bd29e6e8651e50319d3e527705239f9687d1fbce1a8a6-2023-10-13-8.50.54   true                     snapcontent-0a89a20f6f519bbb505bd29e6e8651e50319d3e527705239f9687d1fbce1a8a6-2023-10-13-8.50.54   1Gi                           snapcontent-0a89a20f6f519bbb505bd29e6e8651e50319d3e527705239f9687d1fbce1a8a6-2023-10-13-8.50.54   19s            19s
snapshot-4c6d03c90c122b50363288a808f0e784469b9730117fa028df007967a6b19359-2023-10-13-8.50.54   true                     snapcontent-4c6d03c90c122b50363288a808f0e784469b9730117fa028df007967a6b19359-2023-10-13-8.50.54   1Gi                           snapcontent-4c6d03c90c122b50363288a808f0e784469b9730117fa028df007967a6b19359-2023-10-13-8.50.54   19s            19s
% kubectl get vsc
NAME                                                                                              READYTOUSE   RESTORESIZE   DELETIONPOLICY   DRIVER                VOLUMESNAPSHOTCLASS   VOLUMESNAPSHOT                                                                                 VOLUMESNAPSHOTNAMESPACE   AGE
snapcontent-0a89a20f6f519bbb505bd29e6e8651e50319d3e527705239f9687d1fbce1a8a6-2023-10-13-8.50.54   true         1073741824    Delete           hostpath.csi.k8s.io                         snapshot-0a89a20f6f519bbb505bd29e6e8651e50319d3e527705239f9687d1fbce1a8a6-2023-10-13-8.50.54   default                   20s
snapcontent-4c6d03c90c122b50363288a808f0e784469b9730117fa028df007967a6b19359-2023-10-13-8.50.54   true         1073741824    Delete           hostpath.csi.k8s.io                         snapshot-4c6d03c90c122b50363288a808f0e784469b9730117fa028df007967a6b19359-2023-10-13-8.50.54   default                   20s
```


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Introduce logic to delete volume group snapshots
```
