### PR TITLE
Avoid conflicts in updateSnapshotContentStatus

### DIFF
--- a/pkg/sidecar-controller/snapshot_controller.go
+++ b/pkg/sidecar-controller/snapshot_controller.go
@@ -484,8 +484,16 @@ func (ctrl *csiSnapshotSideCarController) updateSnapshotContentStatus(
 
 	if updated {
 		contentClone := contentObj.DeepCopy()
-		contentClone.Status = newStatus
-		newContent, err := ctrl.clientset.SnapshotV1().VolumeSnapshotContents().UpdateStatus(context.TODO(), contentClone, metav1.UpdateOptions{})
+
+		patches := []utils.PatchOp{
+			{
+				Op:    "replace",
+				Path:  "/status",
+				Value: newStatus,
+			},
+		}
+
+		newContent, err := utils.PatchVolumeSnapshotContent(contentClone, patches, ctrl.clientset, "status")
 		if err != nil {
 			return contentObj, newControllerUpdateError(content.Name, err.Error())
 		}


### PR DESCRIPTION
This patch replace the usage of `UpdateStatus` with a patch against the `status` subresource in the `updateSnapshotContentStatus`.

The reason behind this change is to avoid conflicts that could potentially arise, as they pose a risk within the context of the calling function `createGroupSnapshotWrapper`.

If `createGroupSnapshotWrapper` is called multiple times for the same GroupSnapshot, this will lead to multiple stale `VolumeSnapshot` and `VolumeSnapshotContent` being created.

Related: #1050

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Prevent VolumeSnapshotContent's update from erroring out because of conflicts in the CSI snapshotter sidecar.
```
