### PR TITLE
Add nil check for SourceVolumeMode in the ValidationWebHook

### DIFF
--- a/pkg/validation-webhook/snapshot.go
+++ b/pkg/validation-webhook/snapshot.go
@@ -246,8 +246,12 @@ func checkSnapshotContentImmutableFieldsV1(snapcontent, oldSnapcontent *volumesn
 	}
 
 	if preventVolumeModeConversion {
-		if !reflect.DeepEqual(snapcontent.Spec.SourceVolumeMode, oldSnapcontent.Spec.SourceVolumeMode) {
+		if oldSnapcontent.Spec.SourceVolumeMode != nil && snapcontent.Spec.SourceVolumeMode != nil && !reflect.DeepEqual(snapcontent.Spec.SourceVolumeMode, oldSnapcontent.Spec.SourceVolumeMode) {
 			return fmt.Errorf("Spec.SourceVolumeMode is immutable but was changed from %v to %v", *oldSnapcontent.Spec.SourceVolumeMode, *snapcontent.Spec.SourceVolumeMode)
+		} else if oldSnapcontent.Spec.SourceVolumeMode == nil && snapcontent.Spec.SourceVolumeMode != nil {
+			return fmt.Errorf("Spec.SourceVolumeMode is immutable but was changed from nil to %v", *snapcontent.Spec.SourceVolumeMode)
+		} else if oldSnapcontent.Spec.SourceVolumeMode != nil && snapcontent.Spec.SourceVolumeMode == nil {
+			return fmt.Errorf("Spec.SourceVolumeMode is immutable but was changed from %v to nil", *oldSnapcontent.Spec.SourceVolumeMode)
 		}
 	}
 


### PR DESCRIPTION
(cherry picked from commit 36738cd8bc99a39149db514ea95f1e317d119546)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Cherry-pick from PR [#1005](https://github.com/kubernetes-csi/external-snapshotter/pull/1005). Fixes a panic in the snapshot validation webhook.
```
