### PR TITLE
Add nil check for groupSnapshotContent in deleteCSIGroupSnapshotOperaion and unit tests

### DIFF
--- a/pkg/sidecar-controller/groupsnapshot_helper.go
+++ b/pkg/sidecar-controller/groupsnapshot_helper.go
@@ -238,6 +238,9 @@ func (ctrl csiSnapshotSideCarController) removeGroupSnapshotContentFinalizer(gro
 
 // Delete a groupsnapshot: Ask the backend to remove the groupsnapshot device
 func (ctrl *csiSnapshotSideCarController) deleteCSIGroupSnapshotOperation(groupSnapshotContent *crdv1beta1.VolumeGroupSnapshotContent) error {
+	if groupSnapshotContent == nil {
+		return fmt.Errorf("groupSnapshotContent is nil")
+	}
 	klog.V(5).Infof("deleteCSIGroupSnapshotOperation [%s] started", groupSnapshotContent.Name)
 
 	snapshotterCredentials, err := ctrl.GetCredentialsFromAnnotationForGroupSnapshot(groupSnapshotContent)
@@ -258,6 +261,7 @@ func (ctrl *csiSnapshotSideCarController) deleteCSIGroupSnapshotOperation(groupS
 		} else if groupSnapshotContent.Spec.Source.GroupSnapshotHandles != nil {
 			ids := groupSnapshotContent.Spec.Source.GroupSnapshotHandles.VolumeSnapshotHandles
 			snapshotIDs = slices.Clone(ids)
+
 		}
 	}
 

--- a/pkg/sidecar-controller/groupsnapshot_helper_test.go
+++ b/pkg/sidecar-controller/groupsnapshot_helper_test.go
@@ -1,0 +1,53 @@
+package sidecar_controller
+
+import (
+	"testing"
+
+	crdv1beta1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumegroupsnapshot/v1beta1"
+
+	v1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/tools/record"
+)
+
+type fakeContentLister struct {
+}
+
+func (f *fakeContentLister) List(selector labels.Selector) (ret []*v1.VolumeSnapshotContent, err error) {
+	return nil, nil
+}
+func (f *fakeContentLister) Get(name string) (*v1.VolumeSnapshotContent, error) {
+	return &v1.VolumeSnapshotContent{}, nil
+}
+
+func TestDeleteCSIGroupSnapshotOperation(t *testing.T) {
+	ctrl := &csiSnapshotSideCarController{
+		contentLister: &fakeContentLister{},
+		handler:       &csiHandler{},
+		eventRecorder: &record.FakeRecorder{},
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("deleteCSIGroupSnapshotOperation() panicked with: %v", r)
+		}
+	}()
+	err := ctrl.deleteCSIGroupSnapshotOperation(nil)
+	if err == nil {
+		t.Errorf("expected deleteCSIGroupSnapshotOperation to return error when groupsnapshotContent is nil: %v", err)
+	}
+	gsc := crdv1beta1.VolumeGroupSnapshotContent{
+		Status: &crdv1beta1.VolumeGroupSnapshotContentStatus{
+			VolumeSnapshotHandlePairList: []crdv1beta1.VolumeSnapshotHandlePair{
+				{
+					VolumeHandle:   "test-pv",
+					SnapshotHandle: "test-vsc",
+				},
+			},
+		},
+	}
+	err = ctrl.deleteCSIGroupSnapshotOperation(&gsc)
+	if err == nil {
+		t.Errorf("expected deleteCSIGroupSnapshotOperation to return error when groupsnapshotContent is empty: %v", err)
+	}
+}


### PR DESCRIPTION
- Add a check to ensure `groupSnapshotContent` is not nil in `deleteCSIGroupSnapshotOperation` to prevent panics.
- Enhance error handling for missing `SnapshotHandle` in `VolumeSnapshotContent` objects during deletion.
- Create initial unit tests in `groupsnapshot_helper_test.go` to cover cases where `groupSnapshotContent` is nil or incomplete.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Before fix:
```bash
[Running: /usr/local/go/bin/go test -timeout 30s -run ^TestDeleteCSIGroupSnapshotOperation$ [github.com/kubernetes-csi/external-snapshotter/v8/pkg/sidecar-controller](http://github.com/kubernetes-csi/external-snapshotter/v8/pkg/sidecar-controller)]
--- FAIL: TestDeleteCSIGroupSnapshotOperation (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x105c44fd4]
goroutine 7 [running]:
testing.tRunner.func1.2({0x1060d4860, 0x107102300})
        /Users/manish/.gvm/pkgsets/go1.22.5/global/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.5.darwin-arm64/src/testing/testing.go:1631 +0x1c4
testing.tRunner.func1()
        /Users/manish/.gvm/pkgsets/go1.22.5/global/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.5.darwin-arm64/src/testing/testing.go:1634 +0x33c
panic({0x1060d4860?, 0x107102300?})
        /Users/manish/.gvm/pkgsets/go1.22.5/global/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.5.darwin-arm64/src/runtime/panic.go:770 +0x124
[github.com/kubernetes-csi/external-snapshotter/v8/pkg/sidecar-controller.(*csiSnapshotSideCarController).deleteCSIGroupSnapshotOperation(0x14000094e48](http://github.com/kubernetes-csi/external-snapshotter/v8/pkg/sidecar-controller.(*csiSnapshotSideCarController).deleteCSIGroupSnapshotOperation(0x14000094e48), 0x140000d65a0)
        /Users/manish/work/openshift/external-snapshotter/pkg/sidecar-controller/groupsnapshot_helper.go:263 +0x404
[github.com/kubernetes-csi/external-snapshotter/v8/pkg/sidecar-controller.TestDeleteCSIGroupSnapshotOperation(0x140002df520)](http://github.com/kubernetes-csi/external-snapshotter/v8/pkg/sidecar-controller.TestDeleteCSIGroupSnapshotOperation(0x140002df520))
        /Users/manish/work/openshift/external-snapshotter/pkg/sidecar-controller/groupsnapshot_helper_test.go:50 +0x1d4
testing.tRunner(0x140002df520, 0x10634dda8)
        /Users/manish/.gvm/pkgsets/go1.22.5/global/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.5.darwin-arm64/src/testing/testing.go:1689 +0xec
created by testing.(*T).Run in goroutine 1
        /Users/manish/.gvm/pkgsets/go1.22.5/global/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.5.darwin-arm64/src/testing/testing.go:1742 +0x318
FAIL    [github.com/kubernetes-csi/external-snapshotter/v8/pkg/sidecar-controller](http://github.com/kubernetes-csi/external-snapshotter/v8/pkg/sidecar-controller)        1.298s
FAIL
[Command exited with 1]
```

After fix:
```bash
[Running: /usr/local/go/bin/go test -timeout 30s -run ^TestDeleteCSIGroupSnapshotOperation$ [github.com/kubernetes-csi/external-snapshotter/v8/pkg/sidecar-controller](http://github.com/kubernetes-csi/external-snapshotter/v8/pkg/sidecar-controller)]
ok      [github.com/kubernetes-csi/external-snapshotter/v8/pkg/sidecar-controller](http://github.com/kubernetes-csi/external-snapshotter/v8/pkg/sidecar-controller) 
```

**Which issue(s) this PR fixes**:


Fixes #1123

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
