### PR TITLE
Look for a VolumeGroupSnapshotClass when getting the class of a VolumeGroupSnapshot

### DIFF
--- a/pkg/common-controller/groupsnapshot_controller_helper.go
+++ b/pkg/common-controller/groupsnapshot_controller_helper.go
@@ -1371,7 +1371,7 @@ func (ctrl *csiSnapshotCommonController) removeGroupSnapshotFinalizer(groupSnaps
 // getGroupSnapshotDriverName is a helper function to get driver from the VolumeGroupSnapshot.
 // We try to get the driverName in multiple ways, as snapshot controller metrics depend on the correct driverName.
 func (ctrl *csiSnapshotCommonController) getGroupSnapshotDriverName(vgs *crdv1alpha1.VolumeGroupSnapshot) (string, error) {
-	klog.V(5).Infof("getSnapshotDriverName: VolumeSnapshot[%s]", vgs.Name)
+	klog.V(5).Infof("getGroupSnapshotDriverName: VolumeGroupSnapshot[%s]", vgs.Name)
 	var driverName string
 
 	// Pre-Provisioned groupsnapshots have contentName as source
@@ -1396,9 +1396,9 @@ func (ctrl *csiSnapshotCommonController) getGroupSnapshotDriverName(vgs *crdv1al
 
 	// Dynamic groupsnapshots will have a groupsnapshotclass with a driver
 	if vgs.Spec.VolumeGroupSnapshotClassName != nil {
-		class, err := ctrl.getSnapshotClass(*vgs.Spec.VolumeGroupSnapshotClassName)
+		class, err := ctrl.getGroupSnapshotClass(*vgs.Spec.VolumeGroupSnapshotClassName)
 		if err != nil {
-			klog.Errorf("getGroupSnapshotDriverName: failed to get groupsnapshotClass: %v", *vgs.Spec.VolumeGroupSnapshotClassName)
+			klog.Errorf("getGroupSnapshotDriverName: failed to get groupSnapshotClass: %v", *vgs.Spec.VolumeGroupSnapshotClassName)
 		} else {
 			driverName = class.Driver
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

When looking for the name of the CSI driver to use for a volume group snapshot, we were looking for a VolumeSnapshotClass instead of a VolumeGroupSnapshotClass. This made the VolumeGroupSnapshot fail when there is no such VolumeGroupSnapshotClass.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Look for a VolumeGroupSnapshotClass instead of a VolumeSnapshotClass when getting metrics data for VolumeGroupSnapshot metrics.
```
