### PR TITLE
Discard unnecessary VolumeSnapshotContent updates to prevent rapid RPC calls

### DIFF
--- a/pkg/utils/util_test.go
+++ b/pkg/utils/util_test.go
@@ -302,3 +302,220 @@ func TestIsDefaultAnnotation(t *testing.T) {
 		}
 	}
 }
+
+func TestShouldEnqueueContentChange(t *testing.T) {
+	oldValue := "old"
+	newValue := "new"
+
+	testcases := []struct {
+		name           string
+		old            *crdv1.VolumeSnapshotContent
+		new            *crdv1.VolumeSnapshotContent
+		expectedResult bool
+	}{
+		{
+			name:           "basic no change",
+			old:            &crdv1.VolumeSnapshotContent{},
+			new:            &crdv1.VolumeSnapshotContent{},
+			expectedResult: false,
+		},
+		{
+			name: "basic change",
+			old: &crdv1.VolumeSnapshotContent{
+				Spec: crdv1.VolumeSnapshotContentSpec{
+					VolumeSnapshotClassName: &oldValue,
+				},
+			},
+			new: &crdv1.VolumeSnapshotContent{
+				Spec: crdv1.VolumeSnapshotContentSpec{
+					VolumeSnapshotClassName: &newValue,
+				},
+			},
+			expectedResult: true,
+		},
+		{
+			name: "status change",
+			old: &crdv1.VolumeSnapshotContent{
+				Status: &crdv1.VolumeSnapshotContentStatus{
+					Error: &crdv1.VolumeSnapshotError{
+						Message: &oldValue,
+					},
+				},
+			},
+			new: &crdv1.VolumeSnapshotContent{
+				Status: &crdv1.VolumeSnapshotContentStatus{
+					Error: &crdv1.VolumeSnapshotError{
+						Message: &newValue,
+					},
+				},
+			},
+			expectedResult: false,
+		},
+		{
+			name: "finalizers change",
+			old: &crdv1.VolumeSnapshotContent{
+				ObjectMeta: metav1.ObjectMeta{
+					Finalizers: []string{
+						oldValue,
+					},
+				},
+			},
+			new: &crdv1.VolumeSnapshotContent{
+				ObjectMeta: metav1.ObjectMeta{
+					Finalizers: []string{
+						newValue,
+					},
+				},
+			},
+			expectedResult: false,
+		},
+		{
+			name: "managed fields change",
+			old: &crdv1.VolumeSnapshotContent{
+				ObjectMeta: metav1.ObjectMeta{
+					ManagedFields: []metav1.ManagedFieldsEntry{
+						{
+							Manager: oldValue,
+						},
+					},
+				},
+			},
+			new: &crdv1.VolumeSnapshotContent{
+				ObjectMeta: metav1.ObjectMeta{
+					ManagedFields: []metav1.ManagedFieldsEntry{
+						{
+							Manager: newValue,
+						},
+					},
+				},
+			},
+			expectedResult: false,
+		},
+		{
+			name: "sidecar-managed annotation change",
+			old: &crdv1.VolumeSnapshotContent{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						AnnVolumeSnapshotBeingCreated: oldValue,
+					},
+				},
+			},
+			new: &crdv1.VolumeSnapshotContent{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						AnnVolumeSnapshotBeingCreated: newValue,
+					},
+				},
+			},
+			expectedResult: false,
+		},
+		{
+			name: "sidecar-unmanaged annotation change",
+			old: &crdv1.VolumeSnapshotContent{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"test-annotation": oldValue,
+					},
+				},
+			},
+			new: &crdv1.VolumeSnapshotContent{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"test-annotation": newValue,
+					},
+				},
+			},
+			expectedResult: true,
+		},
+		{
+			name: "sidecar-managed annotation created",
+			old: &crdv1.VolumeSnapshotContent{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: nil,
+				},
+			},
+			new: &crdv1.VolumeSnapshotContent{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						AnnVolumeSnapshotBeingCreated: newValue,
+					},
+				},
+			},
+			expectedResult: false,
+		},
+		{
+			name: "sidecar-unmanaged annotation created",
+			old: &crdv1.VolumeSnapshotContent{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: nil,
+				},
+			},
+			new: &crdv1.VolumeSnapshotContent{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"test-annotation": newValue,
+					},
+				},
+			},
+			expectedResult: true,
+		},
+		{
+			name: "sidecar-managed annotation deleted",
+			old: &crdv1.VolumeSnapshotContent{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						AnnVolumeSnapshotBeingCreated: oldValue,
+					},
+				},
+			},
+			new: &crdv1.VolumeSnapshotContent{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: nil,
+				},
+			},
+			expectedResult: false,
+		},
+		{
+			name: "sidecar-unmanaged annotation deleted",
+			old: &crdv1.VolumeSnapshotContent{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"test-annotation": oldValue,
+					},
+				},
+			},
+			new: &crdv1.VolumeSnapshotContent{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: nil,
+				},
+			},
+			expectedResult: true,
+		},
+		{
+			name: "sidecar-unmanaged annotation change (AnnVolumeSnapshotBeingDeleted)",
+			old: &crdv1.VolumeSnapshotContent{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						AnnVolumeSnapshotBeingDeleted: oldValue,
+					},
+				},
+			},
+			new: &crdv1.VolumeSnapshotContent{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						AnnVolumeSnapshotBeingDeleted: newValue,
+					},
+				},
+			},
+			expectedResult: true,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := ShouldEnqueueContentChange(tc.old, tc.new)
+			if result != tc.expectedResult {
+				t.Fatalf("Incorrect result: Expected %v received %v", tc.expectedResult, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

In many scenarios, the `csi-snapshotter` sidecar will enqueue a `VolumeSnapshotContent` object in rapid succession, causing a flood of RPC requests to the attached CSI Driver.

The most user-visible subset of this, when the CSI driver fails the request, has been reported and attempted to be fixed twice: #463 and #778. However, neither of the fixes completely fix the issue, *which occurs even when the CSI driver does not return an error*.

The most basic and common version of this issue is as follows:
1. A `VolumeSnapshotContent` object is enqueued (for example, because it is created)
2. Very early on in this process, the `csi-snapshotter` will update the status of the content https://github.com/kubernetes-csi/external-snapshotter/blob/ebf903ae5f0fa9dca7280adbb7bc681b15ac5c1f/pkg/sidecar-controller/snapshot_controller.go#L296
3. This update causes the `csi-snapshotter`'s own informer to fire https://github.com/kubernetes-csi/external-snapshotter/blob/ebf903ae5f0fa9dca7280adbb7bc681b15ac5c1f/pkg/sidecar-controller/snapshot_controller_base.go#L118-L127
4. The informer, seeing that there's no error, enqueues the snapshot
5. Go back to step 1

This loop will constantly spam the attached CSI driver with `CreateSnasphot` RPC calls until the snapshot actually is created (at which point, the sync will realize there's no action to take because the snapshot already exists, breaking out of the loop).

You can very easily see this by upping the verbosity on the `csi-snapshotter` to 5, example log:
```
I0213 21:04:42.424486       1 main.go:109] Version: v6.3.3
I0213 21:04:42.427776       1 common.go:138] Probing CSI driver for readiness
I0213 21:04:42.430452       1 leaderelection.go:250] attempting to acquire leader lease kube-system/external-snapshotter-leader-ebs-csi-aws-com...
I0213 21:04:58.343183       1 leaderelection.go:260] successfully acquired lease kube-system/external-snapshotter-leader-ebs-csi-aws-com
I0213 21:04:58.343743       1 snapshot_controller_base.go:170] Starting CSI snapshotter
I0213 21:05:20.970965       1 snapshot_controller.go:291] createSnapshotWrapper: Creating snapshot for content snapcontent-327fb0c7-f069-45a7-ad95-eb6edeac8bb6 through the plugin ...
I0213 21:05:21.471960       1 snapshot_controller.go:291] createSnapshotWrapper: Creating snapshot for content snapcontent-327fb0c7-f069-45a7-ad95-eb6edeac8bb6 through the plugin ...
I0213 21:05:21.572808       1 snapshot_controller.go:291] createSnapshotWrapper: Creating snapshot for content snapcontent-327fb0c7-f069-45a7-ad95-eb6edeac8bb6 through the plugin ...
I0213 21:05:21.629789       1 snapshot_controller.go:291] createSnapshotWrapper: Creating snapshot for content snapcontent-327fb0c7-f069-45a7-ad95-eb6edeac8bb6 through the plugin ...
I0213 21:05:21.691748       1 snapshot_controller.go:291] createSnapshotWrapper: Creating snapshot for content snapcontent-327fb0c7-f069-45a7-ad95-eb6edeac8bb6 through the plugin ...
(... many many more repeats, cut for brevity ...)
```

**How does this PR fix the bug?**:

This PR adopts a similar approach to that used in other sidecars (for example the `external-attacher`'s implementation of this idea: https://github.com/kubernetes-csi/external-attacher/blob/41cb23d3172818737b6573112219f443de3a6bf8/pkg/controller/controller.go#L282-L304). Changes in fields that we do not care about (and thus should not enqueue to sync for) are sanitized - specifically the following changes:
- Resource version (always changes between different k8s objects)
- Status (controlled entirely by the `csi-snapshotter` sidecar)
- Managed fields (not relevant for sync purposes, sometimes updated by the sidecar)
- Finalizers (not relevant for sync purposes, sometimes updated by the sidecar)
- Sidecar-controlled annotations (annotations that the sidecar itself adds are ignored)

The `VolumeSnapshotContent` is enqueued for sync only if there is still a difference after sanitization.

**Does this PR introduce a user-facing change?**:
```release-note
Fixed a bug in the csi-snapshotter sidecar causing it to rapidly make RPC calls to CSI drivers due to its own updates to VolumeSnapshotContent objects
```
