### PR TITLE
replace enable-volume-group-snapshots with featuregate

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,10 +119,10 @@ Other than this, the NODE_NAME environment variable must be set where the CSI sn
 The following requisites must be met to enable the volume group snapshot feature:
 
 * the Volume Group Snapshot CRDs are installed in the cluster
-* the `--enable-volume-group-snapshots=true` option is being passed to the snapshot controller
-* the `--enable-volume-group-snapshots=true` option is being passed to the CSI snapshotter sidecar
+* the `--feature-gates=CSIVolumeGroupSnapshot=true` option is being passed to the snapshot controller
+* the `--feature-gates=CSIVolumeGroupSnapshot=true` option is being passed to the CSI snapshotter sidecar
 
-Specifically, `deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml` needs to be updated with `--enable-volume-group-snapshots=true` in order to enable this feature in the snapshot controller.
+Specifically, `deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml` needs to be updated with `--feature-gates=CSIVolumeGroupSnapshot=true` in order to enable this feature in the snapshot controller.
 
 ### Snapshot controller command line options
 
@@ -159,7 +159,7 @@ Specifically, `deploy/kubernetes/snapshot-controller/setup-snapshot-controller.y
 
 #### Volume Group Snapshot support
 
-* `--enable-volume-group-snapshots`: Enables support for Volume Group Snapshots. If this option is enabled, the VolumeGroupSnapshots CRD should be available on the cluster.
+* `--feature-gates=CSIVolumeGroupSnapshot=true`: Enables support for Volume Group Snapshots. If this option is enabled, the VolumeGroupSnapshots CRD should be available on the cluster.
 
 #### Other recognized arguments
 * `--kubeconfig <path>`: Path to Kubernetes client configuration that the snapshot controller uses to connect to Kubernetes API server. When omitted, default token provided by Kubernetes will be used. This option is useful only when the snapshot controller does not run as a Kubernetes pod, e.g. for debugging.
@@ -205,7 +205,7 @@ Specifically, `deploy/kubernetes/snapshot-controller/setup-snapshot-controller.y
 
 #### Volume Group Snapshot support
 
-* `--enable-volume-group-snapshots`: Enables support for Volume Group Snapshots. If this option is enabled, the VolumeGroupSnapshots CRD should be available on the cluster.
+* `--feature-gates=CSIVolumeGroupSnapshot=true`: Enables support for Volume Group Snapshots. If this option is enabled, the VolumeGroupSnapshots CRD should be available on the cluster.
 
 #### Other recognized arguments
 * `--kubeconfig <path>`: Path to Kubernetes client configuration that the CSI external-snapshotter uses to connect to Kubernetes API server. When omitted, default token provided by Kubernetes will be used. This option is useful only when the external-snapshotter does not run as a Kubernetes pod, e.g. for debugging.

--- a/cmd/csi-snapshotter/main.go
+++ b/cmd/csi-snapshotter/main.go
@@ -250,7 +250,7 @@ func main() {
 		if err != nil {
 			klog.Errorf("error determining if driver supports create/delete group snapshot operations: %v", err)
 		} else if !supportsCreateVolumeGroupSnapshot {
-			klog.Warningf("CSI driver %s does not support GroupControllerCreateVolumeGroupSnapshot when the --enable-volume-group-snapshots flag is true", driverName)
+			klog.Warningf("CSI driver %s does not support GroupControllerCreateVolumeGroupSnapshot when the --feature-gates=CSIVolumeGroupSnapshot=true flag is set", driverName)
 		}
 		groupSnapshotter = group_snapshotter.NewGroupSnapshotter(csiConn)
 		if len(*groupSnapshotNamePrefix) == 0 {


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

 /kind cleanup

> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

replace the old ref of enable-volume-group-snapshots flag with featuregate

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1227

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```
