### PR TITLE
Use patch instead of update for GroupSnapshots, VolumeSnapshots, PVCs

### DIFF
--- a/pkg/common-controller/framework_test.go
+++ b/pkg/common-controller/framework_test.go
@@ -498,7 +498,7 @@ func (r *snapshotReactor) React(action core.Action) (handled bool, ret runtime.O
 		r.changedObjects = append(r.changedObjects, claim)
 		r.changedSinceLastSync++
 		klog.V(4).Infof("saved updated claim %s", claim.Name)
-		return 
+		return
 
 	case action.Matches("get", "secrets"):
 		name := action.(core.GetAction).GetName()

--- a/pkg/common-controller/framework_test.go
+++ b/pkg/common-controller/framework_test.go
@@ -1299,16 +1299,13 @@ func testSyncContentError(ctrl *csiSnapshotCommonController, reactor *snapshotRe
 }
 
 func testAddPVCFinalizer(ctrl *csiSnapshotCommonController, reactor *snapshotReactor, test controllerTest) error {
-	thisTestVolumeSnapshot = test.initialSnapshots[0]
 	return ctrl.ensurePVCFinalizer(test.initialSnapshots[0])
 }
 
 func testRemovePVCFinalizer(ctrl *csiSnapshotCommonController, reactor *snapshotReactor, test controllerTest) error {
 	return ctrl.checkandRemovePVCFinalizer(test.initialSnapshots[0], false)
 }
-var thisTestVolumeSnapshot *crdv1.VolumeSnapshot
 func testAddSnapshotFinalizer(ctrl *csiSnapshotCommonController, reactor *snapshotReactor, test controllerTest) error {
-	thisTestVolumeSnapshot = test.initialSnapshots[0]
 	return ctrl.addSnapshotFinalizer(test.initialSnapshots[0], true, true)
 }
 

--- a/pkg/common-controller/groupsnapshot_controller_helper.go
+++ b/pkg/common-controller/groupsnapshot_controller_helper.go
@@ -953,21 +953,7 @@ func (ctrl *csiSnapshotCommonController) needsUpdateGroupSnapshotStatus(groupSna
 // addGroupSnapshotContentFinalizer adds a Finalizer for VolumeGroupSnapshotContent.
 func (ctrl *csiSnapshotCommonController) addGroupSnapshotContentFinalizer(groupSnapshotContent *crdv1alpha1.VolumeGroupSnapshotContent) error {
 	var patches []utils.PatchOp
-	if len(groupSnapshotContent.Finalizers) > 0 {
-		// Add to the end of the finalizers if we have any other finalizers
-		patches = append(patches, utils.PatchOp{
-			Op:    "add",
-			Path:  "/metadata/finalizers/-",
-			Value: utils.VolumeGroupSnapshotContentFinalizer,
-		})
-	} else {
-		// Replace finalizers with new array if there are no other finalizers
-		patches = append(patches, utils.PatchOp{
-			Op:    "add",
-			Path:  "/metadata/finalizers",
-			Value: []string{utils.VolumeGroupSnapshotContentFinalizer},
-		})
-	}
+	patches = append(patches, utils.PatchOpsToAddFinalizers(groupSnapshotContent, utils.VolumeGroupSnapshotContentFinalizer)...)
 	newGroupSnapshotContent, err := utils.PatchVolumeGroupSnapshotContent(groupSnapshotContent, patches, ctrl.clientset)
 	if err != nil {
 		return newControllerUpdateError(groupSnapshotContent.Name, err.Error())
@@ -1020,11 +1006,7 @@ func (ctrl *csiSnapshotCommonController) addGroupSnapshotFinalizer(groupSnapshot
 	var patches []utils.PatchOp
 
 	if addBoundFinalizer {
-		patches = append(patches, utils.PatchOp{
-			Op:    "add",
-			Path:  "/metadata/finalizers/-",
-			Value: utils.VolumeGroupSnapshotBoundFinalizer,
-		})
+		patches = append(patches, utils.PatchOpsToAddFinalizers(groupSnapshot, utils.VolumeGroupSnapshotBoundFinalizer)...)
 	}
 
 	updatedGroupSnapshot, err = utils.PatchVolumeGroupSnapshot(groupSnapshot, patches, ctrl.clientset)

--- a/pkg/common-controller/groupsnapshot_controller_helper_test.go
+++ b/pkg/common-controller/groupsnapshot_controller_helper_test.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common_controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	crdv1alpha1 "github.com/kubernetes-csi/external-snapshotter/client/v7/apis/volumegroupsnapshot/v1alpha1"
+	"github.com/kubernetes-csi/external-snapshotter/client/v7/clientset/versioned/fake"
+	"github.com/kubernetes-csi/external-snapshotter/v7/pkg/utils"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+	// crdv1alpha1 "github.com/kubernetes-csi/external-snapshotter/client/v7/apis/volumegroupsnapshot/v1alpha1"
+	// clientset "github.com/kubernetes-csi/external-snapshotter/client/v7/clientset/versioned"
+	// groupsnapshotlisters "github.com/kubernetes-csi/external-snapshotter/client/v7/listers/volumegroupsnapshot/v1alpha1"
+	// snapshotlisters "github.com/kubernetes-csi/external-snapshotter/client/v7/listers/volumesnapshot/v1"
+	// "github.com/kubernetes-csi/external-snapshotter/v2/pkg/metrics"
+	// "k8s.io/client-go/kubernetes"
+	// corelisters "k8s.io/client-go/listers/core/v1"
+	// "k8s.io/client-go/tools/cache"
+	// "k8s.io/client-go/tools/record"
+	// "k8s.io/client-go/util/workqueue"
+)
+
+func Test_csiSnapshotCommonController_removeGroupSnapshotFinalizer(t *testing.T) {
+	type args struct {
+		groupSnapshot        *crdv1alpha1.VolumeGroupSnapshot
+		removeBoundFinalizer bool
+	}
+	tests := []struct {
+		name               string
+		args               args
+		wantErr            bool
+		expectedFinalizers []string
+	}{
+		{
+			name: "Test removeGroupSnapshotFinalizer",
+			args: args{
+				removeBoundFinalizer: true,
+				groupSnapshot: &crdv1alpha1.VolumeGroupSnapshot{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "test-group-snapshot",
+						Finalizers: []string{utils.VolumeGroupSnapshotBoundFinalizer},
+					},
+				},
+			},
+		},
+		{
+			name: "Test removeGroupSnapshotFinalizer and not something else",
+			args: args{
+				removeBoundFinalizer: true,
+				groupSnapshot: &crdv1alpha1.VolumeGroupSnapshot{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "test-group-snapshot",
+						Finalizers: []string{"somethingElse", utils.VolumeGroupSnapshotBoundFinalizer},
+					},
+				},
+			},
+			expectedFinalizers: []string{"somethingElse"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := &csiSnapshotCommonController{
+				clientset:          fake.NewSimpleClientset(tt.args.groupSnapshot),
+				groupSnapshotStore: cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc),
+			}
+			if err := ctrl.removeGroupSnapshotFinalizer(tt.args.groupSnapshot, tt.args.removeBoundFinalizer); (err != nil) != tt.wantErr {
+				t.Errorf("csiSnapshotCommonController.removeGroupSnapshotFinalizer() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			vgs, err := ctrl.clientset.GroupsnapshotV1alpha1().VolumeGroupSnapshots(tt.args.groupSnapshot.Namespace).Get(context.TODO(), tt.args.groupSnapshot.Name, metav1.GetOptions{})
+			if err != nil {
+				t.Errorf("Error getting volume group snapshot: %v", err)
+			}
+			if tt.expectedFinalizers == nil && vgs.Finalizers != nil {
+				tt.expectedFinalizers = []string{} // if expectedFinalizers is nil, then it should be an empty slice so that cmp.Diff does not panic
+			}
+			if vgs.Finalizers != nil && cmp.Diff(vgs.Finalizers, tt.expectedFinalizers) != "" {
+				t.Errorf("Finalizers not expected: %v", cmp.Diff(vgs.Finalizers, tt.expectedFinalizers))
+			}
+
+		})
+	}
+}

--- a/pkg/common-controller/snapshot_controller.go
+++ b/pkg/common-controller/snapshot_controller.go
@@ -1506,23 +1506,12 @@ func (ctrl *csiSnapshotCommonController) addSnapshotFinalizer(snapshot *crdv1.Vo
 	var updatedSnapshot *crdv1.VolumeSnapshot
 	var err error
 
-	// var patches []utils.PatchOp
 	finalizersToAdd := []string{}
 	// If finalizers exist already, add new ones to the end of the array
 	if addSourceFinalizer {
-		// patches = append(patches, utils.PatchOp{
-		// 	Op:    "add",
-		// 	Path:  "/metadata/finalizers/-",
-		// 	Value: utils.VolumeSnapshotAsSourceFinalizer,
-		// })
 		finalizersToAdd = append(finalizersToAdd, utils.VolumeSnapshotAsSourceFinalizer)
 	}
 	if addBoundFinalizer {
-		// patches = append(patches, utils.PatchOp{
-		// 	Op:    "add",
-		// 	Path:  "/metadata/finalizers/-",
-		// 	Value: utils.VolumeSnapshotBoundFinalizer,
-		// })
 		finalizersToAdd = append(finalizersToAdd, utils.VolumeSnapshotBoundFinalizer)
 	}
 	patches := utils.PatchOpsToAddFinalizers(snapshot, finalizersToAdd...)

--- a/pkg/common-controller/snapshot_delete_test.go
+++ b/pkg/common-controller/snapshot_delete_test.go
@@ -19,6 +19,7 @@ package common_controller
 import (
 	"errors"
 	"testing"
+	"time"
 
 	crdv1 "github.com/kubernetes-csi/external-snapshotter/client/v7/apis/volumesnapshot/v1"
 	"github.com/kubernetes-csi/external-snapshotter/v7/pkg/utils"
@@ -49,7 +50,12 @@ var class5Parameters = map[string]string{
 	utils.PrefixedSnapshotterSecretNamespaceKey: "default",
 }
 
-var timeNowMetav1 = metav1.Now()
+var timeNowMetav1 = func() metav1.Time {
+	// json.unmarshal does not restore millisecond precision
+	// so we need to round the time to seconds
+	timeNow := timeNow.Round(time.Second)
+	return metav1.NewTime(timeNow)
+}()
 
 var (
 	content31 = "content3-1"

--- a/pkg/common-controller/snapshot_update_test.go
+++ b/pkg/common-controller/snapshot_update_test.go
@@ -117,9 +117,10 @@ func TestSync(t *testing.T) {
 			initialVolumes:    newVolumeArray("volume2-8", "pv-uid2-8", "pv-handle2-8", "1Gi", "pvc-uid2-8", "claim2-8", v1.VolumeBound, v1.PersistentVolumeReclaimDelete, classEmpty),
 			initialSecrets:    []*v1.Secret{secret()},
 			errors: []reactorError{
-				// Inject error to the first client.VolumesnapshotV1().VolumeSnapshots().Update call.
+				// Inject error to the first client.VolumesnapshotV1().VolumeSnapshots().Update and .Patch call.
 				// All other calls will succeed.
 				{"update", "volumesnapshots", errors.New("mock update error")},
+				{"patch", "volumesnapshots", errors.New("mock update error")},
 			},
 			test: testSyncSnapshotError,
 		},

--- a/pkg/utils/patch.go
+++ b/pkg/utils/patch.go
@@ -3,12 +3,17 @@ package utils
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
+	"slices"
+
 	crdv1alpha1 "github.com/kubernetes-csi/external-snapshotter/client/v7/apis/volumegroupsnapshot/v1alpha1"
 
 	crdv1 "github.com/kubernetes-csi/external-snapshotter/client/v7/apis/volumesnapshot/v1"
 	clientset "github.com/kubernetes-csi/external-snapshotter/client/v7/clientset/versioned"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	kubernetes "k8s.io/client-go/kubernetes"
 )
 
 // PatchOp represents a json patch operation
@@ -96,4 +101,95 @@ func PatchVolumeGroupSnapshotContent(
 	}
 
 	return newGroupSnapshotContent, nil
+}
+
+// Remove one or more finalizers from an object
+// if finalizers is not empty, only the specified finalizers will be removed
+func PatchRemoveFinalizers(object metav1.Object, client clientset.Interface, finalizers ...string) (metav1.Object, error) {
+	data, err := PatchOpsBytesToRemoveFinalizers(object, finalizers...)
+	if err != nil {
+		return nil, err
+	}
+	switch object.(type) {
+	case *crdv1.VolumeSnapshot:
+		obj, err := client.SnapshotV1().VolumeSnapshots(object.GetNamespace()).Patch(context.TODO(), object.GetName(), types.JSONPatchType, data, metav1.PatchOptions{})
+		if len(obj.Finalizers) == 0 {
+			// to satisfy some tests that requires nil rather than []string{}
+			obj.Finalizers = nil
+		}
+		return obj, err
+	case *crdv1alpha1.VolumeGroupSnapshot:
+		obj, err := client.GroupsnapshotV1alpha1().VolumeGroupSnapshots(object.GetNamespace()).Patch(context.TODO(), object.GetName(), types.JSONPatchType, data, metav1.PatchOptions{})
+		if len(obj.Finalizers) == 0 {
+			// to satisfy some tests that requires nil rather than []string{}
+			obj.Finalizers = nil
+		}
+		return obj, err
+	default:
+		return nil, errors.New("PatchRemoveFinalizers: unsupported object type")
+	}
+}
+
+func PatchRemoveFinalizersCorev1(object metav1.Object, client kubernetes.Interface, finalizers ...string) (metav1.Object, error) {
+	data, err := PatchOpsBytesToRemoveFinalizers(object, finalizers...)
+	if err != nil {
+		return nil, err
+	}
+	obj, err := client.CoreV1().Pods(object.GetNamespace()).Patch(context.TODO(), object.GetName(), types.JSONPatchType, data, metav1.PatchOptions{})
+	if len(obj.Finalizers) == 0 {
+		// to satisfy some tests that requires nil rather than []string{}
+		obj.Finalizers = nil
+	}
+	return obj, err
+}
+
+func PatchOpsToRemoveFinalizers(object metav1.Object, finalizers ...string) []PatchOp {
+	patches := []PatchOp{}
+	if len(finalizers) == 0 {
+		return patches
+	}
+	// remove only the specified finalizers
+	// get index of all finalizers to be removed
+	// sort the indexes in descending order
+	// remove the finalizers in descending order
+	// this is to avoid the need to adjust the index after each removal
+	indexes := []int{}
+	for _, finalizer := range finalizers {
+		for i, f := range object.GetFinalizers() {
+			if f == finalizer {
+				indexes = append(indexes, i)
+			}
+		}
+	}
+	slices.Sort(indexes)
+	slices.Reverse(indexes)
+	for _, i := range indexes {
+		patches = append(patches, PatchOp{
+			Op:   "remove",
+			Path: "/metadata/finalizers/" + fmt.Sprint(i),
+		})
+	}
+	return patches
+}
+
+func PatchOpsBytesToRemoveFinalizers(object metav1.Object, finalizers ...string) ([]byte, error) {
+	patches := PatchOpsToRemoveFinalizers(object, finalizers...)
+	return json.Marshal(patches)
+}
+
+func PatchOpsToAddFinalizers(object metav1.Object, finalizers ...string) []PatchOp {
+	patches := []PatchOp{}
+	for _, finalizer := range finalizers {
+		patches = append(patches, PatchOp{
+			Op:    "add",
+			Path:  "/metadata/finalizers/-",
+			Value: finalizer,
+		})
+	}
+	return patches
+}
+
+func PatchOpsBytesToAddFinalizers(object metav1.Object, finalizers ...string) ([]byte, error) {
+	patches := PatchOpsToAddFinalizers(object, finalizers...)
+	return json.Marshal(patches)
 }

--- a/pkg/utils/patch.go
+++ b/pkg/utils/patch.go
@@ -181,7 +181,7 @@ func PatchOpsToAddFinalizers(object metav1.Object, finalizers ...string) []Patch
 	if len(finalizers) == 0 {
 		return patches
 	}
-	if object.GetFinalizers() == nil || len(object.GetFinalizers()) == 0{
+	if object.GetFinalizers() == nil || len(object.GetFinalizers()) == 0 {
 		patches = append(patches, PatchOp{
 			Op:    "add",
 			Path:  "/metadata/finalizers",

--- a/pkg/utils/patch_test.go
+++ b/pkg/utils/patch_test.go
@@ -1,0 +1,83 @@
+package utils
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestPatchOpsBytesToRemoveFinalizers(t *testing.T) {
+	type args struct {
+		object             *corev1.PersistentVolumeClaim
+		finalizersToRemove []string
+	}
+	tests := []struct {
+		name                 string
+		args                 args
+		finalizersAfterPatch []string
+		wantErr              bool
+	}{
+		{
+			name: "remove all finalizers",
+			args: args{
+				object: &corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "pvc1",
+						Namespace:  "default",
+						Finalizers: []string{"finalizer1", "finalizer2"},
+					},
+				},
+				finalizersToRemove: []string{"finalizer1", "finalizer2"},
+			},
+			finalizersAfterPatch: []string{},
+			wantErr:              false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := fake.NewSimpleClientset(tt.args.object)
+			gotObj, err := client.CoreV1().PersistentVolumeClaims(tt.args.object.GetNamespace()).Get(context.Background(), tt.args.object.GetName(), metav1.GetOptions{})
+			if err != nil {
+				t.Errorf("PatchOpsBytesToRemoveFinalizers() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			for i, finalizer := range gotObj.GetFinalizers() {
+				if finalizer != tt.args.object.Finalizers[i] {
+					t.Errorf("PatchOpsBytesToRemoveFinalizers() error = %v, wantErr %v", err, tt.wantErr)
+					return
+				}
+			}
+			got, err := PatchOpsBytesToRemoveFinalizers(tt.args.object, tt.args.finalizersToRemove...)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("PatchOpsBytesToRemoveFinalizers() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			// try to apply the patch
+			_, err = client.CoreV1().PersistentVolumeClaims(tt.args.object.GetNamespace()).Patch(context.Background(), tt.args.object.GetName(), types.JSONPatchType, got, metav1.PatchOptions{})
+			if err != nil {
+				t.Errorf("PatchOpsBytesToRemoveFinalizers() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			// check if the finalizers were removed
+			gotObj, err = client.CoreV1().PersistentVolumeClaims(tt.args.object.GetNamespace()).Get(context.Background(), tt.args.object.GetName(), metav1.GetOptions{})
+			if err != nil {
+				t.Errorf("PatchOpsBytesToRemoveFinalizers() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if len(gotObj.GetFinalizers()) != len(tt.finalizersAfterPatch) {
+				t.Errorf("PatchOpsBytesToRemoveFinalizers() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			for i, finalizer := range gotObj.GetFinalizers() {
+				if finalizer != tt.finalizersAfterPatch[i] {
+					t.Errorf("PatchOpsBytesToRemoveFinalizers() error = %v, wantErr %v", err, tt.wantErr)
+					return
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Tiger Kaovilai <tkaovila@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
/kind bug
/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This PR cleans up some of the unit test reactor code, and eliminate update calls that I can see, fixing unit tests to accommodate the changes.
Previously update call was required simply cause unit test is borked. Patch calls was modifying original input causing compare failures.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #748

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

This PR extend https://github.com/kubernetes-csi/external-snapshotter/pull/876 work to later added update calls.