### PR TITLE
Avoid group snapshot provisioning with mismatching CSI Drivers

### DIFF
--- a/pkg/common-controller/groupsnapshot_controller_helper.go
+++ b/pkg/common-controller/groupsnapshot_controller_helper.go
@@ -838,6 +838,23 @@ func (ctrl *csiSnapshotCommonController) createGroupSnapshotContent(groupSnapsho
 			)
 			return nil, err
 		}
+
+		volumeCSIDriver := pv.Spec.CSI.Driver
+		classCSIDriver := groupSnapshotClass.Driver
+		if volumeCSIDriver != classCSIDriver {
+			strErr := fmt.Sprintf(
+				"Volume CSI driver (%s) mismatch with VolumeGroupSnapshotClass (%s) %s: %s",
+				volumeCSIDriver, classCSIDriver, utils.GroupSnapshotKey(groupSnapshot), pv.Name)
+			klog.Error(strErr)
+			ctrl.eventRecorder.Event(
+				groupSnapshot,
+				v1.EventTypeWarning,
+				"CreateGroupSnapshotContentFailed",
+				strErr,
+			)
+			return nil, newControllerUpdateError(utils.GroupSnapshotKey(groupSnapshot), strErr)
+
+		}
 		volumeHandles = append(volumeHandles, pv.Spec.CSI.VolumeHandle)
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

Check whether the volumes to be snapshotted in a group belong to the CSI driver referenced in the VolumeGroupSnapshot resource.

**Which issue(s) this PR fixes**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1096

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Prevents a VolumeGroupSnapshot to be provisioned when the volumes' CSI driver is different from the one referenced in the VolumeGroupSnapshotClass resource
```
