### PR TITLE
Link PVCs and PVs in VolumeGroupSnapshot and VolumeGroupSnapshotContent

### DIFF
--- a/pkg/utils/pvs.go
+++ b/pkg/utils/pvs.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import v1 "k8s.io/api/core/v1"
+
+// GetPersistentVolumeFromHandle looks for the PV having a certain CSI driver name
+// and corresponding to a volume with a given handle, in a PV List.
+// If the PV is not found, returns nil
+func GetPersistentVolumeFromHandle(pvList *v1.PersistentVolumeList, driverName, volumeHandle string) *v1.PersistentVolume {
+	for i := range pvList.Items {
+		if pvList.Items[i].Spec.CSI == nil {
+			continue
+		}
+
+		if pvList.Items[i].Spec.CSI.Driver == driverName && pvList.Items[i].Spec.CSI.VolumeHandle == volumeHandle {
+			return &pvList.Items[i]
+		}
+	}
+
+	return nil
+}

--- a/pkg/utils/pvs_test.go
+++ b/pkg/utils/pvs_test.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestGetPersistentVolumeFromHandle(t *testing.T) {
+	testDriverName := "hostpath.csi.k8s.io"
+	testVolumeHandle := "df39ea9e-1296-11ef-adde-baf37ed30dae"
+	testPvName := "pv-name"
+
+	pvListTest := v1.PersistentVolumeList{
+		Items: []v1.PersistentVolume{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: testPvName,
+				},
+				Spec: v1.PersistentVolumeSpec{
+					PersistentVolumeSource: v1.PersistentVolumeSource{
+						CSI: &v1.CSIPersistentVolumeSource{
+							Driver:       testDriverName,
+							VolumeHandle: testVolumeHandle,
+						},
+					},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pv-no-csi",
+				},
+				Spec: v1.PersistentVolumeSpec{
+					PersistentVolumeSource: v1.PersistentVolumeSource{
+						HostPath: &v1.HostPathVolumeSource{},
+					},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		testName     string
+		driverName   string
+		volumeHandle string
+		pvList       v1.PersistentVolumeList
+		pvName       string
+	}{
+		{
+			testName:     "empty-pv-list",
+			driverName:   testDriverName,
+			volumeHandle: testVolumeHandle,
+			pvName:       "",
+		},
+		{
+			testName:     "pv-in-list",
+			driverName:   testDriverName,
+			volumeHandle: testVolumeHandle,
+			pvList:       pvListTest,
+			pvName:       testPvName,
+		},
+		{
+			testName:     "not-existing-volume-handle",
+			driverName:   testDriverName,
+			volumeHandle: "not-existing-volume-handle",
+			pvList:       pvListTest,
+			pvName:       "",
+		},
+		{
+			testName:     "invalid-driver-name",
+			driverName:   "invalid-driver-name",
+			volumeHandle: testVolumeHandle,
+			pvList:       pvListTest,
+			pvName:       "",
+		},
+	}
+	for _, tt := range tests {
+		got := GetPersistentVolumeFromHandle(&tt.pvList, tt.driverName, tt.volumeHandle)
+		if got == nil {
+			if len(tt.pvName) != 0 {
+				t.Errorf("%v: GetPersistentVolumeFromHandle = %v WANT %v", tt.testName, got, tt.pvName)
+			}
+		} else {
+			if tt.pvName != got.Name {
+				t.Errorf("%v: GetPersistentVolumeFromHandle = %v WANT %v", tt.testName, got.Name, tt.pvName)
+			}
+		}
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
> /kind flake

**What this PR does / why we need it**:

Following #1068 and the discussion in #969, this PR improves the snapshot controller and the CSI snapshotter sidecar to track which PVC and PVs are snapshotted by a VolumeGroupSnapshot.

With this PR applied, a `VolumeGroupSnapshot` will look like:

```
apiVersion: groupsnapshot.storage.k8s.io/v1alpha1
kind: VolumeGroupSnapshot
metadata:
  finalizers:
  - groupsnapshot.storage.kubernetes.io/volumegroupsnapshot-bound-protection
  generation: 1
  name: new-groupsnapshot
  namespace: default
  resourceVersion: "64488"
  uid: 02f28293-ff7e-4d1c-8ea8-c64fb2b45a26
spec:
  source:
    selector:
      matchLabels:
        cnpg.io/instanceName: cluster-example-1
  volumeGroupSnapshotClassName: csi-hostpath-groupsnapclass
status:
  boundVolumeGroupSnapshotContentName: groupsnapcontent-02f28293-ff7e-4d1c-8ea8-c64fb2b45a26
  creationTime: "2024-05-14T10:02:50Z"
  pvcVolumeSnapshotRefList:
  - persistentVolumeClaimRef:
      name: cluster-example-1
    volumeSnapshotRef:
      name: snapshot-219cbb76259445b14e5a1f0e11008cb976aacfb23bada2e4346d7d4da81d2d2b-2024-05-14-10.2.52
  - persistentVolumeClaimRef:
      name: cluster-example-1-wal
    volumeSnapshotRef:
      name: snapshot-8b65beb9db8573e67e31c3120401d13f1ccd83bf4974b546970799ce0b0016c3-2024-05-14-10.2.52
  readyToUse: true
```

The corresponding `VolumeGroupSnapshotContent` will look like:

```
apiVersion: groupsnapshot.storage.k8s.io/v1alpha1
kind: VolumeGroupSnapshotContent
metadata:
  creationTimestamp: "2024-05-14T10:02:50Z"
  finalizers:
  - groupsnapshot.storage.kubernetes.io/volumegroupsnapshotcontent-bound-protection
  generation: 1
  name: groupsnapcontent-02f28293-ff7e-4d1c-8ea8-c64fb2b45a26
  resourceVersion: "64482"
  uid: 7671dd61-0af3-4e53-a389-d7528fca5260
spec:
  deletionPolicy: Delete
  driver: hostpath.csi.k8s.io
  source:
    volumeHandles:
    - f4416324-1165-11ef-91b4-22776546f286
    - f440f487-1165-11ef-91b4-22776546f286
  volumeGroupSnapshotClassName: csi-hostpath-groupsnapclass
  volumeGroupSnapshotRef:
    apiVersion: groupsnapshot.storage.k8s.io/v1alpha1
    kind: VolumeGroupSnapshot
    name: new-groupsnapshot
    namespace: default
    resourceVersion: "64440"
    uid: 02f28293-ff7e-4d1c-8ea8-c64fb2b45a26
status:
  creationTime: 1715680970153290824
  pvVolumeSnapshotContentList:
  - persistentVolumeRef:
      name: pvc-e92d8114-160f-4a59-8c29-bb6fb42e345f
    volumeSnapshotContentRef:
      name: snapcontent-219cbb76259445b14e5a1f0e11008cb976aacfb23bada2e4346d7d4da81d2d2b-2024-05-14-10.2.52
  - persistentVolumeRef:
      name: pvc-7b7b185e-2c35-4973-959e-15593d5f74a5
    volumeSnapshotContentRef:
      name: snapcontent-8b65beb9db8573e67e31c3120401d13f1ccd83bf4974b546970799ce0b0016c3-2024-05-14-10.2.52
  readyToUse: true
  volumeGroupSnapshotHandle: 1f3e6247-11d9-11ef-a7bc-b25da50ff257
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:


**Testing**

To test this patch, I used the [CSI host path driver](https://github.com/kubernetes-csi/csi-driver-host-path).
Having two PVCs and creating a VolumeGroupSnapshot matching them is enough to trigger the process.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
Link the snapshotted PVCs and the corresponding PVs in VolumeGroupSnaphot and VolumeGroupSnapshotContent to make restoring data easier.
```
