### PR TITLE
Prow update master

### DIFF
--- a/release-tools/prow.sh
+++ b/release-tools/prow.sh
@@ -199,7 +199,7 @@ kindest/node:v1.18.20@sha256:738cdc23ed4be6cc0b7ea277a2ebcc454c8373d7d8fb991a7fc
 # If the deployment script is called with CSI_PROW_TEST_DRIVER=<file name> as
 # environment variable, then it must write a suitable test driver configuration
 # into that file in addition to installing the driver.
-configvar CSI_PROW_DRIVER_VERSION "v1.12.0" "CSI driver version"
+configvar CSI_PROW_DRIVER_VERSION "v1.15.0" "CSI driver version"
 configvar CSI_PROW_DRIVER_REPO https://github.com/kubernetes-csi/csi-driver-host-path "CSI driver repo"
 configvar CSI_PROW_DEPLOYMENT "" "deployment"
 configvar CSI_PROW_DEPLOYMENT_SUFFIX "" "additional suffix in kubernetes-x.yy[suffix].yaml files"
@@ -425,7 +425,7 @@ die () {
     exit 1
 }
 
-# Ensure that PATH has the desired version of the Go tools, then run command given as argument.
+# Ensure we use the desired version of the Go tools, then run command given as argument.
 # Empty parameter uses the already installed Go. In Prow, that version is kept up-to-date by
 # bumping the container image regularly.
 run_with_go () {
@@ -433,15 +433,16 @@ run_with_go () {
     version="$1"
     shift
 
-    if ! [ "$version" ] || go version 2>/dev/null | grep -q "go$version"; then
-        run "$@"
-    else
-        if ! [ -d "${CSI_PROW_WORK}/go-$version" ];  then
-            run curl --fail --location "https://dl.google.com/go/go$version.linux-amd64.tar.gz" | tar -C "${CSI_PROW_WORK}" -zxf - || die "installation of Go $version failed"
-            mv "${CSI_PROW_WORK}/go" "${CSI_PROW_WORK}/go-$version"
+    if [ "$version" ]; then
+        version=go$version
+        if [ "$(GOTOOLCHAIN=$version go version | cut -d' ' -f3)" != "$version" ]; then
+            die "Please install Go 1.21+"
         fi
-        PATH="${CSI_PROW_WORK}/go-$version/bin:$PATH" run "$@"
+    else
+        version=local
     fi
+    # Set GOMODCACHE to make sure Kubernetes does not need to download again.
+    GOTOOLCHAIN=$version GOMODCACHE="$(go env GOMODCACHE)" run "$@"
 }
 
 # Ensure that we have the desired version of kind.
@@ -624,7 +625,7 @@ start_cluster () {
             go_version="$(go_version_for_kubernetes "${CSI_PROW_WORK}/src/kubernetes" "$version")" || die "cannot proceed without knowing Go version for Kubernetes"
             # Changing into the Kubernetes source code directory is a workaround for https://github.com/kubernetes-sigs/kind/issues/1910
             # shellcheck disable=SC2046
-            (cd "${CSI_PROW_WORK}/src/kubernetes" && run_with_go "$go_version" kind build node-image --image csiprow/node:latest --kube-root "${CSI_PROW_WORK}/src/kubernetes") || die "'kind build node-image' failed"
+            (cd "${CSI_PROW_WORK}/src/kubernetes" && run_with_go "$go_version" kind build node-image "${CSI_PROW_WORK}/src/kubernetes" --image csiprow/node:latest) || die "'kind build node-image' failed"
             csi_prow_kind_have_kubernetes=true
         fi
         image="csiprow/node:latest"


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup


**What this PR does / why we need it**:

Update release-tools according to https://github.com/kubernetes-csi/csi-release-tools/issues/7

Squashed 'release-tools/' changes from e31de525b..98f23071d
98f23071d Merge pull request https://github.com/kubernetes-csi/external-snapshotter/pull/260 from TerryHowe/update-csi-driver-version
e9d8712d0 Merge pull request https://github.com/kubernetes-csi/external-snapshotter/issues/259 from stmcginnis/deprecated-kind-kube-root
faf79ff66 Remove --kube-root deprecated kind argument
734c2b950 Merge pull request https://github.com/kubernetes-csi/external-snapshotter/pull/265 from Rakshith-R/consider-main-branch
f95c855be Merge pull request https://github.com/kubernetes-csi/external-snapshotter/pull/262 from huww98/golang-toolchain
3c8d966fe Treat main branch as equivalent to master branch
6b05f0fcc use new GOTOOLCHAIN env to manage go version
18b6ac6d2 chore: update CSI driver version to 1.15

git-subtree-dir: release-tools
git-subtree-split: 98f23071d946dd3de3188a7e1f84679067003162

**Which issue(s) this PR fixes**:
Related https://github.com/kubernetes-csi/csi-release-tools/pull/259

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
