### PR TITLE
[snapshot-controller] Retry PVC finalizer removal on conflict

### DIFF
--- a/vendor/k8s.io/client-go/util/retry/OWNERS
+++ b/vendor/k8s.io/client-go/util/retry/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - caesarxuchao

--- a/vendor/k8s.io/client-go/util/retry/util.go
+++ b/vendor/k8s.io/client-go/util/retry/util.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package retry
+
+import (
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// DefaultRetry is the recommended retry for a conflict where multiple clients
+// are making changes to the same resource.
+var DefaultRetry = wait.Backoff{
+	Steps:    5,
+	Duration: 10 * time.Millisecond,
+	Factor:   1.0,
+	Jitter:   0.1,
+}
+
+// DefaultBackoff is the recommended backoff for a conflict where a client
+// may be attempting to make an unrelated modification to a resource under
+// active management by one or more controllers.
+var DefaultBackoff = wait.Backoff{
+	Steps:    4,
+	Duration: 10 * time.Millisecond,
+	Factor:   5.0,
+	Jitter:   0.1,
+}
+
+// OnError allows the caller to retry fn in case the error returned by fn is retriable
+// according to the provided function. backoff defines the maximum retries and the wait
+// interval between two retries.
+func OnError(backoff wait.Backoff, retriable func(error) bool, fn func() error) error {
+	var lastErr error
+	err := wait.ExponentialBackoff(backoff, func() (bool, error) {
+		err := fn()
+		switch {
+		case err == nil:
+			return true, nil
+		case retriable(err):
+			lastErr = err
+			return false, nil
+		default:
+			return false, err
+		}
+	})
+	if err == wait.ErrWaitTimeout {
+		err = lastErr
+	}
+	return err
+}
+
+// RetryOnConflict is used to make an update to a resource when you have to worry about
+// conflicts caused by other code making unrelated updates to the resource at the same
+// time. fn should fetch the resource to be modified, make appropriate changes to it, try
+// to update it, and return (unmodified) the error from the update function. On a
+// successful update, RetryOnConflict will return nil. If the update function returns a
+// "Conflict" error, RetryOnConflict will wait some amount of time as described by
+// backoff, and then try again. On a non-"Conflict" error, or if it retries too many times
+// and gives up, RetryOnConflict will return an error to the caller.
+//
+//	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+//	    // Fetch the resource here; you need to refetch it on every try, since
+//	    // if you got a conflict on the last update attempt then you need to get
+//	    // the current version before making your own changes.
+//	    pod, err := c.Pods("mynamespace").Get(name, metav1.GetOptions{})
+//	    if err != nil {
+//	        return err
+//	    }
+//
+//	    // Make whatever updates to the resource are needed
+//	    pod.Status.Phase = v1.PodFailed
+//
+//	    // Try to update
+//	    _, err = c.Pods("mynamespace").UpdateStatus(pod)
+//	    // You have to return err itself here (not wrapped inside another error)
+//	    // so that RetryOnConflict can identify it correctly.
+//	    return err
+//	})
+//	if err != nil {
+//	    // May be conflict if max retries were hit, or may be something unrelated
+//	    // like permissions or a network error
+//	    return err
+//	}
+//	...
+//
+// TODO: Make Backoff an interface?
+func RetryOnConflict(backoff wait.Backoff, fn func() error) error {
+	return OnError(backoff, errors.IsConflict, fn)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -770,6 +770,7 @@ k8s.io/client-go/util/consistencydetector
 k8s.io/client-go/util/flowcontrol
 k8s.io/client-go/util/homedir
 k8s.io/client-go/util/keyutil
+k8s.io/client-go/util/retry
 k8s.io/client-go/util/watchlist
 k8s.io/client-go/util/workqueue
 # k8s.io/component-base v0.31.0-rc.0 => k8s.io/component-base v0.31.0-rc.0


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

> /kind bug

**What this PR does / why we need it**:

The previous `removePVCFinalizer` function was using the PVC stored in the informer which, in cases where the PVC had been modified since, lead to conflict errors when trying to remove the PVC finalizer through an update.
Example error:
```
E0807 13:09:20.573657       1 snapshot_controller.go:183] error check and remove PVC finalizer for snapshot [snapshot]: snapshot controller failed to update pvc-sts-0 on API server: Operation cannot be fulfilled on persistentvolumeclaims "pvc-sts-0": the object has been modified; please apply your changes to the latest version and try again
```
Unfortunately, the error was not retried so the PVC ends up stuck.

Now the `removePVCFinalizer` function uses the `RetryOnConflict` helper to make sure the update goes through.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixes a race condition where the PVC finalizer could end up not being removed by the snapshot-controller if the update had a conflict.
```
