### PR TITLE
[release-7.0]: Fix detecting default annotation on VolumeGroupSnapshotClass

### DIFF
--- a/pkg/common-controller/groupsnapshot_controller_helper.go
+++ b/pkg/common-controller/groupsnapshot_controller_helper.go
@@ -140,7 +140,7 @@ func (ctrl *csiSnapshotCommonController) SetDefaultGroupSnapshotClass(groupSnaps
 
 	defaultClasses := []*crdv1alpha1.VolumeGroupSnapshotClass{}
 	for _, groupSnapshotClass := range list {
-		if utils.IsDefaultAnnotation(groupSnapshotClass.ObjectMeta) && pvDriver == groupSnapshotClass.Driver {
+		if utils.IsDefaultAnnotation(groupSnapshotClass.TypeMeta, groupSnapshotClass.ObjectMeta) && pvDriver == groupSnapshotClass.Driver {
 			defaultClasses = append(defaultClasses, groupSnapshotClass)
 			klog.V(5).Infof("get defaultGroupClass added: %s, driver: %s", groupSnapshotClass.Name, pvDriver)
 		}

--- a/pkg/common-controller/snapshot_controller.go
+++ b/pkg/common-controller/snapshot_controller.go
@@ -1416,7 +1416,7 @@ func (ctrl *csiSnapshotCommonController) SetDefaultSnapshotClass(snapshot *crdv1
 
 	defaultClasses := []*crdv1.VolumeSnapshotClass{}
 	for _, class := range list {
-		if utils.IsDefaultAnnotation(class.ObjectMeta) && pvDriver == class.Driver {
+		if utils.IsDefaultAnnotation(class.TypeMeta, class.ObjectMeta) && pvDriver == class.Driver {
 			defaultClasses = append(defaultClasses, class)
 			klog.V(5).Infof("get defaultClass added: %s, driver: %s", class.Name, pvDriver)
 		}

--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -262,9 +262,16 @@ func GetDynamicSnapshotContentNameForSnapshot(snapshot *crdv1.VolumeSnapshot) st
 
 // IsDefaultAnnotation returns a boolean if
 // the annotation is set
-func IsDefaultAnnotation(obj metav1.ObjectMeta) bool {
-	if obj.Annotations[IsDefaultSnapshotClassAnnotation] == "true" {
-		return true
+func IsDefaultAnnotation(tm metav1.TypeMeta, obj metav1.ObjectMeta) bool {
+	switch tm.Kind {
+	case "VolumeSnapshotClass":
+		if obj.Annotations[IsDefaultSnapshotClassAnnotation] == "true" {
+			return true
+		}
+	case "VolumeGroupSnapshotClass":
+		if obj.Annotations[IsDefaultGroupSnapshotClassAnnotation] == "true" {
+			return true
+		}
 	}
 
 	return false

--- a/pkg/utils/util_test.go
+++ b/pkg/utils/util_test.go
@@ -207,3 +207,98 @@ func TestRemovePrefixedCSIParams(t *testing.T) {
 		}
 	}
 }
+
+func TestIsDefaultAnnotation(t *testing.T) {
+	testcases := []struct {
+		name       string
+		typeMeta   metav1.TypeMeta
+		objectMeta metav1.ObjectMeta
+		isDefault  bool
+	}{
+		{
+			name: "no default annotation in snapshot class",
+			typeMeta: metav1.TypeMeta{
+				Kind: "VolumeSnapshotClass",
+			},
+			objectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{},
+			},
+			isDefault: false,
+		},
+		{
+			name: "with default annotation in snapshot class",
+			typeMeta: metav1.TypeMeta{
+				Kind: "VolumeSnapshotClass",
+			},
+			objectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					IsDefaultSnapshotClassAnnotation: "true",
+				},
+			},
+			isDefault: true,
+		},
+		{
+			name: "with default=false annotation in snapshot class",
+			typeMeta: metav1.TypeMeta{
+				Kind: "VolumeSnapshotClass",
+			},
+			objectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					IsDefaultSnapshotClassAnnotation: "false",
+				},
+			},
+			isDefault: false,
+		},
+		{
+			name: "no default annotation in group snapshot class",
+			typeMeta: metav1.TypeMeta{
+				Kind: "VolumeGroupSnapshotClass",
+			},
+			objectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{},
+			},
+			isDefault: false,
+		},
+		{
+			name: "with default annotation in group snapshot class",
+			typeMeta: metav1.TypeMeta{
+				Kind: "VolumeGroupSnapshotClass",
+			},
+			objectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					IsDefaultGroupSnapshotClassAnnotation: "true",
+				},
+			},
+			isDefault: true,
+		},
+		{
+			name: "with default=false annotation in group snapshot class",
+			typeMeta: metav1.TypeMeta{
+				Kind: "VolumeGroupSnapshotClass",
+			},
+			objectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					IsDefaultGroupSnapshotClassAnnotation: "false",
+				},
+			},
+			isDefault: false,
+		},
+		{
+			name: "unknown kind, not a snapshot or group snapshot class",
+			typeMeta: metav1.TypeMeta{
+				Kind: "PersistentVolume",
+			},
+			objectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{},
+			},
+			isDefault: false,
+		},
+	}
+	for _, tc := range testcases {
+		t.Logf("test: %s", tc.name)
+		isDefault := IsDefaultAnnotation(tc.typeMeta, tc.objectMeta)
+		if tc.isDefault != isDefault {
+			t.Fatalf("default annotation on class incorrectly detected: %v != %v", isDefault, tc.isDefault)
+		}
+	}
+}


### PR DESCRIPTION
The `IsDefaultAnnotation()` function has been extended to check for the correct default annotation, taking the Kind of the object into consideration.

(cherry picked from commit aa837d1ddfc7a04d74dd533e2e32f6a6cc43ae70)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Adding the annotation `groupsnapshot.storage.kubernetes.io/is-default-class=true` on a VolumeGroupSnapshotClass will cause that VolumeGroupSnapshotClass to be used by default.
```
