### PR TITLE
Change CreationTime in VolumeGroupSnapshotContentStatus from *int64 to *metav1.Time

### DIFF
--- a/client/apis/volumegroupsnapshot/v1beta1/types.go
+++ b/client/apis/volumegroupsnapshot/v1beta1/types.go
@@ -327,7 +327,7 @@ type VolumeGroupSnapshotContentStatus struct {
 	// since 1970-01-01 00:00:00 UTC.
 	// This field is the source for the CreationTime field in VolumeGroupSnapshotStatus
 	// +optional
-	CreationTime *int64 `json:"creationTime,omitempty" protobuf:"varint,2,opt,name=creationTime"`
+	CreationTime *metav1.Time `json:"creationTime,omitempty" protobuf:"bytes,2,opt,name=creationTime"`
 
 	// ReadyToUse indicates if all the individual snapshots in the group are ready to be
 	// used to restore a group of volumes.

--- a/client/apis/volumegroupsnapshot/v1beta1/zz_generated.deepcopy.go
+++ b/client/apis/volumegroupsnapshot/v1beta1/zz_generated.deepcopy.go
@@ -270,8 +270,7 @@ func (in *VolumeGroupSnapshotContentStatus) DeepCopyInto(out *VolumeGroupSnapsho
 	}
 	if in.CreationTime != nil {
 		in, out := &in.CreationTime, &out.CreationTime
-		*out = new(int64)
-		**out = **in
+		*out = (*in).DeepCopy()
 	}
 	if in.ReadyToUse != nil {
 		in, out := &in.ReadyToUse, &out.ReadyToUse

--- a/client/config/crd/groupsnapshot.storage.k8s.io_volumegroupsnapshotcontents.yaml
+++ b/client/config/crd/groupsnapshot.storage.k8s.io_volumegroupsnapshotcontents.yaml
@@ -256,8 +256,8 @@ spec:
                   On Unix, the command date +%s%N returns the current time in nanoseconds
                   since 1970-01-01 00:00:00 UTC.
                   This field is the source for the CreationTime field in VolumeGroupSnapshotStatus
-                format: int64
-                type: integer
+                format: date-time
+                type: string
               error:
                 description: |-
                   Error is the last observed error during group snapshot creation, if any.

--- a/pkg/common-controller/framework_test.go
+++ b/pkg/common-controller/framework_test.go
@@ -1280,7 +1280,7 @@ func newContent(contentName, boundToSnapshotUID, boundToSnapshotName, snapshotHa
 }
 
 func newGroupSnapshotContent(groupSnapshotContentName, boundToGroupSnapshotUID, boundToGroupSnapshotName, groupSnapshotHandle, groupSnapshotClassName string, desiredVolumeHandles []string, targetVolumeGroupSnapshotHandle string,
-	deletionPolicy crdv1.DeletionPolicy, creationTime *int64,
+	deletionPolicy crdv1.DeletionPolicy, creationTime *metav1.Time,
 	withFinalizer bool, withStatus bool) *crdv1beta1.VolumeGroupSnapshotContent {
 	ready := true
 	content := crdv1beta1.VolumeGroupSnapshotContent{
@@ -1337,7 +1337,7 @@ func newGroupSnapshotContent(groupSnapshotContentName, boundToGroupSnapshotUID, 
 }
 
 func newGroupSnapshotContentArray(groupSnapshotContentName, boundToGroupSnapshotUID, boundToGroupSnapshotSnapshotName, groupSnapshotHandle, groupSnapshotClassName string, desiredVolumeHandles []string, volumeGroupHandle string,
-	deletionPolicy crdv1.DeletionPolicy, creationTime *int64,
+	deletionPolicy crdv1.DeletionPolicy, creationTime *metav1.Time,
 	withFinalizer bool, withStatus bool) []*crdv1beta1.VolumeGroupSnapshotContent {
 	return []*crdv1beta1.VolumeGroupSnapshotContent{
 		newGroupSnapshotContent(groupSnapshotContentName, boundToGroupSnapshotUID, boundToGroupSnapshotSnapshotName, groupSnapshotHandle, groupSnapshotClassName, desiredVolumeHandles, volumeGroupHandle,

--- a/pkg/common-controller/groupsnapshot_controller_helper.go
+++ b/pkg/common-controller/groupsnapshot_controller_helper.go
@@ -832,8 +832,7 @@ func (ctrl *csiSnapshotCommonController) updateGroupSnapshotStatus(groupSnapshot
 	boundContentName := groupSnapshotContent.Name
 	var createdAt *time.Time
 	if groupSnapshotContent.Status != nil && groupSnapshotContent.Status.CreationTime != nil {
-		unixTime := time.Unix(0, *groupSnapshotContent.Status.CreationTime)
-		createdAt = &unixTime
+		createdAt = &groupSnapshotContent.Status.CreationTime.DeepCopy().Time
 	}
 	var readyToUse bool
 	if groupSnapshotContent.Status != nil && groupSnapshotContent.Status.ReadyToUse != nil {

--- a/pkg/sidecar-controller/groupsnapshot_helper.go
+++ b/pkg/sidecar-controller/groupsnapshot_helper.go
@@ -443,7 +443,7 @@ func (ctrl *csiSnapshotSideCarController) createGroupSnapshotWrapper(groupSnapsh
 		})
 	}
 
-	newGroupSnapshotContent, err := ctrl.updateGroupSnapshotContentStatus(groupSnapshotContent, groupSnapshotID, readyToUse, creationTime.UnixNano(), snapshotContentLinks)
+	newGroupSnapshotContent, err := ctrl.updateGroupSnapshotContentStatus(groupSnapshotContent, groupSnapshotID, readyToUse, metav1.NewTime(creationTime), snapshotContentLinks)
 	if err != nil {
 		klog.Errorf("error updating status for volume group snapshot content %s: %v.", groupSnapshotContent.Name, err)
 		return groupSnapshotContent, fmt.Errorf("error updating status for volume group snapshot content %s: %v", groupSnapshotContent.Name, err)
@@ -578,7 +578,7 @@ func (ctrl *csiSnapshotSideCarController) updateGroupSnapshotContentStatus(
 	groupSnapshotContent *crdv1beta1.VolumeGroupSnapshotContent,
 	groupSnapshotHandle string,
 	readyToUse bool,
-	createdAt int64,
+	createdAt metav1.Time,
 	snapshotContentLinks []snapshotContentNameVolumeHandlePair,
 ) (*crdv1beta1.VolumeGroupSnapshotContent, error) {
 	klog.V(5).Infof("updateGroupSnapshotContentStatus: updating VolumeGroupSnapshotContent [%s], groupSnapshotHandle %s, readyToUse %v, createdAt %v", groupSnapshotContent.Name, groupSnapshotHandle, readyToUse, createdAt)
@@ -789,7 +789,7 @@ func (ctrl *csiSnapshotSideCarController) checkandUpdateGroupSnapshotContentStat
 		}
 
 		// TODO: Get a reference to snapshot contents for this volume group snapshot
-		updatedContent, err := ctrl.updateGroupSnapshotContentStatus(groupSnapshotContent, groupSnapshotID, readyToUse, creationTime.UnixNano(), []snapshotContentNameVolumeHandlePair{})
+		updatedContent, err := ctrl.updateGroupSnapshotContentStatus(groupSnapshotContent, groupSnapshotID, readyToUse, metav1.NewTime(creationTime), []snapshotContentNameVolumeHandlePair{})
 		if err != nil {
 			return groupSnapshotContent, err
 		}

--- a/vendor/github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumegroupsnapshot/v1beta1/types.go
+++ b/vendor/github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumegroupsnapshot/v1beta1/types.go
@@ -327,7 +327,7 @@ type VolumeGroupSnapshotContentStatus struct {
 	// since 1970-01-01 00:00:00 UTC.
 	// This field is the source for the CreationTime field in VolumeGroupSnapshotStatus
 	// +optional
-	CreationTime *int64 `json:"creationTime,omitempty" protobuf:"varint,2,opt,name=creationTime"`
+	CreationTime *metav1.Time `json:"creationTime,omitempty" protobuf:"bytes,2,opt,name=creationTime"`
 
 	// ReadyToUse indicates if all the individual snapshots in the group are ready to be
 	// used to restore a group of volumes.

--- a/vendor/github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumegroupsnapshot/v1beta1/zz_generated.deepcopy.go
+++ b/vendor/github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumegroupsnapshot/v1beta1/zz_generated.deepcopy.go
@@ -270,8 +270,7 @@ func (in *VolumeGroupSnapshotContentStatus) DeepCopyInto(out *VolumeGroupSnapsho
 	}
 	if in.CreationTime != nil {
 		in, out := &in.CreationTime, &out.CreationTime
-		*out = new(int64)
-		**out = **in
+		*out = (*in).DeepCopy()
 	}
 	if in.ReadyToUse != nil {
 		in, out := &in.ReadyToUse, &out.ReadyToUse


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>

/kind api-change

> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1234

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
`VolumeGroupSnapshotContent.status.creationTime` is now a metav1.Time instead of an unix epoch time
```
