### PR TITLE
Remove PVVolumeSnapshotContentList from the VolumeGroupSnapshotContentStatus API

### DIFF
--- a/client/apis/volumegroupsnapshot/v1alpha1/types.go
+++ b/client/apis/volumegroupsnapshot/v1alpha1/types.go
@@ -353,12 +353,6 @@ type VolumeGroupSnapshotContentStatus struct {
 	// +optional
 	Error *snapshotv1.VolumeSnapshotError `json:"error,omitempty" protobuf:"bytes,4,opt,name=error,casttype=VolumeSnapshotError"`
 
-	// PVVolumeSnapshotContentList is the list of pairs of PV and
-	// VolumeSnapshotContent for this group snapshot
-	// The maximum number of allowed snapshots in the group is 100.
-	// +optional
-	PVVolumeSnapshotContentList []PVVolumeSnapshotContentPair `json:"pvVolumeSnapshotContentList,omitempty" protobuf:"bytes,5,opt,name=pvVolumeSnapshotContentRefList"`
-
 	// VolumeSnapshotHandlePairList is a list of CSI "volume_id" and "snapshot_id"
 	// pair returned by the CSI driver to identify snapshots and their source volumes
 	// on the storage system.

--- a/client/apis/volumegroupsnapshot/v1alpha1/zz_generated.deepcopy.go
+++ b/client/apis/volumegroupsnapshot/v1alpha1/zz_generated.deepcopy.go
@@ -319,11 +319,6 @@ func (in *VolumeGroupSnapshotContentStatus) DeepCopyInto(out *VolumeGroupSnapsho
 		*out = new(v1.VolumeSnapshotError)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.PVVolumeSnapshotContentList != nil {
-		in, out := &in.PVVolumeSnapshotContentList, &out.PVVolumeSnapshotContentList
-		*out = make([]PVVolumeSnapshotContentPair, len(*in))
-		copy(*out, *in)
-	}
 	if in.VolumeSnapshotHandlePairList != nil {
 		in, out := &in.VolumeSnapshotHandlePairList, &out.VolumeSnapshotHandlePairList
 		*out = make([]VolumeSnapshotHandlePair, len(*in))

--- a/client/config/crd/groupsnapshot.storage.k8s.io_volumegroupsnapshotcontents.yaml
+++ b/client/config/crd/groupsnapshot.storage.k8s.io_volumegroupsnapshotcontents.yaml
@@ -274,42 +274,6 @@ spec:
                     format: date-time
                     type: string
                 type: object
-              pvVolumeSnapshotContentList:
-                description: |-
-                  PVVolumeSnapshotContentList is the list of pairs of PV and
-                  VolumeSnapshotContent for this group snapshot
-                  The maximum number of allowed snapshots in the group is 100.
-                items:
-                  description: |-
-                    PVVolumeSnapshotContentPair represent a pair of PV names and
-                    VolumeSnapshotContent names
-                  properties:
-                    persistentVolumeRef:
-                      description: PersistentVolumeRef is a reference to the persistent
-                        volume resource
-                      properties:
-                        name:
-                          description: |-
-                            Name of the referent.
-                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?
-                          type: string
-                      type: object
-                      x-kubernetes-map-type: atomic
-                    volumeSnapshotContentRef:
-                      description: VolumeSnapshotContentRef is a reference to the
-                        volume snapshot content resource
-                      properties:
-                        name:
-                          description: |-
-                            Name of the referent.
-                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?
-                          type: string
-                      type: object
-                      x-kubernetes-map-type: atomic
-                  type: object
-                type: array
               readyToUse:
                 description: |-
                   ReadyToUse indicates if all the individual snapshots in the group are ready to be

--- a/pkg/sidecar-controller/groupsnapshot_helper.go
+++ b/pkg/sidecar-controller/groupsnapshot_helper.go
@@ -247,13 +247,9 @@ func (ctrl *csiSnapshotSideCarController) deleteCSIGroupSnapshotOperation(groupS
 	}
 
 	var snapshotIDs []string
-	if groupSnapshotContent.Status != nil && len(groupSnapshotContent.Status.PVVolumeSnapshotContentList) != 0 {
-		for _, contentRef := range groupSnapshotContent.Status.PVVolumeSnapshotContentList {
-			snapshotContent, err := ctrl.contentLister.Get(contentRef.VolumeSnapshotContentRef.Name)
-			if err != nil {
-				return fmt.Errorf("failed to get snapshot content %s from snapshot content store: %v", contentRef.VolumeSnapshotContentRef.Name, err)
-			}
-			snapshotIDs = append(snapshotIDs, *snapshotContent.Status.SnapshotHandle)
+	if groupSnapshotContent.Status != nil && len(groupSnapshotContent.Status.VolumeSnapshotHandlePairList) != 0 {
+		for _, contentRef := range groupSnapshotContent.Status.VolumeSnapshotHandlePairList {
+			snapshotIDs = append(snapshotIDs, contentRef.SnapshotHandle)
 		}
 	}
 
@@ -290,7 +286,6 @@ func (ctrl *csiSnapshotSideCarController) clearGroupSnapshotContentStatus(
 		groupSnapshotContent.Status.ReadyToUse = nil
 		groupSnapshotContent.Status.CreationTime = nil
 		groupSnapshotContent.Status.Error = nil
-		groupSnapshotContent.Status.PVVolumeSnapshotContentList = nil
 	}
 	newContent, err := ctrl.clientset.GroupsnapshotV1alpha1().VolumeGroupSnapshotContents().UpdateStatus(context.TODO(), groupSnapshotContent, metav1.UpdateOptions{})
 	if err != nil {

--- a/vendor/github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumegroupsnapshot/v1alpha1/types.go
+++ b/vendor/github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumegroupsnapshot/v1alpha1/types.go
@@ -353,12 +353,6 @@ type VolumeGroupSnapshotContentStatus struct {
 	// +optional
 	Error *snapshotv1.VolumeSnapshotError `json:"error,omitempty" protobuf:"bytes,4,opt,name=error,casttype=VolumeSnapshotError"`
 
-	// PVVolumeSnapshotContentList is the list of pairs of PV and
-	// VolumeSnapshotContent for this group snapshot
-	// The maximum number of allowed snapshots in the group is 100.
-	// +optional
-	PVVolumeSnapshotContentList []PVVolumeSnapshotContentPair `json:"pvVolumeSnapshotContentList,omitempty" protobuf:"bytes,5,opt,name=pvVolumeSnapshotContentRefList"`
-
 	// VolumeSnapshotHandlePairList is a list of CSI "volume_id" and "snapshot_id"
 	// pair returned by the CSI driver to identify snapshots and their source volumes
 	// on the storage system.

--- a/vendor/github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumegroupsnapshot/v1alpha1/zz_generated.deepcopy.go
+++ b/vendor/github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumegroupsnapshot/v1alpha1/zz_generated.deepcopy.go
@@ -319,11 +319,6 @@ func (in *VolumeGroupSnapshotContentStatus) DeepCopyInto(out *VolumeGroupSnapsho
 		*out = new(v1.VolumeSnapshotError)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.PVVolumeSnapshotContentList != nil {
-		in, out := &in.PVVolumeSnapshotContentList, &out.PVVolumeSnapshotContentList
-		*out = make([]PVVolumeSnapshotContentPair, len(*in))
-		copy(*out, *in)
-	}
 	if in.VolumeSnapshotHandlePairList != nil {
 		in, out := &in.VolumeSnapshotHandlePairList, &out.VolumeSnapshotHandlePairList
 		*out = make([]VolumeSnapshotHandlePair, len(*in))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
/kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

This PR removes the `volumegroupsnapshotcontent.status.pvVolumeSnapshotContentList` field, as requested from the KEP review.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1195

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The `volumegroupsnapshotcontent.status.pvVolumeSnapshotContentList` field has been removed. The same information can be found in `volumegroupsnapshotcontent.status.volumeSnapshotHandlePairList`
```
