### PR TITLE
Pass context on in GroupSnapshot sync functions

### DIFF
--- a/pkg/common-controller/framework_test.go
+++ b/pkg/common-controller/framework_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package common_controller
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -1751,7 +1752,7 @@ func testSyncSnapshot(ctrl *csiSnapshotCommonController, reactor *snapshotReacto
 }
 
 func testSyncGroupSnapshot(ctrl *csiSnapshotCommonController, reactor *snapshotReactor, test controllerTest) error {
-	return ctrl.syncGroupSnapshot(test.initialGroupSnapshots[0])
+	return ctrl.syncGroupSnapshot(context.TODO(), test.initialGroupSnapshots[0])
 }
 
 func testSyncSnapshotError(ctrl *csiSnapshotCommonController, reactor *snapshotReactor, test controllerTest) error {

--- a/pkg/common-controller/snapshot_controller_base.go
+++ b/pkg/common-controller/snapshot_controller_base.go
@@ -17,6 +17,7 @@ limitations under the License.
 package common_controller
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -671,7 +672,7 @@ func (ctrl *csiSnapshotCommonController) groupSnapshotWorker() {
 	}
 	defer ctrl.groupSnapshotQueue.Done(keyObj)
 
-	if err := ctrl.syncGroupSnapshotByKey(keyObj.(string)); err != nil {
+	if err := ctrl.syncGroupSnapshotByKey(context.Background(), keyObj.(string)); err != nil {
 		// Rather than wait for a full resync, re-add the key to the
 		// queue to be processed.
 		ctrl.groupSnapshotQueue.AddRateLimited(keyObj)
@@ -704,7 +705,7 @@ func (ctrl *csiSnapshotCommonController) groupSnapshotContentWorker() {
 }
 
 // syncGroupSnapshotByKey processes a VolumeGroupSnapshot request.
-func (ctrl *csiSnapshotCommonController) syncGroupSnapshotByKey(key string) error {
+func (ctrl *csiSnapshotCommonController) syncGroupSnapshotByKey(ctx context.Context, key string) error {
 	klog.V(5).Infof("syncGroupSnapshotByKey[%s]", key)
 
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)
@@ -726,7 +727,7 @@ func (ctrl *csiSnapshotCommonController) syncGroupSnapshotByKey(key string) erro
 				klog.V(5).Infof("GroupSnapshot %q is being deleted. GroupSnapshotClass has already been removed", key)
 			}
 			klog.V(5).Infof("Updating group snapshot %q", key)
-			return ctrl.updateGroupSnapshot(newGroupSnapshot)
+			return ctrl.updateGroupSnapshot(ctx, newGroupSnapshot)
 		}
 		return err
 	}


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

kind cleanup

> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Address a TODO comment.

**Which issue(s) this PR fixes**:
Updates #1171

**Special notes for your reviewer**:
TODO note added by @leonardoce.

The sync operations are triggered from a work queue, so there are no real contexts related to the original request. A single context is now created and passed on from the work queue function.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
