### PR TITLE
Add secrets for Get VolumeGroupSnapshot

### DIFF
--- a/pkg/sidecar-controller/groupsnapshot_helper.go
+++ b/pkg/sidecar-controller/groupsnapshot_helper.go
@@ -873,7 +873,7 @@ func (ctrl *csiSnapshotSideCarController) checkandUpdateGroupSnapshotContentStat
 				return groupSnapshotContent, fmt.Errorf("failed to get group snapshot class %s for group snapshot content %s: %v", *groupSnapshotContent.Spec.VolumeGroupSnapshotClassName, groupSnapshotContent.Name, err)
 			}
 
-			groupSnapshotSecretRef, err := utils.GetGroupSnapshotSecretReference(utils.GroupSnapshotterSecretParams, class.Parameters, groupSnapshotContent.GetObjectMeta().GetName(), nil)
+			groupSnapshotSecretRef, err := utils.GetGroupSnapshotSecretReference(utils.GroupSnapshotterGetSecretParams, class.Parameters, groupSnapshotContent.GetObjectMeta().GetName(), nil)
 			if err != nil {
 				klog.Errorf("Failed to get secret reference for group snapshot content %s: %v", groupSnapshotContent.Name, err)
 				return groupSnapshotContent, fmt.Errorf("failed to get secret reference for group snapshot content %s: %v", groupSnapshotContent.Name, err)

--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -65,6 +65,9 @@ const (
 	PrefixedSnapshotterListSecretNameKey      = csiParameterPrefix + "snapshotter-list-secret-name"      // Prefixed name key for ListSnapshots secret
 	PrefixedSnapshotterListSecretNamespaceKey = csiParameterPrefix + "snapshotter-list-secret-namespace" // Prefixed namespace key for ListSnapshots secret
 
+	PrefixedGroupSnapshotterGetSecretNameKey      = csiParameterPrefix + "group-snapshotter-get-secret-name"      // Prefixed name key for GetVolumeGroupSnapshot secret
+	PrefixedGroupSnapshotterGetSecretNamespaceKey = csiParameterPrefix + "group-snapshotter-get-secret-namespace" // Prefixed namespace key for GetVolumeGroupSnapshot secret
+
 	PrefixedVolumeSnapshotNameKey        = csiParameterPrefix + "volumesnapshot/name"        // Prefixed VolumeSnapshot name key
 	PrefixedVolumeSnapshotNamespaceKey   = csiParameterPrefix + "volumesnapshot/namespace"   // Prefixed VolumeSnapshot namespace key
 	PrefixedVolumeSnapshotContentNameKey = csiParameterPrefix + "volumesnapshotcontent/name" // Prefixed VolumeSnapshotContent name key
@@ -170,6 +173,12 @@ var SnapshotterListSecretParams = secretParamsMap{
 	name:               "SnapshotterList",
 	secretNameKey:      PrefixedSnapshotterListSecretNameKey,
 	secretNamespaceKey: PrefixedSnapshotterListSecretNamespaceKey,
+}
+
+var GroupSnapshotterGetSecretParams = secretParamsMap{
+	name:               "GroupSnapshotterGet",
+	secretNameKey:      PrefixedGroupSnapshotterGetSecretNameKey,
+	secretNamespaceKey: PrefixedGroupSnapshotterGetSecretNamespaceKey,
 }
 
 // Annotations on VolumeSnapshotContent objects entirely controlled by csi-snapshotter
@@ -544,6 +553,8 @@ func RemovePrefixedParameters(param map[string]string) (map[string]string, error
 			case PrefixedSnapshotterSecretNamespaceKey:
 			case PrefixedSnapshotterListSecretNameKey:
 			case PrefixedSnapshotterListSecretNamespaceKey:
+			case PrefixedGroupSnapshotterGetSecretNameKey:
+			case PrefixedGroupSnapshotterGetSecretNamespaceKey:
 			case PrefixedGroupSnapshotterSecretNameKey:
 			case PrefixedGroupSnapshotterSecretNamespaceKey:
 			default:


### PR DESCRIPTION
this commit adds new parameter keys for
getvolumegroupsnapshot

Ref: https://github.com/kubernetes-csi/external-snapshotter/issues/1122#issuecomment-2436739611 

```release-note
Add VolumeGroupSnapshotClass secrets for GetVolumeGroupSnapshot.
```
