### PR TITLE
Remove volumeGroupSnapshotRef immutable validation rule

### DIFF
--- a/client/apis/volumegroupsnapshot/v1alpha1/types.go
+++ b/client/apis/volumegroupsnapshot/v1alpha1/types.go
@@ -281,7 +281,6 @@ type VolumeGroupSnapshotContentSpec struct {
 	// This field is immutable after creation.
 	// Required.
 	// +kubebuilder:validation:XValidation:rule="has(self.name) && has(self.__namespace__)",message="both volumeGroupSnapshotRef.name and volumeGroupSnapshotRef.namespace must be set"
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="volumeGroupSnapshotRef is immutable"
 	VolumeGroupSnapshotRef core_v1.ObjectReference `json:"volumeGroupSnapshotRef" protobuf:"bytes,1,opt,name=volumeGroupSnapshotRef"`
 
 	// DeletionPolicy determines whether this VolumeGroupSnapshotContent and the

--- a/client/config/crd/groupsnapshot.storage.k8s.io_volumegroupsnapshotcontents.yaml
+++ b/client/config/crd/groupsnapshot.storage.k8s.io_volumegroupsnapshotcontents.yaml
@@ -237,8 +237,6 @@ spec:
                 - message: both volumeGroupSnapshotRef.name and volumeGroupSnapshotRef.namespace
                     must be set
                   rule: has(self.name) && has(self.__namespace__)
-                - message: volumeGroupSnapshotRef is immutable
-                  rule: self == oldSelf
             required:
             - deletionPolicy
             - driver

--- a/vendor/github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumegroupsnapshot/v1alpha1/types.go
+++ b/vendor/github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumegroupsnapshot/v1alpha1/types.go
@@ -281,7 +281,6 @@ type VolumeGroupSnapshotContentSpec struct {
 	// This field is immutable after creation.
 	// Required.
 	// +kubebuilder:validation:XValidation:rule="has(self.name) && has(self.__namespace__)",message="both volumeGroupSnapshotRef.name and volumeGroupSnapshotRef.namespace must be set"
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="volumeGroupSnapshotRef is immutable"
 	VolumeGroupSnapshotRef core_v1.ObjectReference `json:"volumeGroupSnapshotRef" protobuf:"bytes,1,opt,name=volumeGroupSnapshotRef"`
 
 	// DeletionPolicy determines whether this VolumeGroupSnapshotContent and the


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
We need to remove the validation rule that ensures volumeGroupSnapshotRef is immutable. 
This is because that UID needs to be set by the snapshot controller after volumeGroupSnapshotRef is populated with name and namespace for pre-provisioned VolumeGroupSnapshotContent.

This immutable validation rule was added as part of this PR https://github.com/kubernetes-csi/external-snapshotter/pull/1073 to use CEL to replace the validation added in the validation webhook:
```
	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="volumeGroupSnapshotRef is immutable"
```
However, in the original validation webhook, we never had this rule:
https://github.com/kubernetes-csi/external-snapshotter/blob/v7.0.2/pkg/validation-webhook/validation.go#L52
With this rule, the snapshot controller won't be able to set UID for volumeGroupSnapshotRef after it was populated with name and namespace initially. So we need to remove this rule.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Remove the rule that ensures volumeGroupSnapshotRef is immutable. UID needs to be set by the snapshot controller after volumeGroupSnapshotRef is populated with name and namespace for pre-provisioned VolumeGroupSnapshotContent.
```
