### PR TITLE
Remove PVCVolumeSnapshotRefList from VolumeGroupSnapshot API

### DIFF
--- a/client/apis/volumegroupsnapshot/v1alpha1/types.go
+++ b/client/apis/volumegroupsnapshot/v1alpha1/types.go
@@ -108,12 +108,6 @@ type VolumeGroupSnapshotStatus struct {
 	// group snapshot creation. Upon success, this error field will be cleared.
 	// +optional
 	Error *snapshotv1.VolumeSnapshotError `json:"error,omitempty" protobuf:"bytes,4,opt,name=error,casttype=VolumeSnapshotError"`
-
-	// VolumeSnapshotRefList is the list of PVC and VolumeSnapshot pairs that
-	// is part of this group snapshot.
-	// The maximum number of allowed snapshots in the group is 100.
-	// +optional
-	PVCVolumeSnapshotRefList []PVCVolumeSnapshotPair `json:"pvcVolumeSnapshotRefList,omitempty" protobuf:"bytes,5,opt,name=pvcVolumeSnapshotRefList"`
 }
 
 // PVCVolumeSnapshotPair defines a pair of a PVC reference and a Volume Snapshot Reference

--- a/client/apis/volumegroupsnapshot/v1alpha1/zz_generated.deepcopy.go
+++ b/client/apis/volumegroupsnapshot/v1alpha1/zz_generated.deepcopy.go
@@ -440,11 +440,6 @@ func (in *VolumeGroupSnapshotStatus) DeepCopyInto(out *VolumeGroupSnapshotStatus
 		*out = new(v1.VolumeSnapshotError)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.PVCVolumeSnapshotRefList != nil {
-		in, out := &in.PVCVolumeSnapshotRefList, &out.PVCVolumeSnapshotRefList
-		*out = make([]PVCVolumeSnapshotPair, len(*in))
-		copy(*out, *in)
-	}
 	return
 }
 

--- a/client/config/crd/groupsnapshot.storage.k8s.io_volumegroupsnapshots.yaml
+++ b/client/config/crd/groupsnapshot.storage.k8s.io_volumegroupsnapshots.yaml
@@ -221,41 +221,6 @@ spec:
                     format: date-time
                     type: string
                 type: object
-              pvcVolumeSnapshotRefList:
-                description: |-
-                  VolumeSnapshotRefList is the list of PVC and VolumeSnapshot pairs that
-                  is part of this group snapshot.
-                  The maximum number of allowed snapshots in the group is 100.
-                items:
-                  description: PVCVolumeSnapshotPair defines a pair of a PVC reference
-                    and a Volume Snapshot Reference
-                  properties:
-                    persistentVolumeClaimRef:
-                      description: PersistentVolumeClaimRef is a reference to the
-                        PVC this pair is referring to
-                      properties:
-                        name:
-                          description: |-
-                            Name of the referent.
-                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?
-                          type: string
-                      type: object
-                      x-kubernetes-map-type: atomic
-                    volumeSnapshotRef:
-                      description: VolumeSnapshotRef is a reference to the VolumeSnapshot
-                        this pair is referring to
-                      properties:
-                        name:
-                          description: |-
-                            Name of the referent.
-                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?
-                          type: string
-                      type: object
-                      x-kubernetes-map-type: atomic
-                  type: object
-                type: array
               readyToUse:
                 description: |-
                   ReadyToUse indicates if all the individual snapshots in the group are ready

