### PR TITLE
Update release tools

### DIFF
--- a/release-tools/SIDECAR_RELEASE_PROCESS.md
+++ b/release-tools/SIDECAR_RELEASE_PROCESS.md
@@ -46,54 +46,45 @@ naming convention `<hostpath-deployment-version>-on-<kubernetes-version>`.
 ## Release Process
 1. Identify all issues and ongoing PRs that should go into the release, and
   drive them to resolution.
-1. Download the latest version of the
-   [K8s release notes generator](https://github.com/kubernetes/release/tree/HEAD/cmd/release-notes)
-1. Create a
-   [Github personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)
-   with `repo:public_repo` access
-1. Generate release notes for the release. Replace arguments with the relevant
-   information.
-    * Clean up old cached information (also needed if you are generating release
-      notes for multiple repos)
-      ```bash
-      rm -rf /tmp/k8s-repo
-      ```
-    * For new minor releases on master:
-        ```bash
-        GITHUB_TOKEN=<token> release-notes \
-          --discover=mergebase-to-latest \
-          --org=kubernetes-csi \
-          --repo=external-provisioner \
-          --required-author="" \
-          --markdown-links \
-          --output out.md
-        ```
-    * For new patch releases on a release branch:
-        ```bash
-        GITHUB_TOKEN=<token> release-notes \
-          --discover=patch-to-latest \
-          --branch=release-1.1 \
-          --org=kubernetes-csi \
-          --repo=external-provisioner \
-          --required-author="" \
-          --markdown-links \
-          --output out.md
-        ```
-1. Compare the generated output to the new commits for the release to check if
-   any notable change missed a release note.
-1. Reword release notes as needed. Make sure to check notes for breaking
-   changes and deprecations.
-1. If release is a new major/minor version, create a new `CHANGELOG-<major>.<minor>.md`
-   file. Otherwise, add the release notes to the top of the existing CHANGELOG
-   file for that minor version.
-1. Submit a PR for the CHANGELOG changes.
-1. Submit a PR for README changes, in particular, Compatibility, Feature status,
-   and any other sections that may need updating.
 1. Check that all [canary CI
   jobs](https://testgrid.k8s.io/sig-storage-csi-ci) are passing,
   and that test coverage is adequate for the changes that are going into the release.
 1. Check that the post-\<sidecar\>-push-images builds are succeeding.
    [Example](https://testgrid.k8s.io/sig-storage-image-build#post-external-snapshotter-push-images)
+1. Generate release notes.
+    1.  Download the latest version of the [K8s release notes generator](https://github.com/kubernetes/release/tree/HEAD/cmd/release-notes)
+    1. Create a
+       [Github personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)
+       with `repo:public_repo` access
+    1. For patch release, use the script generate_patch_release_notes.sh. Read the instructions at the top of the
+       script. The script also creates PRs for each branch.
+    1. For new minor releases, follow these steps and replace arguments with the relevant
+       information.
+        * Clean up old cached information (also needed if you are generating release
+          notes for multiple repos)
+          ```bash
+          rm -rf /tmp/k8s-repo
+          ```
+        * For new minor releases on master:
+            ```bash
+            GITHUB_TOKEN=<token> release-notes \
+              --discover=mergebase-to-latest \
+              --org=kubernetes-csi \
+              --repo=external-provisioner \
+              --required-author="" \
+              --markdown-links \
+              --output out.md
+            ```
+    1. Compare the generated output to the new commits for the release to check if
+       any notable change missed a release note.
+    1. Reword release notes as needed, ideally in the original PRs so that the
+       release notes can be regnerated. Make sure to check notes for breaking
+       changes and deprecations.
+    1. If release is a new major/minor version, create a new `CHANGELOG-<major>.<minor>.md`
+       file.
+    1. Submit a PR for the CHANGELOG changes.
+1. Submit a PR for README changes, in particular, Compatibility, Feature status,
+   and any other sections that may need updating.
 1. Make sure that no new PRs have merged in the meantime, and no PRs are in
    flight and soon to be merged.
 1. Create a new release following a previous release as a template. Be sure to select the correct

--- a/release-tools/generate_patch_release_notes.sh
+++ b/release-tools/generate_patch_release_notes.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Usage: generate_patch_release_notes.sh
+#
+# Generates and creates PRs for kubernetes-csi patch releases.
+#
+# Required environment variables
+# CSI_RELEASE_TOKEN: Github token needed for generating release notes
+# GITHUB_USER: Github username to create PRs with
+#
+# Instructions:
+# 1. Login with "gh auth login"
+# 2. Copy this script to the kubernetes-csi directory (one directory above the
+# repos)
+# 3. Update the repos and versions in the $releases array
+# 4. Set environment variables
+# 5. Run script from the kubernetes-csi directory
+#
+# Caveats:
+# - This script doesn't handle regenerating and updating existing PRs yet.
+#   It might work if you comment out the PR creation line
+
+set -e
+set -x
+
+releases=(
+#  "external-attacher 4.4.1"
+#  "external-provisioner 3.6.1"
+#  "external-snapshotter 6.2.3"
+)
+
+function gen_patch_relnotes() {
+  rm out.md || true
+  rm -rf /tmp/k8s-repo || true
+  GITHUB_TOKEN="$CSI_RELEASE_TOKEN" \
+  release-notes --discover=patch-to-latest --branch="$2" \
+    --org=kubernetes-csi --repo="$1" \
+    --required-author="" --markdown-links --output out.md
+}
+
+for rel in "${releases[@]}"; do
+  read -r repo version <<< "$rel"
+
+  # Parse minor version
+  minorPattern="(^[[:digit:]]+\.[[:digit:]]+)\."
+  [[ "$version" =~ $minorPattern ]]
+  minor="${BASH_REMATCH[1]}"
+
+  echo "$repo" "$version" "$minor"
+
+  pushd "$repo/CHANGELOG"
+
+  git fetch upstream
+
+  # Create branch
+  branch="changelog-release-$minor"
+  git checkout master
+  git branch -D "$branch" || true
+  git checkout --track "upstream/release-$minor" -b "$branch"
+
+  # Generate release notes
+  gen_patch_relnotes "$repo" "release-$minor"
+  cat > tmp.md <<EOF
+# Release notes for v$version
+
+[Documentation](https://kubernetes-csi.github.io)
+
+EOF
+
+  cat out.md >> tmp.md
+  echo >> tmp.md
+
+  file="CHANGELOG-$minor.md"
+  cat "$file" >> tmp.md
+  mv tmp.md "$file"
+
+  git add -u
+  git commit -m "Add changelog for $version"
+  git push -f origin "$branch"
+
+  # Create PR
+prbody=$(cat <<EOF
+\`\`\`release-note
+NONE
+\`\`\`
+EOF
+)
+  gh pr create --title="Changelog for v$version" --body "$prbody"  --head "$GITHUB_USER:$branch" --base "release-$minor" --repo="kubernetes-csi/$repo"
+
+  popd
+done

--- a/release-tools/prow.sh
+++ b/release-tools/prow.sh
@@ -86,7 +86,7 @@ configvar CSI_PROW_BUILD_PLATFORMS "linux amd64 amd64; linux ppc64le ppc64le -pp
 # which is disabled with GOFLAGS=-mod=vendor).
 configvar GOFLAGS_VENDOR "$( [ -d vendor ] && echo '-mod=vendor' )" "Go flags for using the vendor directory"
 
-configvar CSI_PROW_GO_VERSION_BUILD "1.20" "Go version for building the component" # depends on component's source code
+configvar CSI_PROW_GO_VERSION_BUILD "1.21" "Go version for building the component" # depends on component's source code
 configvar CSI_PROW_GO_VERSION_E2E "" "override Go version for building the Kubernetes E2E test suite" # normally doesn't need to be set, see install_e2e
 configvar CSI_PROW_GO_VERSION_SANITY "${CSI_PROW_GO_VERSION_BUILD}" "Go version for building the csi-sanity test suite" # depends on CSI_PROW_SANITY settings below
 configvar CSI_PROW_GO_VERSION_KIND "${CSI_PROW_GO_VERSION_BUILD}" "Go version for building 'kind'" # depends on CSI_PROW_KIND_VERSION below
@@ -240,7 +240,7 @@ configvar CSI_PROW_SIDECAR_E2E_IMPORT_PATH "none" "CSI Sidecar E2E package"
 # of the cluster. The alternative would have been to (cross-)compile csi-sanity
 # and install it inside the cluster, which is not necessarily easier.
 configvar CSI_PROW_SANITY_REPO https://github.com/kubernetes-csi/csi-test "csi-test repo"
-configvar CSI_PROW_SANITY_VERSION v5.0.0 "csi-test version"
+configvar CSI_PROW_SANITY_VERSION v5.2.0 "csi-test version"
 configvar CSI_PROW_SANITY_PACKAGE_PATH github.com/kubernetes-csi/csi-test "csi-test package"
 configvar CSI_PROW_SANITY_SERVICE "hostpath-service" "Kubernetes TCP service name that exposes csi.sock"
 configvar CSI_PROW_SANITY_POD "csi-hostpathplugin-0" "Kubernetes pod with CSI driver"

--- a/release-tools/pull-test.sh
+++ b/release-tools/pull-test.sh
@@ -25,6 +25,7 @@ CSI_RELEASE_TOOLS_DIR="$(pwd)"
 
 # Update the other repo.
 cd "$PULL_TEST_REPO_DIR"
+git reset --hard # Shouldn't be necessary, but somehow is to avoid "fatal: working tree has modifications.  Cannot add." (https://stackoverflow.com/questions/3623351/git-subtree-pull-says-that-the-working-tree-has-modifications-but-git-status-sa)
 git subtree pull --squash --prefix=release-tools "$CSI_RELEASE_TOOLS_DIR" master
 git log -n2
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR updates release-tools.

```
Squashed 'release-tools/' changes from f9d5b9c0..f8c8cc4c
f8c8cc4c Merge pull request https://github.com/kubernetes-csi/external-snapshotter/pull/237 from msau42/prow
b36b5bfd Merge pull request https://github.com/kubernetes-csi/external-snapshotter/pull/240 from dannawang0221/upgrade-go-version
adfddcc9 Merge pull request https://github.com/kubernetes-csi/external-snapshotter/pull/243 from pohly/git-subtree-pull-fix
c4650889 pull-test.sh: avoid "git subtree pull" error
7b175a1e Update csi-test version to v5.2.0
987c90cc Update go version to 1.21 to match k/k
2c625d41 Add script to generate patch release notes

git-subtree-dir: release-tools
git-subtree-split: f8c8cc4c7414c11526f14649856ff8e6b8a4e67c
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
