### PR TITLE
Use ownership to identify volume group snapshot members

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	k8s.io/component-base v0.31.0
 	k8s.io/component-helpers v0.31.0
 	k8s.io/klog/v2 v2.130.1
+	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8
 )
 
 require (
@@ -72,7 +73,6 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340 // indirect
-	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect

--- a/pkg/common-controller/framework_test.go
+++ b/pkg/common-controller/framework_test.go
@@ -1728,7 +1728,7 @@ func newVolumeError(message string) *crdv1.VolumeSnapshotError {
 }
 
 func testSyncSnapshot(ctrl *csiSnapshotCommonController, reactor *snapshotReactor, test controllerTest) error {
-	return ctrl.syncSnapshot(test.initialSnapshots[0])
+	return ctrl.syncSnapshot(context.TODO(), test.initialSnapshots[0])
 }
 
 func testSyncGroupSnapshot(ctrl *csiSnapshotCommonController, reactor *snapshotReactor, test controllerTest) error {
@@ -1736,7 +1736,7 @@ func testSyncGroupSnapshot(ctrl *csiSnapshotCommonController, reactor *snapshotR
 }
 
 func testSyncSnapshotError(ctrl *csiSnapshotCommonController, reactor *snapshotReactor, test controllerTest) error {
-	err := ctrl.syncSnapshot(test.initialSnapshots[0])
+	err := ctrl.syncSnapshot(context.TODO(), test.initialSnapshots[0])
 	if err != nil {
 		return nil
 	}

--- a/pkg/common-controller/snapshot_controller.go
+++ b/pkg/common-controller/snapshot_controller.go
@@ -173,7 +173,7 @@ func (ctrl *csiSnapshotCommonController) syncContent(content *crdv1.VolumeSnapsh
 // created, updated or periodically synced. We do not differentiate between
 // these events.
 // For easier readability, it is split into syncUnreadySnapshot and syncReadySnapshot
-func (ctrl *csiSnapshotCommonController) syncSnapshot(snapshot *crdv1.VolumeSnapshot) error {
+func (ctrl *csiSnapshotCommonController) syncSnapshot(ctx context.Context, snapshot *crdv1.VolumeSnapshot) error {
 	klog.V(5).Infof("synchronizing VolumeSnapshot[%s]: %s", utils.SnapshotKey(snapshot), utils.GetSnapshotStatusForLogging(snapshot))
 
 	klog.V(5).Infof("syncSnapshot [%s]: check if we should remove finalizer on snapshot PVC source and remove it if we can", utils.SnapshotKey(snapshot))
@@ -214,7 +214,7 @@ func (ctrl *csiSnapshotCommonController) syncSnapshot(snapshot *crdv1.VolumeSnap
 	if !utils.IsSnapshotReady(snapshot) || !utils.IsBoundVolumeSnapshotContentNameSet(snapshot) {
 		return ctrl.syncUnreadySnapshot(snapshot)
 	}
-	return ctrl.syncReadySnapshot(snapshot)
+	return ctrl.syncReadySnapshot(ctx, snapshot)
 }
 
 // processSnapshotWithDeletionTimestamp processes finalizers and deletes the content when appropriate. It has the following steps:
@@ -395,7 +395,7 @@ func (ctrl *csiSnapshotCommonController) checkandAddSnapshotFinalizers(snapshot 
 
 // syncReadySnapshot checks the snapshot which has been bound to snapshot content successfully before.
 // If there is any problem with the binding (e.g., snapshot points to a non-existent snapshot content), update the snapshot status and emit event.
-func (ctrl *csiSnapshotCommonController) syncReadySnapshot(snapshot *crdv1.VolumeSnapshot) error {
+func (ctrl *csiSnapshotCommonController) syncReadySnapshot(ctx context.Context, snapshot *crdv1.VolumeSnapshot) error {
 	if !utils.IsBoundVolumeSnapshotContentNameSet(snapshot) {
 		return fmt.Errorf("snapshot %s is not bound to a content", utils.SnapshotKey(snapshot))
 	}
@@ -415,8 +415,54 @@ func (ctrl *csiSnapshotCommonController) syncReadySnapshot(snapshot *crdv1.Volum
 		return ctrl.updateSnapshotErrorStatusWithEvent(snapshot, true, v1.EventTypeWarning, "SnapshotMisbound", "VolumeSnapshotContent is not bound to the VolumeSnapshot correctly")
 	}
 
+	// If this snapshot is a member of a volume group snapshot, ensure we have
+	// the correct ownership. This happens when the user
+	// statically provisioned volume group snapshot members.
+	if utils.NeedToAddVolumeGroupSnapshotOwnership(snapshot) {
+		if _, err := ctrl.addVolumeGroupSnapshotOwnership(ctx, snapshot); err != nil {
+			return err
+		}
+	}
+
 	// everything is verified, return
 	return nil
+}
+
+// addVolumeGroupSnapshotOwnership adds the ownership information to a statically provisioned VolumeSnapshot
+// that is a member of a volume group snapshot
+func (ctrl *csiSnapshotCommonController) addVolumeGroupSnapshotOwnership(ctx context.Context, snapshot *crdv1.VolumeSnapshot) (*crdv1.VolumeSnapshot, error) {
+	klog.V(4).Infof("addVolumeGroupSnapshotOwnership[%s]: adding ownership information", utils.SnapshotKey(snapshot))
+	if snapshot.Status == nil || snapshot.Status.VolumeGroupSnapshotName == nil {
+		klog.V(4).Infof("addVolumeGroupSnapshotOwnership[%s]: no need to add ownership information, empty volumeGroupSnapshotName", utils.SnapshotKey(snapshot))
+		return nil, nil
+	}
+	parentObjectName := *snapshot.Status.VolumeGroupSnapshotName
+
+	parentGroup, err := ctrl.groupSnapshotLister.VolumeGroupSnapshots(snapshot.Namespace).Get(parentObjectName)
+	if err != nil {
+		klog.V(4).Infof("addVolumeGroupSnapshotOwnership[%s]: error while looking for parent group %v", utils.SnapshotKey(snapshot), err)
+		return nil, err
+	}
+	if parentGroup == nil {
+		klog.V(4).Infof("addVolumeGroupSnapshotOwnership[%s]: parent group not found %v", utils.SnapshotKey(snapshot), err)
+		return nil, fmt.Errorf("missing parent group for snapshot %v", utils.SnapshotKey(snapshot))
+	}
+
+	updatedSnapshot := snapshot.DeepCopy()
+	updatedSnapshot.ObjectMeta.OwnerReferences = append(
+		snapshot.ObjectMeta.OwnerReferences,
+		utils.BuildVolumeGroupSnapshotOwnerReference(parentGroup),
+	)
+
+	newSnapshot, err := ctrl.clientset.SnapshotV1().VolumeSnapshots(snapshot.Namespace).Update(ctx, updatedSnapshot, metav1.UpdateOptions{})
+	if err != nil {
+		klog.V(4).Infof("addVolumeGroupSnapshotOwnership[%s]: error when updating VolumeSnapshot %v", utils.SnapshotKey(snapshot), err)
+		return nil, err
+	}
+
+	klog.V(4).Infof("addVolumeGroupSnapshotOwnership[%s]: updated ownership", utils.SnapshotKey(snapshot))
+
+	return newSnapshot, nil
 }
 
 // syncUnreadySnapshot is the main controller method to decide what to do with a snapshot which is not set to ready.
@@ -483,7 +529,7 @@ func (ctrl *csiSnapshotCommonController) syncUnreadySnapshot(snapshot *crdv1.Vol
 	}
 
 	// member of a dynamically provisioned volume group snapshot
-	if _, ok := snapshot.Labels[utils.VolumeGroupSnapshotNameLabel]; ok {
+	if utils.IsVolumeGroupSnapshotMember(snapshot) {
 		if snapshot.Status == nil || snapshot.Status.BoundVolumeSnapshotContentName == nil {
 			klog.V(5).Infof(
 				"syncUnreadySnapshot [%s]: detected group snapshot member with no content, retrying",
@@ -1422,7 +1468,7 @@ func (ctrl *csiSnapshotCommonController) SetDefaultSnapshotClass(snapshot *crdv1
 		return nil, snapshot, nil
 	}
 
-	if _, ok := snapshot.Labels[utils.VolumeGroupSnapshotNameLabel]; ok {
+	if utils.IsVolumeGroupSnapshotMember(snapshot) {
 		// don't return error for volume group snapshot members
 		klog.V(5).Infof("Don't need to find SnapshotClass for volume group snapshot member [%s]", snapshot.Name)
 		return nil, snapshot, nil

--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -146,10 +146,6 @@ const (
 	AnnDeletionGroupSecretRefName      = "groupsnapshot.storage.kubernetes.io/deletion-secret-name"
 	AnnDeletionGroupSecretRefNamespace = "groupsnapshot.storage.kubernetes.io/deletion-secret-namespace"
 
-	// VolumeGroupSnapshotNameLabel is applied to VolumeSnapshots that are member
-	// of a VolumeGroupSnapshot, and indicates the name of the latter.
-	VolumeGroupSnapshotNameLabel = "groupsnapshot.storage.k8s.io/volumeGroupSnapshotName"
-
 	// VolumeGroupSnapshotHandleAnnotation is applied to VolumeSnapshotContents that are member
 	// of a VolumeGroupSnapshotContent, and indicates the handle of the latter.
 	//

--- a/pkg/utils/vgs.go
+++ b/pkg/utils/vgs.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"fmt"
+
+	crdv1alpha1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumegroupsnapshot/v1alpha1"
+	crdv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// VolumeSnapshotParentGroupIndex is the name of the cache index hosting the relationship
+// between volume snapshots and their volume group snapshot owner
+const VolumeSnapshotParentGroupIndex = "ByVolumeGroupSnapshotMembership"
+
+// getVolumeGroupSnapshotParentObjectName returns the name of the parent group snapshot, if present.
+// The second return value is true when the parent object have been found, false otherwise.
+func getVolumeGroupSnapshotParentObjectName(snapshot *crdv1.VolumeSnapshot) string {
+	if snapshot == nil {
+		return ""
+	}
+
+	apiVersion := fmt.Sprintf(
+		"%s/%s",
+		crdv1alpha1.SchemeGroupVersion.Group,
+		crdv1alpha1.SchemeGroupVersion.Version,
+	)
+
+	for _, owner := range snapshot.ObjectMeta.OwnerReferences {
+		if owner.Kind == "VolumeGroupSnapshot" && owner.APIVersion == apiVersion {
+			return owner.Name
+		}
+	}
+
+	return ""
+}
+
+// IsVolumeGroupSnapshotMember returns true if the passed VolumeSnapshot object
+// is a member of a VolumeGroupSnapshot.
+func IsVolumeGroupSnapshotMember(snapshot *crdv1.VolumeSnapshot) bool {
+	parentName := getVolumeGroupSnapshotParentObjectName(snapshot)
+	return len(parentName) > 0
+}
+
+// VolumeSnapshotParentGroupKeyFunc maps a member snapshot to the name
+// of the parent VolumeGroupSnapshot
+func VolumeSnapshotParentGroupKeyFunc(snapshot *crdv1.VolumeSnapshot) string {
+	parentName := getVolumeGroupSnapshotParentObjectName(snapshot)
+	if len(parentName) == 0 {
+		return ""
+	}
+
+	return VolumeSnapshotParentGroupKeyFuncByComponents(types.NamespacedName{
+		Namespace: snapshot.Namespace,
+		Name:      parentName,
+	})
+}
+
+// VolumeSnapshotParentGroupKeyFuncByComponents computes the index key for a certain
+// name and namespace pair
+func VolumeSnapshotParentGroupKeyFuncByComponents(objectKey types.NamespacedName) string {
+	return fmt.Sprintf("%s^%s", objectKey.Namespace, objectKey.Name)
+}
+
+// NeedToAddVolumeGroupSnapshotOwnership checks if the passed snapshot is a member
+// of a volume group snapshot but the ownership is missing
+func NeedToAddVolumeGroupSnapshotOwnership(snapshot *crdv1.VolumeSnapshot) bool {
+	parentObjectName := getVolumeGroupSnapshotParentObjectName(snapshot)
+	if len(parentObjectName) > 0 {
+		return false
+	}
+
+	// Group snapshot ownership should be added only when
+	// the snapshot is marked with its group snapshot name
+	if snapshot == nil ||
+		snapshot.Status == nil ||
+		snapshot.Status.VolumeGroupSnapshotName == nil ||
+		len(*snapshot.Status.VolumeGroupSnapshotName) == 0 {
+		return false
+	}
+
+	return true
+}
+
+// BuildVolumeGroupSnapshotOwnerReference creates a OwnerReference record declaring an
+// object as a child of passed VolumeGroupSnapshot
+func BuildVolumeGroupSnapshotOwnerReference(parentGroup *crdv1alpha1.VolumeGroupSnapshot) metav1.OwnerReference {
+	return metav1.OwnerReference{
+		APIVersion: fmt.Sprintf(
+			"%s/%s",
+			crdv1alpha1.SchemeGroupVersion.Group,
+			crdv1alpha1.SchemeGroupVersion.Version,
+		),
+		Kind: "VolumeGroupSnapshot",
+		Name: parentGroup.Name,
+		UID:  parentGroup.UID,
+	}
+}

--- a/pkg/utils/vgs_test.go
+++ b/pkg/utils/vgs_test.go
@@ -1,0 +1,216 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	crdv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+)
+
+func TestIsVolumeSnapshotGroupMember(t *testing.T) {
+	testCases := []struct {
+		name                     string
+		snapshot                 *crdv1.VolumeSnapshot
+		expected                 bool
+		expectedParentObjectName string
+		expectedIndexKey         string
+	}{
+		{
+			name:                     "nil snapshot",
+			snapshot:                 nil,
+			expected:                 false,
+			expectedParentObjectName: "",
+			expectedIndexKey:         "",
+		},
+		{
+			name:                     "without ownership",
+			snapshot:                 &crdv1.VolumeSnapshot{},
+			expected:                 false,
+			expectedParentObjectName: "",
+			expectedIndexKey:         "",
+		},
+		{
+			name: "with a different ownership",
+			snapshot: &crdv1.VolumeSnapshot{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "v1",
+							Name:       "test",
+							Kind:       "Deployment",
+						},
+					},
+				},
+			},
+			expected:                 false,
+			expectedParentObjectName: "",
+			expectedIndexKey:         "",
+		},
+		{
+			name: "with wrong ownership",
+			snapshot: &crdv1.VolumeSnapshot{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "test/v1beta1",
+							Kind:       "VolumeGroupSnapshot",
+							Name:       "vgs",
+						},
+					},
+				},
+			},
+			expected:                 false,
+			expectedParentObjectName: "",
+			expectedIndexKey:         "",
+		},
+		{
+			name: "with correct ownership",
+			snapshot: &crdv1.VolumeSnapshot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vs",
+					Namespace: "default",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "groupsnapshot.storage.k8s.io/v1alpha1",
+							Kind:       "VolumeGroupSnapshot",
+							Name:       "vgs",
+						},
+					},
+				},
+			},
+			expected:                 true,
+			expectedParentObjectName: "vgs",
+			expectedIndexKey:         "default^vgs",
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			result := IsVolumeGroupSnapshotMember(test.snapshot)
+			if result != test.expected {
+				t.Errorf("IsVolumeSnapshotGroupMember(s) = %v WANT %v", result, test.expected)
+			}
+
+			resultParentObject := getVolumeGroupSnapshotParentObjectName(test.snapshot)
+			if resultParentObject != test.expectedParentObjectName {
+				t.Errorf("GetVolumeGroupSnapshotParentObjectName(s) = %v WANTED %v", resultParentObject, test.expectedParentObjectName)
+			}
+
+			resultKey := VolumeSnapshotParentGroupKeyFunc(test.snapshot)
+			if resultKey != test.expectedIndexKey {
+				t.Errorf("VolumeSnapshotParentGroupKeyFunc(s) = %v WANTED %v", resultKey, test.expectedIndexKey)
+			}
+		})
+	}
+}
+
+func TestNeedToAddVolumeGroupSnapshotOwnership(t *testing.T) {
+	testCases := []struct {
+		name     string
+		snapshot *crdv1.VolumeSnapshot
+		expected bool
+	}{
+		{
+			name:     "nil snapshot",
+			snapshot: nil,
+			expected: false,
+		},
+		{
+			name: "snapshot with nil status",
+			snapshot: &crdv1.VolumeSnapshot{
+				Status: nil,
+			},
+			expected: false,
+		},
+		{
+			name: "independent snapshot",
+			snapshot: &crdv1.VolumeSnapshot{
+				Status: &crdv1.VolumeSnapshotStatus{
+					VolumeGroupSnapshotName: nil,
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "snapshot with empty volume group snapshot name",
+			snapshot: &crdv1.VolumeSnapshot{
+				Status: &crdv1.VolumeSnapshotStatus{
+					VolumeGroupSnapshotName: ptr.To(""),
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "snapshot with empty ownership metadata",
+			snapshot: &crdv1.VolumeSnapshot{
+				Status: &crdv1.VolumeSnapshotStatus{
+					VolumeGroupSnapshotName: ptr.To("vgs"),
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "snapshot missing the group ownership but having other ownerships",
+			snapshot: &crdv1.VolumeSnapshot{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "v1",
+							Kind:       "Deployment",
+							Name:       "test",
+						},
+					},
+				},
+				Status: &crdv1.VolumeSnapshotStatus{
+					VolumeGroupSnapshotName: ptr.To("vgs"),
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "snapshot with the ownership already set",
+			snapshot: &crdv1.VolumeSnapshot{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "groupsnapshot.storage.k8s.io/v1alpha1",
+							Kind:       "VolumeGroupSnapshot",
+							Name:       "vgs",
+						},
+					},
+				},
+				Status: &crdv1.VolumeSnapshotStatus{
+					VolumeGroupSnapshotName: ptr.To("vgs"),
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			result := NeedToAddVolumeGroupSnapshotOwnership(test.snapshot)
+			if result != test.expected {
+				t.Errorf("NeedToAddVolumeGroupSnapshotOwnership(s) = %v WANT %v", result, test.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Instead of marking the member snapshot object with a label, this PR uses an ownership reference.

Member objects are looked up using a new index in the informer cache.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

This PR removes the usage of the `groupsnapshot.storage.k8s.io/volumeGroupSnapshotName` label, opting for an ownership-based volume group snapshot member tracking as described in [the relative comment](https://github.com/kubernetes-csi/external-snapshotter/issues/1213#issuecomment-2498764193).

The patch fixes an issue in the `csi-snapshotter` sidecar that was failing to pass the snapshot ids to the DeleteGroupSnapshot RPC endpoint for statically provisioned snapshots with the `Delete` retention policy.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1213

**Special notes for your reviewer**:

With this PR applied, my smoke tests are passing.
They cover volume group snapshots (static and dynamic provisioning, both retain and delete deletion policy) and volume snapshots (static and dynamic provisioning, both retain and delete deletion policy).

I manually tested creating a volume group snapshot with a name of 73 characters and everything went fine.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The  `groupsnapshot.storage.k8s.io/volumeGroupSnapshotName` label is not used anymore for dynamically provisioned volume group snapshot members. The members of a volume group snapshot can be identified as being owned by the VolumeGroupSnapshot.
```