--- a/pkg/common-controller/groupsnapshot_controller_helper.go
+++ b/pkg/common-controller/groupsnapshot_controller_helper.go
@@ -325,7 +325,7 @@ func (ctrl *csiSnapshotCommonController) syncGroupSnapshot(ctx context.Context, 
 	// 2) groupSnapshot.Status.ReadyToUse is false
 	// 3) groupSnapshot.Status.IsBoundVolumeGroupSnapshotContentNameSet is not set
 	// 4) groupSnapshot.Status.IsVolumeSnapshotRefListSet is not set
-	if !utils.IsGroupSnapshotReady(groupSnapshot) || !utils.IsBoundVolumeGroupSnapshotContentNameSet(groupSnapshot) || !utils.IsPVCVolumeSnapshotRefListSet(groupSnapshot) {
+	if !utils.IsGroupSnapshotReady(groupSnapshot) || !utils.IsBoundVolumeGroupSnapshotContentNameSet(groupSnapshot) {
 		return ctrl.syncUnreadyGroupSnapshot(ctx, groupSnapshot)
 	}
 	return ctrl.syncReadyGroupSnapshot(groupSnapshot)
@@ -1398,11 +1398,17 @@ func (ctrl *csiSnapshotCommonController) processGroupSnapshotWithDeletionTimesta
 		return nil
 	}
 
+	snapshotMembers, err := ctrl.snapshotLister.List(labels.SelectorFromSet(
+		labels.Set{
+			utils.VolumeGroupSnapshotNameLabel: groupSnapshot.Name,
+		},
+	))
+
 	// check if an individual snapshot belonging to the group snapshot is being
 	// used for restore a PVC
 	// If yes, do nothing and wait until PVC restoration finishes
-	for _, snapshotRef := range groupSnapshot.Status.PVCVolumeSnapshotRefList {
-		snapshot, err := ctrl.snapshotLister.VolumeSnapshots(groupSnapshot.Namespace).Get(snapshotRef.VolumeSnapshotRef.Name)
+	for _, snapshot := range snapshotMembers {
+		snapshot, err := ctrl.snapshotLister.VolumeSnapshots(groupSnapshot.Namespace).Get(snapshot.Name)
 		if err != nil {
 			if apierrs.IsNotFound(err) {
 				continue
@@ -1449,10 +1455,16 @@ func (ctrl *csiSnapshotCommonController) processGroupSnapshotWithDeletionTimesta
 	klog.V(5).Infof("processGroupSnapshotWithDeletionTimestamp[%s]: Delete individual snapshots that are part of the group snapshot", utils.GroupSnapshotKey(groupSnapshot))
 
 	// Delete the individual snapshots part of the group snapshot
-	for _, snapshot := range groupSnapshot.Status.PVCVolumeSnapshotRefList {
-		err := ctrl.clientset.SnapshotV1().VolumeSnapshots(groupSnapshot.Namespace).Delete(context.TODO(), snapshot.VolumeSnapshotRef.Name, metav1.DeleteOptions{})
+	for _, snapshot := range snapshotMembers {
+		err := ctrl.clientset.SnapshotV1().
+			VolumeSnapshots(groupSnapshot.Namespace).
+			Delete(context.TODO(), snapshot.Name, metav1.DeleteOptions{})
 		if err != nil && !apierrs.IsNotFound(err) {
-			msg := fmt.Sprintf("failed to delete snapshot API object %s/%s part of group snapshot %s: %v", groupSnapshot.Namespace, snapshot.VolumeSnapshotRef.Name, utils.GroupSnapshotKey(groupSnapshot), err)
+			msg := fmt.Sprintf(
+				"failed to delete snapshot API object %s/%s part of group snapshot %s: %v",
+				groupSnapshot.Namespace,
+				snapshot.Name,
+				utils.GroupSnapshotKey(groupSnapshot), err)
 			klog.Error(msg)
 			ctrl.eventRecorder.Event(groupSnapshot, v1.EventTypeWarning, "SnapshotDeleteError", msg)
 			return fmt.Errorf(msg)

--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -648,13 +648,6 @@ func IsBoundVolumeGroupSnapshotContentNameSet(groupSnapshot *crdv1alpha1.VolumeG
 	return true
 }
 
-func IsPVCVolumeSnapshotRefListSet(groupSnapshot *crdv1alpha1.VolumeGroupSnapshot) bool {
-	if groupSnapshot.Status == nil || len(groupSnapshot.Status.PVCVolumeSnapshotRefList) == 0 {
-		return false
-	}
-	return true
-}
-
 func IsVolumeGroupSnapshotRefSet(groupSnapshot *crdv1alpha1.VolumeGroupSnapshot, content *crdv1alpha1.VolumeGroupSnapshotContent) bool {
 	if content.Spec.VolumeGroupSnapshotRef.Name == groupSnapshot.Name &&
 		content.Spec.VolumeGroupSnapshotRef.Namespace == groupSnapshot.Namespace &&

--- a/vendor/github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumegroupsnapshot/v1alpha1/types.go
+++ b/vendor/github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumegroupsnapshot/v1alpha1/types.go
@@ -108,12 +108,6 @@ type VolumeGroupSnapshotStatus struct {
 	// group snapshot creation. Upon success, this error field will be cleared.
 	// +optional
 	Error *snapshotv1.VolumeSnapshotError `json:"error,omitempty" protobuf:"bytes,4,opt,name=error,casttype=VolumeSnapshotError"`
-
-	// VolumeSnapshotRefList is the list of PVC and VolumeSnapshot pairs that
-	// is part of this group snapshot.
-	// The maximum number of allowed snapshots in the group is 100.
-	// +optional
-	PVCVolumeSnapshotRefList []PVCVolumeSnapshotPair `json:"pvcVolumeSnapshotRefList,omitempty" protobuf:"bytes,5,opt,name=pvcVolumeSnapshotRefList"`
 }
 
 // PVCVolumeSnapshotPair defines a pair of a PVC reference and a Volume Snapshot Reference

--- a/vendor/github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumegroupsnapshot/v1alpha1/zz_generated.deepcopy.go
+++ b/vendor/github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumegroupsnapshot/v1alpha1/zz_generated.deepcopy.go
@@ -440,11 +440,6 @@ func (in *VolumeGroupSnapshotStatus) DeepCopyInto(out *VolumeGroupSnapshotStatus
 		*out = new(v1.VolumeSnapshotError)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.PVCVolumeSnapshotRefList != nil {
-		in, out := &in.PVCVolumeSnapshotRefList, &out.PVCVolumeSnapshotRefList
-		*out = make([]PVCVolumeSnapshotPair, len(*in))
-		copy(*out, *in)
-	}
 	return
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
/kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

This PR removes the `PVCVolumeSnapshotRefList` entry from the VolumeGroupSnapshot API. This is no longer needed since we now set `persistentVolumeClaimName` in the source of member VolumeSnapshots

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1202 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The `volumegroupsnapshot.status.pvcVolumeSnapshotRefList` field has been removed. VolumeShapshots members of a dynamically provisioned VolumeGroupSnapshot will have their `persistentVolumeClaimName` set, allowing the consumer to map the PVC being snapshotted with the corresponding snapshot.
```
