### PR TITLE
Sync dependabot config from external-provisioner

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,10 +1,29 @@
----
 version: 2
+enable-beta-ecosystems: true
 updates:
 - package-ecosystem: gomod
   directory: "/"
+  allow:
+  - dependency-type: "all"
   schedule:
-    interval: daily
+    interval: weekly
+  groups:
+    golang-dependencies:
+      patterns:
+        - "github.com/golang*"
+    k8s-dependencies:
+      patterns:
+        - "k8s.io*"
+        - "sigs.k8s.io*"
+        - "github.com/kubernetes-csi*"
+    github-dependencies:
+      patterns:
+        - "*"
+      exclude-patterns:
+        - "github.com/golang*"
+        - "k8s.io*"
+        - "sigs.k8s.io*"
+        - "github.com/kubernetes-csi*"
   labels:
     - "area/dependency"
     - "release-note-none"


### PR DESCRIPTION
In the external-provisioner repo we experimented with updating *all* dependencies. IMHO it is useful, I'm syncing it to all sidecars.

/kind cleanup
```release-note
NONE
```