### PR TITLE
Update release tools

### DIFF
--- a/release-tools/prow.sh
+++ b/release-tools/prow.sh
@@ -199,7 +199,7 @@ kindest/node:v1.18.20@sha256:738cdc23ed4be6cc0b7ea277a2ebcc454c8373d7d8fb991a7fc
 # If the deployment script is called with CSI_PROW_TEST_DRIVER=<file name> as
 # environment variable, then it must write a suitable test driver configuration
 # into that file in addition to installing the driver.
-configvar CSI_PROW_DRIVER_VERSION "v1.11.0" "CSI driver version"
+configvar CSI_PROW_DRIVER_VERSION "v1.12.0" "CSI driver version"
 configvar CSI_PROW_DRIVER_REPO https://github.com/kubernetes-csi/csi-driver-host-path "CSI driver repo"
 configvar CSI_PROW_DEPLOYMENT "" "deployment"
 configvar CSI_PROW_DEPLOYMENT_SUFFIX "" "additional suffix in kubernetes-x.yy[suffix].yaml files"


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Squashed 'release-tools/' changes from 984feece..f9d5b9c0
f9d5b9c0 Merge pull request https://github.com/kubernetes-csi/external-snapshotter/issues/236 from mowangdk/feature/bump_csi-driver-host-path_version
b01fd537 Bump csi-driver-host-path version up to v1.12.0

git-subtree-dir: release-tools
git-subtree-split: f9d5b9c05ef730f191dd31f2a012d6161d98bff6

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
