### PR TITLE
use annotation to store the groupsnapshot handle

### DIFF
--- a/pkg/common-controller/groupsnapshot_controller_helper.go
+++ b/pkg/common-controller/groupsnapshot_controller_helper.go
@@ -563,8 +563,8 @@ func (ctrl *csiSnapshotCommonController) createSnapshotsForGroupSnapshotContent(
 		volumeSnapshotContent := &crdv1.VolumeSnapshotContent{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: volumeSnapshotContentName,
-				Labels: map[string]string{
-					utils.VolumeGroupSnapshotHandleLabel: *groupSnapshotContent.Status.VolumeGroupSnapshotHandle,
+				Annotations: map[string]string{
+					utils.VolumeGroupSnapshotHandleAnnotation: *groupSnapshotContent.Status.VolumeGroupSnapshotHandle,
 				},
 			},
 			Spec: crdv1.VolumeSnapshotContentSpec{

--- a/pkg/sidecar-controller/snapshot_controller.go
+++ b/pkg/sidecar-controller/snapshot_controller.go
@@ -86,7 +86,7 @@ func (ctrl *csiSnapshotSideCarController) syncContent(content *crdv1.VolumeSnaps
 
 	// Create snapshot calling the CSI driver only if it is a dynamic
 	// provisioning for an independent snapshot.
-	_, groupSnapshotMember := content.Labels[utils.VolumeGroupSnapshotHandleLabel]
+	_, groupSnapshotMember := content.Annotations[utils.VolumeGroupSnapshotHandleAnnotation]
 	if content.Spec.Source.VolumeHandle != nil && content.Status == nil && !groupSnapshotMember {
 		klog.V(5).Infof("syncContent: Call CreateSnapshot for content %s", content.Name)
 		return ctrl.createSnapshot(content)
@@ -235,7 +235,7 @@ func (ctrl *csiSnapshotSideCarController) getCSISnapshotInput(content *crdv1.Vol
 		}
 	} else {
 		// If dynamic provisioning for an independent snapshot, return failure if no snapshot class
-		_, groupSnapshotMember := content.Labels[utils.VolumeGroupSnapshotHandleLabel]
+		_, groupSnapshotMember := content.Annotations[utils.VolumeGroupSnapshotHandleAnnotation]
 		if content.Spec.Source.VolumeHandle != nil && !groupSnapshotMember {
 			klog.Errorf("failed to getCSISnapshotInput %s without a snapshot class", content.Name)
 			return nil, nil, fmt.Errorf("failed to take snapshot %s without a snapshot class", content.Name)
@@ -316,7 +316,7 @@ func (ctrl *csiSnapshotSideCarController) checkandUpdateContentStatusOperation(c
 		return updatedContent, nil
 	}
 
-	_, groupSnapshotMember := content.Labels[utils.VolumeGroupSnapshotHandleLabel]
+	_, groupSnapshotMember := content.Annotations[utils.VolumeGroupSnapshotHandleAnnotation]
 	if !groupSnapshotMember {
 		return ctrl.createSnapshotWrapper(content)
 	}

--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -150,12 +150,12 @@ const (
 	// of a VolumeGroupSnapshot, and indicates the name of the latter.
 	VolumeGroupSnapshotNameLabel = "groupsnapshot.storage.k8s.io/volumeGroupSnapshotName"
 
-	// VolumeGroupSnapshotHandleLabel is applied to VolumeSnapshotContents that are member
+	// VolumeGroupSnapshotHandleAnnotation is applied to VolumeSnapshotContents that are member
 	// of a VolumeGroupSnapshotContent, and indicates the handle of the latter.
 	//
-	// This label is applied to inform the sidecar not to call CSI driver
+	// This annotation is applied to inform the sidecar not to call CSI driver
 	// to create snapshot if the snapshot belongs to a group.
-	VolumeGroupSnapshotHandleLabel = "groupsnapshot.storage.k8s.io/volumeGroupSnapshotHandle"
+	VolumeGroupSnapshotHandleAnnotation = "groupsnapshot.storage.k8s.io/volumeGroupSnapshotHandle"
 
 	// VolumeSnapshotContentInvalidLabel is applied to invalid content as a label key. The value does not matter.
 	// See https://github.com/kubernetes/enhancements/blob/master/keps/sig-storage/177-volume-snapshot/tighten-validation-webhook-crd.md#automatic-labelling-of-invalid-objects


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

 /kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

use annotation instead of label to storage the groupsnapshot handle to avoid length limit

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1218

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Store the volumegroupsnapshot handle as a annotation in the volumesnapshotcontent instead of labels as label values are restricted to 63 chars
```
