### PR TITLE
Allow snapshot controller to delete VolumeSnapshots

### DIFF
--- a/deploy/kubernetes/snapshot-controller/rbac-snapshot-controller.yaml
+++ b/deploy/kubernetes/snapshot-controller/rbac-snapshot-controller.yaml
@@ -38,7 +38,7 @@ rules:
     verbs: ["patch"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshots"]
-    verbs: ["get", "list", "watch", "update", "patch"]
+    verbs: ["get", "list", "watch", "update", "patch", "delete"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshots/status"]
     verbs: ["update", "patch"]


### PR DESCRIPTION
This patch allows the snapshot-controller-runner ClusterRole, bound to the snapshot-controller Service Account, to delete VolumeSnapshot objects. This is needed during the VolumeGroupSnapshot deletion.

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
