### PR TITLE
Update code-generator to 1.30.0

### DIFF
--- a/client/hack/README.md
+++ b/client/hack/README.md
@@ -26,13 +26,13 @@ Make sure to run this script after making changes to /client/apis/volumesnapshot
     ```
 * Checkout latest release version
     ```bash
-    git checkout v0.29.1
+    git checkout v0.30.0
     ```
 
-* Ensure the file `generate-groups.sh` exists
+* Ensure the file `kube_codegen.sh` exists
 
     ```bash
-    ls ${GOPATH}/src/k8s.io/code-generator/generate-groups.sh
+    ls ${GOPATH}/src/k8s.io/code-generator/kube_codegen.sh
     ```
   
 Update generated client code in external-snapshotter
@@ -42,14 +42,13 @@ Update generated client code in external-snapshotter
     ./hack/update-generated-code.sh
 ``` 
 
-Once you run the script, you will get an output as follows:
+Once you run the script, the code will be generated for volumesnapshot:v1 and volumegroupsnapshot:v1alpha1, and you will get an output as follows:
     
 ```bash
-    Generating deepcopy funcs
-    Generating clientset for volumesnapshot:v1 at github.com/kubernetes-csi/external-snapshotter/client/v7/clientset
-    Generating listers for volumesnapshot:v1 at github.com/kubernetes-csi/external-snapshotter/client/v7/listers
-    Generating informers for volumesnapshot:v1 at github.com/kubernetes-csi/external-snapshotter/client/v7/informers
-    
+Generating deepcopy code for 2 targets
+Generating client code for 2 targets
+Generating lister code for 2 targets
+Generating informer code for 2 targets
 ```
 
 ## update-crd.sh

--- a/client/hack/update-generated-code.sh
+++ b/client/hack/update-generated-code.sh
@@ -20,18 +20,15 @@ set -o pipefail
 
 SCRIPT_ROOT=$(unset CDPATH && cd $(dirname "${BASH_SOURCE[0]}")/.. && pwd)
 
-# generate the code with:
-# --output-base    because this script should also be able to run inside the vendor dir of
-#                  k8s.io/kubernetes. The output-base is needed for the generators to output into the vendor dir
-#                  instead of the $GOPATH directly. For normal projects this can be dropped.
-${GOPATH}/src/k8s.io/code-generator/generate-groups.sh "deepcopy,client,informer,lister" \
-  github.com/kubernetes-csi/external-snapshotter/client/v7 github.com/kubernetes-csi/external-snapshotter/client/v7/apis \
-  "volumesnapshot:v1 volumegroupsnapshot:v1alpha1" \
-  --go-header-file ${SCRIPT_ROOT}/hack/boilerplate.go.txt
+source "${GOPATH}/src/k8s.io/code-generator/kube_codegen.sh"
 
-# To use your own boilerplate text use:
-#   --go-header-file ${SCRIPT_ROOT}/hack/custom-boilerplate.go.txt
+kube::codegen::gen_helpers \
+    --boilerplate "${SCRIPT_ROOT}/hack/boilerplate.go.txt" \
+    "${SCRIPT_ROOT}/apis"
 
-# Move generated file from client/v7 to client folder and remove client/v7
-cp -rf v7/. .
-rm -rf v7
+kube::codegen::gen_client \
+    --output-dir "${SCRIPT_ROOT}" \
+    --output-pkg "github.com/kubernetes-csi/external-snapshotter/client/v7" \
+    --boilerplate "${SCRIPT_ROOT}/hack/boilerplate.go.txt" \
+    --with-watch \
+    "${SCRIPT_ROOT}/apis"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup

> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
code-generator/generate-groups.sh is no longer worker in 1.30.
Use code-generator/kube_codegen.sh instead.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Replace code-generator/generate-groups.sh with code-generator/kube_codegen.sh in update-generated-code.sh.
```
