### PR TITLE
Add VolumeGroupSnaphot examples

### DIFF
--- a/examples/kubernetes/groupsnapshot-v1alpha1.yaml
+++ b/examples/kubernetes/groupsnapshot-v1alpha1.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: groupsnapshot.storage.k8s.io/v1alpha1
+kind: VolumeGroupSnapshot
+metadata:
+  name: new-groupsnapshot-demo
+spec:
+  source:
+    selector:
+      matchLabels:
+        app.kubernetes.io/name: postgresql
+  volumeGroupSnapshotClassName: csi-hostpath-groupsnapclass

--- a/examples/kubernetes/groupsnapshot-v1alpha1.yaml
+++ b/examples/kubernetes/groupsnapshot-v1alpha1.yaml
@@ -7,5 +7,7 @@ spec:
   source:
     selector:
       matchLabels:
+        # The PVCs will need to have this label for it to be
+        # included in the VolumeGroupSnapshot
         app.kubernetes.io/name: postgresql
   volumeGroupSnapshotClassName: csi-hostpath-groupsnapclass

--- a/examples/kubernetes/groupsnapshotclass-v1alpha1.yaml
+++ b/examples/kubernetes/groupsnapshotclass-v1alpha1.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: groupsnapshot.storage.k8s.io/v1alpha1
+kind: VolumeGroupSnapshotClass
+metadata:
+  name: csi-hostpath-groupsnapclass
+driver: hostpath.csi.k8s.io
+deletionPolicy: Delete


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

This PR adds two examples of how a VolumeGroupSnapshotClass and a VolumeGroupSnapshot can be defined.
The examples use the CSI Hostpath Driver.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

NONE

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
