### PR TITLE
Add finalizer to prevent deletion of individual volume snapshots

### DIFF
--- a/pkg/common-controller/groupsnapshot_controller_helper.go
+++ b/pkg/common-controller/groupsnapshot_controller_helper.go
@@ -1114,6 +1114,9 @@ func (ctrl *csiSnapshotCommonController) processGroupSnapshotWithDeletionTimesta
 	for _, snapshotRef := range groupSnapshot.Status.VolumeSnapshotRefList {
 		snapshot, err := ctrl.snapshotLister.VolumeSnapshots(snapshotRef.Namespace).Get(snapshotRef.Name)
 		if err != nil {
+			if apierrs.IsNotFound(err) {
+				continue
+			}
 			return err
 		}
 		if ctrl.isVolumeBeingCreatedFromSnapshot(snapshot) {

--- a/pkg/sidecar-controller/groupsnapshot_helper.go
+++ b/pkg/sidecar-controller/groupsnapshot_helper.go
@@ -461,9 +461,10 @@ func (ctrl *csiSnapshotSideCarController) createGroupSnapshotWrapper(groupSnapsh
 		label["volumeGroupSnapshotName"] = groupSnapshotContent.Spec.VolumeGroupSnapshotRef.Name
 		volumeSnapshot := &crdv1.VolumeSnapshot{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      volumeSnapshotName,
-				Namespace: volumeSnapshotNamespace,
-				Labels:    label,
+				Name:       volumeSnapshotName,
+				Namespace:  volumeSnapshotNamespace,
+				Labels:     label,
+				Finalizers: []string{utils.VolumeSnapshotInGroupFinalizer},
 			},
 			Spec: crdv1.VolumeSnapshotSpec{
 				Source: crdv1.VolumeSnapshotSource{

--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -74,6 +74,8 @@ const (
 	VolumeSnapshotBoundFinalizer = "snapshot.storage.kubernetes.io/volumesnapshot-bound-protection"
 	// Name of finalizer on VolumeSnapshot that is used as a source to create a PVC
 	VolumeSnapshotAsSourceFinalizer = "snapshot.storage.kubernetes.io/volumesnapshot-as-source-protection"
+	// Name of finalizer on VolumeSnapshot that is a part of a VolumeGroupSnapshot
+	VolumeSnapshotInGroupFinalizer = "snapshot.storage.kubernetes.io/volumesnapshot-in-group-protection"
 	// Name of finalizer on PVCs that is being used as a source to create VolumeSnapshots
 	PVCFinalizer = "snapshot.storage.kubernetes.io/pvc-as-source-protection"
 	// Name of finalizer on VolumeGroupSnapshotContents that are bound by VolumeGroupSnapshots


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This PR adds a finaliser to volume snapshot objects that are part of a group snapshot. The finaliser is removed if the group snapshot is deleted.
This is to prevent individual snapshots from being deleted when the group snapshot still exists

**Testing**

Create a group snapshot:
```
% kubectl get vgs
NAME                READYTOUSE   VOLUMEGROUPSNAPSHOTCLASS   VOLUMEGROUPSNAPSHOTCONTENT                              CREATIONTIME   AGE
my-group-snapshot   true         vgs-class                  groupsnapcontent-eb950570-7be9-41c6-a1aa-363d20019095   3s             3s
% kubectl get vs
NAME                                                                                           READYTOUSE   SOURCEPVC   SOURCESNAPSHOTCONTENT                                                                             RESTORESIZE   SNAPSHOTCLASS   SNAPSHOTCONTENT                                                                                   CREATIONTIME   AGE
snapshot-16f64470380b9fadfd5c37aefd2169e56cdd59dbe6c36a3fd1f5cba8203e9241-2023-12-07-12.20.9   true                     snapcontent-16f64470380b9fadfd5c37aefd2169e56cdd59dbe6c36a3fd1f5cba8203e9241-2023-12-07-12.20.9   1Gi                           snapcontent-16f64470380b9fadfd5c37aefd2169e56cdd59dbe6c36a3fd1f5cba8203e9241-2023-12-07-12.20.9   11s            11s
snapshot-cfb80f3c4fe5ad13011e84ed233998ebc58c13b80d7d9c70915cf342d823cf68-2023-12-07-12.20.9   true                     snapcontent-cfb80f3c4fe5ad13011e84ed233998ebc58c13b80d7d9c70915cf342d823cf68-2023-12-07-12.20.9   1Gi                           snapcontent-cfb80f3c4fe5ad13011e84ed233998ebc58c13b80d7d9c70915cf342d823cf68-2023-12-07-12.20.9   11s            11s
```

Delete a volume snapshot and view events:
```
% kubectl delete vs snapshot-16f64470380b9fadfd5c37aefd2169e56cdd59dbe6c36a3fd1f5cba8203e9241-2023-12-07-12.20.9
'volumesnapshot.snapshot.storage.k8s.io "snapshot-16f64470380b9fadfd5c37aefd2169e56cdd59dbe6c36a3fd1f5cba8203e9241-2023-12-07-12.20.9" deleted
^C
% kubectl describe vs snapshot-16f64470380b9fadfd5c37aefd2169e56cdd59dbe6c36a3fd1f5cba8203e9241-2023-12-07-12.20.9
...
Events:
  Type     Reason                 Age              From                 Message
  ----     ------                 ----             ----                 -------
  Normal   SnapshotCreated        38s              snapshot-controller  Snapshot default/snapshot-16f64470380b9fadfd5c37aefd2169e56cdd59dbe6c36a3fd1f5cba8203e9241-2023-12-07-12.20.9 was successfully created by the CSI driver.
  Normal   SnapshotReady          38s              snapshot-controller  Snapshot default/snapshot-16f64470380b9fadfd5c37aefd2169e56cdd59dbe6c36a3fd1f5cba8203e9241-2023-12-07-12.20.9 is ready to use.
  Warning  SnapshotDeletePending  2s (x3 over 5s)  snapshot-controller  deletion of the individual volume snapshot default/snapshot-16f64470380b9fadfd5c37aefd2169e56cdd59dbe6c36a3fd1f5cba8203e9241-2023-12-07-12.20.9 is not allowed as it belongs to group snapshot default/my-group-snapshot. Deleting the group snapshot will trigger the deletion of all the individual volume snapshots that are part of the group
```

Delete group snapshot and validate that all resources are deleted:
```
% kubectl delete -f volumegroupsnapshot-example.yaml 
volumegroupsnapshot.groupsnapshot.storage.k8s.io "my-group-snapshot" deleted
% kubectl get vgs
No resources found in default namespace.
% kubectl get vgsc
No resources found
% kubectl get vs
No resources found in default namespace.
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add finalizer to prevent deletion of individual volume snapshots that are part of a group
```
