### PR TITLE
Enable or Enhance Dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,4 +1,3 @@
----
 version: 2
 updates:
 - package-ecosystem: gomod
@@ -6,16 +5,20 @@ updates:
   schedule:
     interval: daily
   labels:
-    - "area/dependency"
-    - "release-note-none"
-    - "ok-to-test"
+  - "area/dependency"
+  - "release-note-none"
+  - "ok-to-test"
   open-pull-requests-limit: 10
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
-      interval: "daily"
+    interval: "daily"
   labels:
-    - "area/dependency"
-    - "release-note-none"
-    - "ok-to-test"
+  - "area/dependency"
+  - "release-note-none"
+  - "ok-to-test"
   open-pull-requests-limit: 10
+- package-ecosystem: docker
+  directory: /
+  schedule:
+    interval: daily


### PR DESCRIPTION

Enable Dependabot for Docker and GoMod if not already so.
Keeping K8s dependencies up-to-date. 

Signed-off-by: zhuxiaow@google.com
