### PR TITLE
Fix the max duration to wait for CRDs in the snapshot-controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Read more about how to install the example webhook [here](deploy/kubernetes/webh
 
 ##### Volume Snapshot Classes
 
-* There can only be a single default volume snapshot class for a particular driver. 
+* There can only be a single default volume snapshot class for a particular driver.
 
 ### Distributed Snapshotting
 
@@ -139,11 +139,11 @@ The distributed snapshotting feature is provided to handle snapshot operations f
 
 #### Snapshot controller option
 
-* `--enable-distributed-snapshotting`: This option lets the snapshot controller know that distributed snapshotting is enabled and the snapshotter sidecar will be running on each node. Off by default. 
+* `--enable-distributed-snapshotting`: This option lets the snapshot controller know that distributed snapshotting is enabled and the snapshotter sidecar will be running on each node. Off by default.
 
 #### CSI external snapshotter sidecar option
 
-* `--node-deployment`: Enables the snapshotter sidecar to handle snapshot operations for the volumes local to the node on which it is deployed. Off by default. 
+* `--node-deployment`: Enables the snapshotter sidecar to handle snapshot operations for the volumes local to the node on which it is deployed. Off by default.
 
 Other than this, the NODE_NAME environment variable must be set where the CSI snapshotter sidecar is deployed. The value of NODE_NAME should be the name of the node where the sidecar is running.
 
@@ -174,7 +174,7 @@ Other than this, the NODE_NAME environment variable must be set where the CSI sn
 
 * `--retry-interval-max`: Maximum retry interval of failed volume snapshot creation or deletion. Default value is 5 minutes.
 
-* `--retry-crd-interval-max`: Maximum retry interval for detecting the snapshot CRDs on controller startup. Default is 5 seconds.
+* `--retry-crd-interval-max`: Maximum retry duration for detecting the snapshot CRDs on controller startup. Default is 30 seconds.
 
 * `--enable-distributed-snapshotting` : Enables each node to handle snapshots for the volumes local to that node. Off by default. It should be set to true only if `--node-deployment` parameter for the csi external snapshotter sidecar is set to true. See https://github.com/kubernetes-csi/external-snapshotter/blob/master/README.md#distributed-snapshotting for details.
 

--- a/cmd/snapshot-controller/main.go
+++ b/cmd/snapshot-controller/main.go
@@ -74,46 +74,49 @@ var (
 	preventVolumeModeConversion   = flag.Bool("prevent-volume-mode-conversion", true, "Prevents an unauthorised user from modifying the volume mode when creating a PVC from an existing VolumeSnapshot.")
 	enableVolumeGroupSnapshots    = flag.Bool("enable-volume-group-snapshots", false, "Enables the volume group snapshot feature, allowing the user to create a snapshot of a group of volumes.")
 
-	retryCRDIntervalMax = flag.Duration("retry-crd-interval-max", 5*time.Second, "Maximum retry interval to wait for CRDs to appear. The default is 5 seconds.")
+	retryCRDIntervalMax = flag.Duration("retry-crd-interval-max", 30*time.Second, "Maximum time to wait for CRDs to appear. The default is 30 seconds.")
 )
 
 var version = "unknown"
 
-// Checks that the VolumeSnapshot v1 CRDs exist.
+// Checks that the VolumeSnapshot v1 CRDs exist. It will wait at most the duration specified by retryCRDIntervalMax
 func ensureCustomResourceDefinitionsExist(client *clientset.Clientset, enableVolumeGroupSnapshots bool) error {
-	condition := func() (bool, error) {
+	condition := func(ctx context.Context) (bool, error) {
 		var err error
+		// List calls should return faster with a limit of 0.
+		// We do not care about what is returned and just want to make sure the CRDs exist.
+		listOptions := metav1.ListOptions{Limit: 0}
 
 		// scoping to an empty namespace makes `List` work across all namespaces
-		_, err = client.SnapshotV1().VolumeSnapshots("").List(context.TODO(), metav1.ListOptions{})
+		_, err = client.SnapshotV1().VolumeSnapshots("").List(ctx, listOptions)
 		if err != nil {
 			klog.Errorf("Failed to list v1 volumesnapshots with error=%+v", err)
 			return false, nil
 		}
 
-		_, err = client.SnapshotV1().VolumeSnapshotClasses().List(context.TODO(), metav1.ListOptions{})
+		_, err = client.SnapshotV1().VolumeSnapshotClasses().List(ctx, listOptions)
 		if err != nil {
 			klog.Errorf("Failed to list v1 volumesnapshotclasses with error=%+v", err)
 			return false, nil
 		}
-		_, err = client.SnapshotV1().VolumeSnapshotContents().List(context.TODO(), metav1.ListOptions{})
+		_, err = client.SnapshotV1().VolumeSnapshotContents().List(ctx, listOptions)
 		if err != nil {
 			klog.Errorf("Failed to list v1 volumesnapshotcontents with error=%+v", err)
 			return false, nil
 		}
 		if enableVolumeGroupSnapshots {
-			_, err = client.GroupsnapshotV1alpha1().VolumeGroupSnapshots("").List(context.TODO(), metav1.ListOptions{})
+			_, err = client.GroupsnapshotV1alpha1().VolumeGroupSnapshots("").List(ctx, listOptions)
 			if err != nil {
 				klog.Errorf("Failed to list v1alpha1 volumegroupsnapshots with error=%+v", err)
 				return false, nil
 			}
 
-			_, err = client.GroupsnapshotV1alpha1().VolumeGroupSnapshotClasses().List(context.TODO(), metav1.ListOptions{})
+			_, err = client.GroupsnapshotV1alpha1().VolumeGroupSnapshotClasses().List(ctx, listOptions)
 			if err != nil {
 				klog.Errorf("Failed to list v1alpha1 volumegroupsnapshotclasses with error=%+v", err)
 				return false, nil
 			}
-			_, err = client.GroupsnapshotV1alpha1().VolumeGroupSnapshotContents().List(context.TODO(), metav1.ListOptions{})
+			_, err = client.GroupsnapshotV1alpha1().VolumeGroupSnapshotContents().List(ctx, listOptions)
 			if err != nil {
 				klog.Errorf("Failed to list v1alpha1 volumegroupsnapshotcontents with error=%+v", err)
 				return false, nil
@@ -123,24 +126,19 @@ func ensureCustomResourceDefinitionsExist(client *clientset.Clientset, enableVol
 		return true, nil
 	}
 
-	// The maximum retry duration = initial duration * retry factor ^ # steps. Rearranging, this gives
-	// # steps = log(maximum retry / initial duration) / log(retry factor).
 	const retryFactor = 1.5
-	const initialDurationMs = 100
-	maxMs := retryCRDIntervalMax.Milliseconds()
-	if maxMs < initialDurationMs {
-		maxMs = initialDurationMs
-	}
-	steps := int(math.Ceil(math.Log(float64(maxMs)/initialDurationMs) / math.Log(retryFactor)))
-	if steps < 1 {
-		steps = 1
-	}
+	const initialDuration = 100 * time.Millisecond
 	backoff := wait.Backoff{
-		Duration: initialDurationMs * time.Millisecond,
+		Duration: initialDuration,
 		Factor:   retryFactor,
-		Steps:    steps,
+		Steps:    math.MaxInt32, // effectively no limit until the timeout is reached
 	}
-	if err := wait.ExponentialBackoff(backoff, condition); err != nil {
+
+	// Sanity check to make sure we have a minimum duration of 1 second to work with
+	maxBackoffDuration := max(*retryCRDIntervalMax, 1*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), maxBackoffDuration)
+	defer cancel()
+	if err := wait.ExponentialBackoffWithContext(ctx, backoff, condition); err != nil {
 		return err
 	}
 

--- a/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml
+++ b/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml
@@ -16,10 +16,11 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: snapshot-controller
-  # the snapshot controller won't be marked as ready if the v1 CRDs are unavailable
-  # in #504 the snapshot-controller will exit after around 7.5 seconds if it
-  # can't find the v1 CRDs so this value should be greater than that
-  minReadySeconds: 15
+  # The snapshot controller won't be marked as ready if the v1 CRDs are unavailable.
+  # The flag --retry-crd-interval-max is used to determine how long the controller
+  # will wait for the CRDs to become available before exiting. The default is 30 seconds
+  # so minReadySeconds should be set slightly higher than the flag value.
+  minReadySeconds: 35
   strategy:
     rollingUpdate:
       maxSurge: 0


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:

Based on my understanding of the flag `retry-crd-interval-max` (see #980), this PR will ensure that the function `ensureCustomResourceDefinitionsExist` returns when the duration specified in `retryCRDIntervalMax` flag is reached. This works using by passing a context to the backoff so that we can simply timeout with context.WithTimeout (and not too complicated computations that may or may not do what we want).
Also limit the amount of resources returned by the list calls to 0 to speed up the operations because we only care that the CRD exists and not about the number of results.
It changes the default value of the flag to `30s` for 2 reasons:
- the timeout includes a bunch network calls to the apiserver. Network being notoriously slower than CPU, I believe 30s is the default timeout for api calls so it gives us time to wait for 1 complete timeout
- this will give more time for the CRDs to appear when they are created at the same time as the snapshot controller

With this PR, the new behavior is as follow:
- normal:
```
❯ kubectl logs snapshot-controller-5699b76477-vz6v5
I1222 13:43:13.513998       1 main.go:140] Version:
I1222 13:43:13.514943       1 main.go:183] Metrics path successfully registered at /metrics
I1222 13:43:13.553446       1 main.go:248] Metrics http server successfully started on :8080, /metrics
I1222 13:43:13.553709       1 leaderelection.go:250] attempting to acquire leader lease kube-system/snapshot-controller-leader...
I1222 13:43:43.435001       1 leaderelection.go:260] successfully acquired lease kube-system/snapshot-controller-leader
I1222 13:43:43.436397       1 snapshot_controller_base.go:212] Starting snapshot controller
```
- network timeout (fails after 10s and 1 step):
```
❯ kubectl logs snapshot-controller-5699b76477-crr4z
I1222 13:33:29.278744       1 main.go:140] Version:
I1222 13:33:29.280018       1 main.go:183] Metrics path successfully registered at /metrics
E1222 13:33:39.289596       1 main.go:94] Failed to list v1 volumesnapshots with error=Get "https://172.17.0.1:443/apis/snapshot.storage.k8s.io/v1/volumesnapshots": context deadline exceeded
E1222 13:33:39.289628       1 main.go:217] Exiting due to failure to ensure CRDs exist during startup: context deadline exceeded
```
- missing CRD (fails after 10s and 10 steps):
```
❯ kubectl logs snapshot-controller-5699b76477-xcpj9
I1222 13:39:24.679192       1 main.go:140] Version:
I1222 13:39:24.680276       1 main.go:183] Metrics path successfully registered at /metrics
E1222 13:39:24.693060       1 main.go:94] Failed to list v1 volumesnapshots with error=volumesnapshots.snapshot.storage.k8s.io is forbidden: User "system:serviceaccount:snapshot-controller" cannot list resource "volumesnapshots" in API group "snapshot.storage.k8s.io" at the cluster scope
E1222 13:39:24.794276       1 main.go:94] Failed to list v1 volumesnapshots with error=volumesnapshots.snapshot.storage.k8s.io is forbidden: User "system:serviceaccount:snapshot-controller" cannot list resource "volumesnapshots" in API group "snapshot.storage.k8s.io" at the cluster scope
E1222 13:39:24.945760       1 main.go:94] Failed to list v1 volumesnapshots with error=volumesnapshots.snapshot.storage.k8s.io is forbidden: User "system:serviceaccount:snapshot-controller" cannot list resource "volumesnapshots" in API group "snapshot.storage.k8s.io" at the cluster scope
E1222 13:39:25.172186       1 main.go:94] Failed to list v1 volumesnapshots with error=volumesnapshots.snapshot.storage.k8s.io is forbidden: User "system:serviceaccount:snapshot-controller" cannot list resource "volumesnapshots" in API group "snapshot.storage.k8s.io" at the cluster scope
E1222 13:39:25.511779       1 main.go:94] Failed to list v1 volumesnapshots with error=volumesnapshots.snapshot.storage.k8s.io is forbidden: User "system:serviceaccount:snapshot-controller" cannot list resource "volumesnapshots" in API group "snapshot.storage.k8s.io" at the cluster scope
E1222 13:39:26.019556       1 main.go:94] Failed to list v1 volumesnapshots with error=volumesnapshots.snapshot.storage.k8s.io is forbidden: User "system:serviceaccount:snapshot-controller" cannot list resource "volumesnapshots" in API group "snapshot.storage.k8s.io" at the cluster scope
E1222 13:39:26.781178       1 main.go:94] Failed to list v1 volumesnapshots with error=volumesnapshots.snapshot.storage.k8s.io is forbidden: User "system:serviceaccount:snapshot-controller" cannot list resource "volumesnapshots" in API group "snapshot.storage.k8s.io" at the cluster scope
E1222 13:39:27.921712       1 main.go:94] Failed to list v1 volumesnapshots with error=volumesnapshots.snapshot.storage.k8s.io is forbidden: User "system:serviceaccount:snapshot-controller" cannot list resource "volumesnapshots" in API group "snapshot.storage.k8s.io" at the cluster scope
E1222 13:39:29.631696       1 main.go:94] Failed to list v1 volumesnapshots with error=volumesnapshots.snapshot.storage.k8s.io is forbidden: User "system:serviceaccount:snapshot-controller" cannot list resource "volumesnapshots" in API group "snapshot.storage.k8s.io" at the cluster scope
E1222 13:39:32.196718       1 main.go:94] Failed to list v1 volumesnapshots with error=volumesnapshots.snapshot.storage.k8s.io is forbidden: User "system:serviceaccount:snapshot-controller" cannot list resource "volumesnapshots" in API group "snapshot.storage.k8s.io" at the cluster scope
E1222 13:39:34.681660       1 main.go:217] Exiting due to failure to ensure CRDs exist during startup: context deadline exceeded
```

**Which issue(s) this PR fixes**:

Fixes #980 and #981 

**Special notes for your reviewer**:
Maybe this would need a separate flag like `retry-crd-max-duration` instead of reusing the previous unclear `retry-crd-interval-max` flag but I'm not sure. Open to suggestions on that.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixed the max duration to wait for CRDs to appear especially in case of the apiserver being unreachable
```
