### PR TITLE
Ensure vendor checks are run for all modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,3 +17,16 @@
 CMDS=snapshot-controller csi-snapshotter snapshot-validation-webhook
 all: build
 include release-tools/build.make
+
+# The test-vendor-client target performs vendor checks in both
+# the external-snapshotter module and the client module.
+# This target has been added for the following reasons:
+# 1. The test-vendor target does not perform vendor checks for the client module.
+# 2. The test-vendor target cannot detect if vendor updates have been made in
+# the external-snapshotter module when changes are made in the client module.
+.PHONY: test-vendor-client
+test: test-vendor-client
+test-vendor-client:
+	@ echo; echo "### $@:"
+	@ cd client && ../release-tools/verify-vendor.sh
+	@ hack/verify-vendor.sh

--- a/client/go.mod
+++ b/client/go.mod
@@ -2,7 +2,7 @@ module github.com/kubernetes-csi/external-snapshotter/client/v7
 
 go 1.22.0
 
-toolchain go1.22.2
+toolchain go1.22.3
 
 require (
 	k8s.io/api v0.30.0

--- a/hack/verify-vendor.sh
+++ b/hack/verify-vendor.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# Copyright 2024 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script is based on the following script:
+# release-tools/verify-vendor.sh
+
+if ! (set -x; env GO111MODULE=on go mod tidy); then
+	echo "ERROR: vendor check failed."
+	exit 1
+elif [ "$(git status --porcelain -- go.mod go.sum | wc -l)" -gt 0 ]; then
+  echo "ERROR: go module files *not* up-to-date, they did get modified by 'GO111MODULE=on go mod tidy':";
+  git diff --color=always -- go.mod go.sum | cat
+  exit 1
+else
+	if ! (set -x; env GO111MODULE=on go mod vendor); then
+	  echo "ERROR: vendor check failed."
+	  exit 1
+	elif [ "$(git status --porcelain -- vendor | wc -l)" -gt 0 ]; then
+    echo "ERROR: vendor directory *not* up-to-date, it did get modified by 'GO111MODULE=on go mod vendor':"
+	  git status -- vendor
+	  git diff --color=always -- vendor | cat
+    exit 1
+	else
+	  echo "Go dependencies and vendor directory up-to-date."
+	fi
+fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

As observed in the PR below, the current vendor tests might not always detect if go mod tidy or similar commands have been run in the external-snapshotter when changes are made in the client module.
https://github.com/kubernetes-csi/external-snapshotter/pull/1073

To address this, in this PR, I have made the following enhancements:

1. Added vendor checks for the client module
2. Enhanced vendor checks for the external-snapshotter

These changes aim to reduce the risk of vendor updates being overlooked.

refs:

- https://github.com/kubernetes-csi/external-snapshotter/pull/1084
- https://github.com/kubernetes-csi/csi-release-tools/pull/252#issuecomment-2105144487


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
