### PR TITLE
Avoid panicking when snapshotting a non-CSI PV

### DIFF
--- a/pkg/common-controller/groupsnapshot_controller_helper.go
+++ b/pkg/common-controller/groupsnapshot_controller_helper.go
@@ -754,6 +754,19 @@ func (ctrl *csiSnapshotCommonController) createGroupSnapshotContent(groupSnapsho
 	}
 	var volumeHandles []string
 	for _, pv := range volumes {
+		if pv.Spec.CSI == nil {
+			err := fmt.Errorf(
+				"cannot snapshot a non-CSI volume for group snapshot %s: %s",
+				utils.GroupSnapshotKey(groupSnapshot), pv.Name)
+			klog.Error(err.Error())
+			ctrl.eventRecorder.Event(
+				groupSnapshot,
+				v1.EventTypeWarning,
+				"CreateGroupSnapshotContentFailed",
+				fmt.Sprintf("Cannot snapshot a non-CSI volume: %s", pv.Name),
+			)
+			return nil, err
+		}
 		volumeHandles = append(volumeHandles, pv.Spec.CSI.VolumeHandle)
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

This PR avoids the external-snapshotter controller from panicking when the user requests a VolumeGroupSnapshot across non-CSI PVs.

In my tests, `master` was failing with:

```
goroutine 124 [running]:
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0xc0000f8800?})
	/Users/leonardo.cecchi/go/src/github.com/kubernetes-csi/external-snapshotter/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:56 +0xcd
panic({0x17ff940?, 0x29eba50?})
	/Users/leonardo.cecchi/.asdf/installs/golang/1.21.9/go/src/runtime/panic.go:914 +0x21f
github.com/kubernetes-csi/external-snapshotter/v7/pkg/common-controller.(*csiSnapshotCommonController).createGroupSnapshotContent(0xc00031ad00, 0xc0008883c0)
	/Users/leonardo.cecchi/go/src/github.com/kubernetes-csi/external-snapshotter/pkg/common-controller/groupsnapshot_controller_helper.go:757 +0x2db
github.com/kubernetes-csi/external-snapshotter/v7/pkg/common-controller.(*csiSnapshotCommonController).syncUnreadyGroupSnapshot(0xc0000f8ff0?, 0xc0008883c0)
	/Users/leonardo.cecchi/go/src/github.com/kubernetes-csi/external-snapshotter/pkg/common-controller/groupsnapshot_controller_helper.go:445 +0x105b
github.com/kubernetes-csi/external-snapshotter/v7/pkg/common-controller.(*csiSnapshotCommonController).syncGroupSnapshot(0xc00031ad00, 0xc0008883c0)
	/Users/leonardo.cecchi/go/src/github.com/kubernetes-csi/external-snapshotter/pkg/common-controller/groupsnapshot_controller_helper.go:319 +0x6c5
github.com/kubernetes-csi/external-snapshotter/v7/pkg/common-controller.(*csiSnapshotCommonController).updateGroupSnapshot(0xc00031ad00, 0xc0008883c0)
	/Users/leonardo.cecchi/go/src/github.com/kubernetes-csi/external-snapshotter/pkg/common-controller/groupsnapshot_controller_helper.go:247 +0x2a7
github.com/kubernetes-csi/external-snapshotter/v7/pkg/common-controller.(*csiSnapshotCommonController).syncGroupSnapshotByKey(0xc00031ad00, {0xc000058480, 0x1e})
	/Users/leonardo.cecchi/go/src/github.com/kubernetes-csi/external-snapshotter/pkg/common-controller/snapshot_controller_base.go:702 +0xb87
github.com/kubernetes-csi/external-snapshotter/v7/pkg/common-controller.(*csiSnapshotCommonController).groupSnapshotWorker(0xc00031ad00)
	/Users/leonardo.cecchi/go/src/github.com/kubernetes-csi/external-snapshotter/pkg/common-controller/snapshot_controller_base.go:647 +0xed
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x30?)
	/Users/leonardo.cecchi/go/src/github.com/kubernetes-csi/external-snapshotter/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:226 +0x33
k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x0?, {0x1cc8900, 0xc0000f7290}, 0x1, 0xc0000ae540)
	/Users/leonardo.cecchi/go/src/github.com/kubernetes-csi/external-snapshotter/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:227 +0xaf
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0x0?, 0x0, 0x0, 0x0?, 0x0?)
	/Users/leonardo.cecchi/go/src/github.com/kubernetes-csi/external-snapshotter/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:204 +0x7f
k8s.io/apimachinery/pkg/util/wait.Until(0x0?, 0x0?, 0x0?)
	/Users/leonardo.cecchi/go/src/github.com/kubernetes-csi/external-snapshotter/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:161 +0x1e
created by github.com/kubernetes-csi/external-snapshotter/v7/pkg/common-controller.(*csiSnapshotCommonController).Run in goroutine 48
	/Users/leonardo.cecchi/go/src/github.com/kubernetes-csi/external-snapshotter/pkg/common-controller/snapshot_controller_base.go:234 +0x729
```

With this PR, the controller won't panic anymore, and an event will be recorder for the volumegroupsnapshot telling the user what happened:

```
➜ k get events |grep volumegroupsnapshot
13s         Warning   CreateGroupSnapshotContentFailed     volumegroupsnapshot/new-groupsnapshot-demo                 Cannot snapshot a non-CSI volume: pvc-de499b35-6856-4c52-98fc-74f3caa6ac27
42s         Warning   GroupSnapshotContentCreationFailed   volumegroupsnapshot/new-groupsnapshot-demo                 failed to create group snapshot content with error cannot snapshot a non-CSI volume for group snapshot default/new-groupsnapshot-demo: pvc-de499b35-6856-4c52-98fc-74f3caa6ac27
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
Prevent snapshot controller from panicking when requesting a VolumeGroupSnapshot of a non-CSI volume.
```
