### PR TITLE
add check continue VGS deletion

### DIFF
--- a/pkg/sidecar-controller/groupsnapshot_helper.go
+++ b/pkg/sidecar-controller/groupsnapshot_helper.go
@@ -251,6 +251,10 @@ func (ctrl *csiSnapshotSideCarController) deleteCSIGroupSnapshotOperation(groupS
 		for _, contentRef := range groupSnapshotContent.Status.PVVolumeSnapshotContentList {
 			snapshotContent, err := ctrl.contentLister.Get(contentRef.VolumeSnapshotContentRef.Name)
 			if err != nil {
+				if errors.IsNotFound(err) {
+					klog.Infof("snapshot content %v not found", contentRef.VolumeSnapshotContentRef.Name)
+					continue
+				}
 				return fmt.Errorf("failed to get snapshot content %s from snapshot content store: %v", contentRef.VolumeSnapshotContentRef.Name, err)
 			}
 			snapshotIDs = append(snapshotIDs, *snapshotContent.Status.SnapshotHandle)


### PR DESCRIPTION
this commit adds check to continue deleting the
volumegroupsnapshot in case there are no snapshotcontent found under that group.

https://github.com/kubernetes-csi/external-snapshotter/issues/1035 

