### PR TITLE
Update VolumeSnapshot and VolumeSnapshotContent using JSON patch

### DIFF
--- a/pkg/common-controller/snapshot_finalizer_test.go
+++ b/pkg/common-controller/snapshot_finalizer_test.go
@@ -17,10 +17,9 @@ limitations under the License.
 package common_controller
 
 import (
-	"testing"
-
 	"github.com/kubernetes-csi/external-snapshotter/v6/pkg/utils"
 	v1 "k8s.io/api/core/v1"
+	"testing"
 )
 
 // Test single call to ensurePVCFinalizer, checkandRemovePVCFinalizer, addSnapshotFinalizer, removeSnapshotFinalizer


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR replaces the Update calls for VolumeSnapshot and VolumeSnapshotContent with JSON patch calls. Addresses the "object has been modified" issue we see a lot in the snapshot-controller/snapshotter.

**Which issue(s) this PR fixes**:
Partial fix (only for Update() calls) https://github.com/kubernetes-csi/external-snapshotter/issues/748

**Special notes for your reviewer**:
N/A

**Does this PR introduce a user-facing change?**:

```release-note
Cherry-pick from PR 876: Update VolumeSnapshot and VolumeSnapshotContent using JSON patch
```