### PR TITLE
Add snapshot size to VSC created for VGS

### DIFF
--- a/pkg/sidecar-controller/groupsnapshot_helper.go
+++ b/pkg/sidecar-controller/groupsnapshot_helper.go
@@ -477,6 +477,11 @@ func (ctrl *csiSnapshotSideCarController) createGroupSnapshotWrapper(groupSnapsh
 		if err != nil {
 			return groupSnapshotContent, err
 		}
+
+		_, err = ctrl.updateSnapshotContentStatus(volumeSnapshotContent, snapshot.SnapshotId, snapshot.ReadyToUse, snapshot.CreationTime.AsTime().UnixNano(), snapshot.SizeBytes, groupSnapshotID)
+		if err != nil {
+			return groupSnapshotContent, err
+		}
 	}
 
 	newGroupSnapshotContent, err := ctrl.updateGroupSnapshotContentStatus(groupSnapshotContent, groupSnapshotID, readyToUse, creationTime.UnixNano(), snapshotContentNames)

--- a/pkg/sidecar-controller/snapshot_controller.go
+++ b/pkg/sidecar-controller/snapshot_controller.go
@@ -446,10 +446,12 @@ func (ctrl *csiSnapshotSideCarController) updateSnapshotContentStatus(
 			SnapshotHandle: &snapshotHandle,
 			ReadyToUse:     &readyToUse,
 			CreationTime:   &createdAt,
-			RestoreSize:    &size,
 		}
 		if groupSnapshotID != "" {
 			newStatus.VolumeGroupSnapshotHandle = &groupSnapshotID
+		}
+		if size > 0 {
+			newStatus.RestoreSize = &size
 		}
 		updated = true
 	} else {
@@ -469,7 +471,7 @@ func (ctrl *csiSnapshotSideCarController) updateSnapshotContentStatus(
 			newStatus.CreationTime = &createdAt
 			updated = true
 		}
-		if newStatus.RestoreSize == nil {
+		if newStatus.RestoreSize == nil && size > 0 {
 			newStatus.RestoreSize = &size
 			updated = true
 		}


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

Currently the RestoreSize is missing when the corresponding VSC are created for the the volumesnapshotgroup, This PR adds the missing RestoreSize for VSC.

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

 /kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1002

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
This change will update the Restore size in volumesnapshotcontent to the size it's received from the CSI driver. If `0` is received, it won't be added to the Restore size as it means it is unspecified as per CSI spec.
```
