### PR TITLE
Adding validation rules into CRDs for validation

### DIFF
--- a/client/apis/volumegroupsnapshot/v1alpha1/types.go
+++ b/client/apis/volumegroupsnapshot/v1alpha1/types.go
@@ -36,7 +36,7 @@ type VolumeGroupSnapshotSpec struct {
 	// class will be used.
 	// Empty string is not allowed for this field.
 	// +optional
-	// +kubebuilder:validation:XValidation:rule="size(self) > 0",message="VolumeGroupSnapshotClassName must not be the empty string when set"
+	// +kubebuilder:validation:XValidation:rule="size(self) > 0",message="volumeGroupSnapshotClassName must not be the empty string when set"
 	VolumeGroupSnapshotClassName *string `json:"volumeGroupSnapshotClassName,omitempty" protobuf:"bytes,2,opt,name=volumeGroupSnapshotClassName"`
 }
 
@@ -47,6 +47,7 @@ type VolumeGroupSnapshotSpec struct {
 // Members in VolumeGroupSnapshotSource are immutable.
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.selector) || has(self.selector)", message="selector is required once set"
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.volumeGroupSnapshotContentName) || has(self.volumeGroupSnapshotContentName)", message="volumeGroupSnapshotContentName is required once set"
+// +kubebuilder:validation:XValidation:rule="(has(self.selector) && !has(self.volumeGroupSnapshotContentName)) || (!has(self.selector) && has(self.volumeGroupSnapshotContentName))", message="exactly one of selector and volumeGroupSnapshotContentName must be set"
 type VolumeGroupSnapshotSource struct {
 	// Selector is a label query over persistent volume claims that are to be
 	// grouped together for snapshotting.
@@ -56,7 +57,7 @@ type VolumeGroupSnapshotSource struct {
 	// Once a VolumeGroupSnapshotContent is created and the sidecar starts to process
 	// it, the volume list will not change with retries.
 	// +optional
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Spec.Source.Selector is immutable"
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="selector is immutable"
 	Selector *metav1.LabelSelector `json:"selector,omitempty" protobuf:"bytes,1,opt,name=selector"`
 
 	// VolumeGroupSnapshotContentName specifies the name of a pre-existing VolumeGroupSnapshotContent
@@ -65,7 +66,7 @@ type VolumeGroupSnapshotSource struct {
 	// only needs a representation in Kubernetes.
 	// This field is immutable.
 	// +optional
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Spec.Source.VolumeGroupSnapshotContentName is immutable"
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="volumeGroupSnapshotContentName is immutable"
 	VolumeGroupSnapshotContentName *string `json:"volumeGroupSnapshotContentName,omitempty" protobuf:"bytes,2,opt,name=volumeGroupSnapshotContentName"`
 }
 
@@ -270,9 +271,8 @@ type VolumeGroupSnapshotContentSpec struct {
 	// VolumeGroupSnapshot object MUST be provided for binding to happen.
 	// This field is immutable after creation.
 	// Required.
-	// +kubebuilder:validation:XValidation:rule="has(self.name) && has(self.__namespace__)",message="both Spec.VolumeGroupSnapshotRef.Name and Spec.VolumeGroupSnapshotRef.Namespace must be set"
-	// +kubebuilder:validation:XValidation:rule="self.name == oldSelf.name",message="Spec.VolumeGroupSnapshotRef.Name is immutable"
-	// +kubebuilder:validation:XValidation:rule="self.__namespace__ == oldSelf.__namespace__",message="Spec.VolumeGroupSnapshotRef.Namespace is immutable"
+	// +kubebuilder:validation:XValidation:rule="has(self.name) && has(self.__namespace__)",message="both volumeGroupSnapshotRef.name and volumeGroupSnapshotRef.namespace must be set"
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="volumeGroupSnapshotRef is immutable"
 	VolumeGroupSnapshotRef core_v1.ObjectReference `json:"volumeGroupSnapshotRef" protobuf:"bytes,1,opt,name=volumeGroupSnapshotRef"`
 
 	// DeletionPolicy determines whether this VolumeGroupSnapshotContent and the
@@ -355,14 +355,15 @@ type VolumeGroupSnapshotContentStatus struct {
 // VolumeGroupSnapshotContentSource represents the CSI source of a group snapshot.
 // Exactly one of its members must be set.
 // Members in VolumeGroupSnapshotContentSource are immutable.
-// +kubebuilder:validation:XValidation:rule="!has(oldSelf.volumeHandle) || has(self.volumeHandle)", message="volumeHandle is required once set"
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.volumeHandles) || has(self.volumeHandles)", message="volumeHandles is required once set"
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.groupSnapshotHandles) || has(self.groupSnapshotHandles)", message="groupSnapshotHandles is required once set"
+// +kubebuilder:validation:XValidation:rule="(has(self.volumeHandles) && !has(self.groupSnapshotHandles)) || (!has(self.volumeHandles) && has(self.groupSnapshotHandles))", message="exactly one of volumeHandles and groupSnapshotHandles must be set"
 type VolumeGroupSnapshotContentSource struct {
 	// VolumeHandles is a list of volume handles on the backend to be snapshotted
 	// together. It is specified for dynamic provisioning of the VolumeGroupSnapshot.
 	// This field is immutable.
 	// +optional
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Spec.Source.VolumeHandle is immutable"
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="volumeHandles is immutable"
 	VolumeHandles []string `json:"volumeHandles,omitempty" protobuf:"bytes,1,opt,name=volumeHandles"`
 
 	// GroupSnapshotHandles specifies the CSI "group_snapshot_id" of a pre-existing
@@ -371,7 +372,7 @@ type VolumeGroupSnapshotContentSource struct {
 	// representation was (or should be) created.
 	// This field is immutable.
 	// +optional
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Spec.Source.GroupSnapshotHandles is immutable"
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="groupSnapshotHandles is immutable"
 	GroupSnapshotHandles *GroupSnapshotHandles `json:"groupSnapshotHandles,omitempty" protobuf:"bytes,2,opt,name=groupSnapshotHandles"`
 }
 

--- a/client/apis/volumegroupsnapshot/v1alpha1/types.go
+++ b/client/apis/volumegroupsnapshot/v1alpha1/types.go
@@ -36,6 +36,7 @@ type VolumeGroupSnapshotSpec struct {
 	// class will be used.
 	// Empty string is not allowed for this field.
 	// +optional
+	// +kubebuilder:validation:XValidation:rule="size(self) > 0",message="VolumeGroupSnapshotClassName must not be the empty string when set"
 	VolumeGroupSnapshotClassName *string `json:"volumeGroupSnapshotClassName,omitempty" protobuf:"bytes,2,opt,name=volumeGroupSnapshotClassName"`
 }
 
@@ -44,6 +45,8 @@ type VolumeGroupSnapshotSpec struct {
 // object should be used.
 // Exactly one of its members must be set.
 // Members in VolumeGroupSnapshotSource are immutable.
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.selector) || has(self.selector)", message="selector is required once set"
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.volumeGroupSnapshotContentName) || has(self.volumeGroupSnapshotContentName)", message="volumeGroupSnapshotContentName is required once set"
 type VolumeGroupSnapshotSource struct {
 	// Selector is a label query over persistent volume claims that are to be
 	// grouped together for snapshotting.
@@ -53,6 +56,7 @@ type VolumeGroupSnapshotSource struct {
 	// Once a VolumeGroupSnapshotContent is created and the sidecar starts to process
 	// it, the volume list will not change with retries.
 	// +optional
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Spec.Source.Selector is immutable"
 	Selector *metav1.LabelSelector `json:"selector,omitempty" protobuf:"bytes,1,opt,name=selector"`
 
 	// VolumeGroupSnapshotContentName specifies the name of a pre-existing VolumeGroupSnapshotContent
@@ -61,6 +65,7 @@ type VolumeGroupSnapshotSource struct {
 	// only needs a representation in Kubernetes.
 	// This field is immutable.
 	// +optional
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Spec.Source.VolumeGroupSnapshotContentName is immutable"
 	VolumeGroupSnapshotContentName *string `json:"volumeGroupSnapshotContentName,omitempty" protobuf:"bytes,2,opt,name=volumeGroupSnapshotContentName"`
 }
 
@@ -265,6 +270,9 @@ type VolumeGroupSnapshotContentSpec struct {
 	// VolumeGroupSnapshot object MUST be provided for binding to happen.
 	// This field is immutable after creation.
 	// Required.
+	// +kubebuilder:validation:XValidation:rule="has(self.name) && has(self.__namespace__)",message="both Spec.VolumeGroupSnapshotRef.Name and Spec.VolumeGroupSnapshotRef.Namespace must be set"
+	// +kubebuilder:validation:XValidation:rule="self.name == oldSelf.name",message="Spec.VolumeGroupSnapshotRef.Name is immutable"
+	// +kubebuilder:validation:XValidation:rule="self.__namespace__ == oldSelf.__namespace__",message="Spec.VolumeGroupSnapshotRef.Namespace is immutable"
 	VolumeGroupSnapshotRef core_v1.ObjectReference `json:"volumeGroupSnapshotRef" protobuf:"bytes,1,opt,name=volumeGroupSnapshotRef"`
 
 	// DeletionPolicy determines whether this VolumeGroupSnapshotContent and the
@@ -347,11 +355,14 @@ type VolumeGroupSnapshotContentStatus struct {
 // VolumeGroupSnapshotContentSource represents the CSI source of a group snapshot.
 // Exactly one of its members must be set.
 // Members in VolumeGroupSnapshotContentSource are immutable.
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.volumeHandle) || has(self.volumeHandle)", message="volumeHandle is required once set"
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.groupSnapshotHandles) || has(self.groupSnapshotHandles)", message="groupSnapshotHandles is required once set"
 type VolumeGroupSnapshotContentSource struct {
 	// VolumeHandles is a list of volume handles on the backend to be snapshotted
 	// together. It is specified for dynamic provisioning of the VolumeGroupSnapshot.
 	// This field is immutable.
 	// +optional
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Spec.Source.VolumeHandle is immutable"
 	VolumeHandles []string `json:"volumeHandles,omitempty" protobuf:"bytes,1,opt,name=volumeHandles"`
 
 	// GroupSnapshotHandles specifies the CSI "group_snapshot_id" of a pre-existing
@@ -360,6 +371,7 @@ type VolumeGroupSnapshotContentSource struct {
 	// representation was (or should be) created.
 	// This field is immutable.
 	// +optional
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Spec.Source.GroupSnapshotHandles is immutable"
 	GroupSnapshotHandles *GroupSnapshotHandles `json:"groupSnapshotHandles,omitempty" protobuf:"bytes,2,opt,name=groupSnapshotHandles"`
 }
 

--- a/client/apis/volumesnapshot/v1/types.go
+++ b/client/apis/volumesnapshot/v1/types.go
@@ -91,6 +91,7 @@ type VolumeSnapshotSpec struct {
 	// CreateSnapshot will fail and generate an event.
 	// Empty string is not allowed for this field.
 	// +optional
+	// +kubebuilder:validation:XValidation:rule="size(self) > 0",message="volumeSnapshotClassName must not be the empty string when set"
 	VolumeSnapshotClassName *string `json:"volumeSnapshotClassName,omitempty" protobuf:"bytes,2,opt,name=volumeSnapshotClassName"`
 }
 
@@ -99,6 +100,8 @@ type VolumeSnapshotSpec struct {
 // object should be used.
 // Exactly one of its members must be set.
 // Members in VolumeSnapshotSource are immutable.
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.persistentVolumeClaimName) || has(self.persistentVolumeClaimName)", message="persistentVolumeClaimName is required once set"
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.volumeSnapshotContentName) || has(self.volumeSnapshotContentName)", message="volumeSnapshotContentName is required once set"
 type VolumeSnapshotSource struct {
 	// persistentVolumeClaimName specifies the name of the PersistentVolumeClaim
 	// object representing the volume from which a snapshot should be created.
@@ -108,6 +111,7 @@ type VolumeSnapshotSource struct {
 	// created.
 	// This field is immutable.
 	// +optional
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Spec.Source.PersistentVolumeClaimName is immutable"
 	PersistentVolumeClaimName *string `json:"persistentVolumeClaimName,omitempty" protobuf:"bytes,1,opt,name=persistentVolumeClaimName"`
 
 	// volumeSnapshotContentName specifies the name of a pre-existing VolumeSnapshotContent
@@ -115,6 +119,7 @@ type VolumeSnapshotSource struct {
 	// This field should be set if the snapshot already exists and only needs a representation in Kubernetes.
 	// This field is immutable.
 	// +optional
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Spec.Source.VolumeSnapshotContentName is immutable"
 	VolumeSnapshotContentName *string `json:"volumeSnapshotContentName,omitempty" protobuf:"bytes,2,opt,name=volumeSnapshotContentName"`
 }
 
@@ -289,6 +294,7 @@ type VolumeSnapshotContentList struct {
 }
 
 // VolumeSnapshotContentSpec is the specification of a VolumeSnapshotContent
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.sourceVolumeMode) || has(self.sourceVolumeMode)", message="sourceVolumeMode is required once set"
 type VolumeSnapshotContentSpec struct {
 	// volumeSnapshotRef specifies the VolumeSnapshot object to which this
 	// VolumeSnapshotContent object is bound.
@@ -298,6 +304,7 @@ type VolumeSnapshotContentSpec struct {
 	// VolumeSnapshot object MUST be provided for binding to happen.
 	// This field is immutable after creation.
 	// Required.
+	// +kubebuilder:validation:XValidation:rule="has(self.name) && has(self.__namespace__)",message="both spec.volumeSnapshotRef.name and spec.volumeSnapshotRef.namespace must be set"
 	VolumeSnapshotRef core_v1.ObjectReference `json:"volumeSnapshotRef" protobuf:"bytes,1,opt,name=volumeSnapshotRef"`
 
 	// deletionPolicy determines whether this VolumeSnapshotContent and its physical snapshot on
@@ -340,17 +347,21 @@ type VolumeSnapshotContentSpec struct {
 	// This field is immutable.
 	// This field is an alpha field.
 	// +optional
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Spec.sourceVolumeMode is immutable"
 	SourceVolumeMode *core_v1.PersistentVolumeMode `json:"sourceVolumeMode" protobuf:"bytes,6,opt,name=sourceVolumeMode"`
 }
 
 // VolumeSnapshotContentSource represents the CSI source of a snapshot.
 // Exactly one of its members must be set.
 // Members in VolumeSnapshotContentSource are immutable.
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.volumeHandle) || has(self.volumeHandle)", message="volumeHandle is required once set"
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.snapshotHandle) || has(self.snapshotHandle)", message="snapshotHandle is required once set"
 type VolumeSnapshotContentSource struct {
 	// volumeHandle specifies the CSI "volume_id" of the volume from which a snapshot
 	// should be dynamically taken from.
 	// This field is immutable.
 	// +optional
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Spec.Source.VolumeHandle is immutable"
 	VolumeHandle *string `json:"volumeHandle,omitempty" protobuf:"bytes,1,opt,name=volumeHandle"`
 
 	// snapshotHandle specifies the CSI "snapshot_id" of a pre-existing snapshot on
@@ -358,6 +369,7 @@ type VolumeSnapshotContentSource struct {
 	// was (or should be) created.
 	// This field is immutable.
 	// +optional
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Spec.Source.SnapshotHandle is immutable"
 	SnapshotHandle *string `json:"snapshotHandle,omitempty" protobuf:"bytes,2,opt,name=snapshotHandle"`
 }
 

--- a/client/apis/volumesnapshot/v1/types.go
+++ b/client/apis/volumesnapshot/v1/types.go
@@ -102,6 +102,7 @@ type VolumeSnapshotSpec struct {
 // Members in VolumeSnapshotSource are immutable.
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.persistentVolumeClaimName) || has(self.persistentVolumeClaimName)", message="persistentVolumeClaimName is required once set"
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.volumeSnapshotContentName) || has(self.volumeSnapshotContentName)", message="volumeSnapshotContentName is required once set"
+// +kubebuilder:validation:XValidation:rule="(has(self.volumeSnapshotContentName) && !has(self.persistentVolumeClaimName)) || (!has(self.volumeSnapshotContentName) && has(self.persistentVolumeClaimName))", message="exactly one of volumeSnapshotContentName and persistentVolumeClaimName must be set"
 type VolumeSnapshotSource struct {
 	// persistentVolumeClaimName specifies the name of the PersistentVolumeClaim
 	// object representing the volume from which a snapshot should be created.
@@ -111,7 +112,7 @@ type VolumeSnapshotSource struct {
 	// created.
 	// This field is immutable.
 	// +optional
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Spec.Source.PersistentVolumeClaimName is immutable"
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="persistentVolumeClaimName is immutable"
 	PersistentVolumeClaimName *string `json:"persistentVolumeClaimName,omitempty" protobuf:"bytes,1,opt,name=persistentVolumeClaimName"`
 
 	// volumeSnapshotContentName specifies the name of a pre-existing VolumeSnapshotContent
@@ -119,7 +120,7 @@ type VolumeSnapshotSource struct {
 	// This field should be set if the snapshot already exists and only needs a representation in Kubernetes.
 	// This field is immutable.
 	// +optional
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Spec.Source.VolumeSnapshotContentName is immutable"
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="volumeSnapshotContentName is immutable"
 	VolumeSnapshotContentName *string `json:"volumeSnapshotContentName,omitempty" protobuf:"bytes,2,opt,name=volumeSnapshotContentName"`
 }
 
@@ -347,7 +348,7 @@ type VolumeSnapshotContentSpec struct {
 	// This field is immutable.
 	// This field is an alpha field.
 	// +optional
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Spec.sourceVolumeMode is immutable"
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="sourceVolumeMode is immutable"
 	SourceVolumeMode *core_v1.PersistentVolumeMode `json:"sourceVolumeMode" protobuf:"bytes,6,opt,name=sourceVolumeMode"`
 }
 
@@ -356,12 +357,13 @@ type VolumeSnapshotContentSpec struct {
 // Members in VolumeSnapshotContentSource are immutable.
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.volumeHandle) || has(self.volumeHandle)", message="volumeHandle is required once set"
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.snapshotHandle) || has(self.snapshotHandle)", message="snapshotHandle is required once set"
+// +kubebuilder:validation:XValidation:rule="(has(self.volumeHandle) && !has(self.snapshotHandle)) || (!has(self.volumeHandle) && has(self.snapshotHandle))", message="exactly one of volumeHandle and snapshotHandle must be set"
 type VolumeSnapshotContentSource struct {
 	// volumeHandle specifies the CSI "volume_id" of the volume from which a snapshot
 	// should be dynamically taken from.
 	// This field is immutable.
 	// +optional
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Spec.Source.VolumeHandle is immutable"
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="volumeHandle is immutable"
 	VolumeHandle *string `json:"volumeHandle,omitempty" protobuf:"bytes,1,opt,name=volumeHandle"`
 
 	// snapshotHandle specifies the CSI "snapshot_id" of a pre-existing snapshot on
@@ -369,7 +371,7 @@ type VolumeSnapshotContentSource struct {
 	// was (or should be) created.
 	// This field is immutable.
 	// +optional
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Spec.Source.SnapshotHandle is immutable"
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="snapshotHandle is immutable"
 	SnapshotHandle *string `json:"snapshotHandle,omitempty" protobuf:"bytes,2,opt,name=snapshotHandle"`
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature


**What this PR does / why we need it**:
This is to add validation rules to CRDs which did the same validation as written in https://github.com/kubernetes-csi/external-snapshotter/blob/master/pkg/validation-webhook/validation.go


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1072 

**Special notes for your reviewer**:
The feature is available since Kubernetes 1.25. Is there any version compatibility concern there? Could I remove the existing validating webhook in the same PR? Thank you!

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Adds validation rules into CRDs. Minimum required Kubernetes version is 1.25 for these validation rules.
```
