### PR TITLE
Set VolumeHandle for dynamically provisioned VolumeGroupSnapshots

### DIFF
--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -150,6 +150,13 @@ const (
 	// of a VolumeGroupSnapshot, and indicates the name of the latter.
 	VolumeGroupSnapshotNameLabel = "groupsnapshot.storage.k8s.io/volumeGroupSnapshotName"
 
+	// VolumeGroupSnapshotHandleLabel is applied to VolumeSnapshotContents that are member
+	// of a VolumeGroupSnapshotContent, and indicates the handle of the latter.
+	//
+	// This label is applied to inform the sidecar not to call CSI driver
+	// to create snapshot if the snapshot belongs to a group.
+	VolumeGroupSnapshotHandleLabel = "groupsnapshot.storage.k8s.io/volumeGroupSnapshotHandle"
+
 	// VolumeSnapshotContentInvalidLabel is applied to invalid content as a label key. The value does not matter.
 	// See https://github.com/kubernetes/enhancements/blob/master/keps/sig-storage/177-volume-snapshot/tighten-validation-webhook-crd.md#automatic-labelling-of-invalid-objects
 	VolumeSnapshotContentInvalidLabel = "snapshot.storage.kubernetes.io/invalid-snapshot-content-resource"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

This patch sets the `spec.source.volumeHandle` field for
volume snapshot contents that are members of a dynamically provisioned volume
group snapshot, like a dynamically provisioned volume snapshot content would do.

The volume snapshot content logic has been improved to consider this case too.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The "spec.source.volumeHandle" field is now set on VolumeSnapshotContents that are members of a dynamically provisioned VolumeGroupSnapshot. This is consistent with dynamically provisioned VolumeSnapshotContents.
```
