### PR TITLE
Fix Snapshot Controller's unbounded VolumeSnapshot list call on startup

### DIFF
--- a/cmd/snapshot-controller/main.go
+++ b/cmd/snapshot-controller/main.go
@@ -88,9 +88,9 @@ var version = "unknown"
 func ensureCustomResourceDefinitionsExist(client *clientset.Clientset, enableVolumeGroupSnapshots bool) error {
 	condition := func(ctx context.Context) (bool, error) {
 		var err error
-		// List calls should return faster with a limit of 0.
+		// List calls should return faster with a limit of 1.
 		// We do not care about what is returned and just want to make sure the CRDs exist.
-		listOptions := metav1.ListOptions{Limit: 0}
+		listOptions := metav1.ListOptions{Limit: 1}
 
 		// scoping to an empty namespace makes `List` work across all namespaces
 		_, err = client.SnapshotV1().VolumeSnapshots("").List(ctx, listOptions)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change


/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

As of v6.2.2, the snapshot controller performs a list operation on startup as a way of validating the Snapshot CRD is installed on the cluster. v7.0.0 attempts to put a limit on this list call of 0, but [that is treated as an unbounded request by etcd](https://github.com/kubernetes/kubernetes/blob/249ad2a6137cc8f1e0ccb7f0aef9ff4ba38927b9/vendor/go.etcd.io/etcd/client/v3/kubernetes/interface.go#L75). 

For clusters with many VolumeSnapshots, the API Server may struggle to handle an unbounded list request within 60s, leading to continuous restarts in the snapshot controller. 

@wongma7 proposes a better longterm solution [here](https://github.com/kubernetes-csi/external-snapshotter/pull/1238#discussion_r1876893801), but this PR introduces a short-term fix of properly setting the list response limit to 1.  

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

Within k8s API server, paging gets set to false [here](https://github.com/kubernetes/apiserver/blob/3658357fea9fa8b36173d072f2d548f135049e05/pkg/storage/etcd3/store.go#L713) because limit <= 0

We pass through limit = 0 to store.getList [here](https://github.com/kubernetes/apiserver/blob/3658357fea9fa8b36173d072f2d548f135049e05/pkg/storage/etcd3/store.go#L749)

For etcd, limit of 0 allegedly means no limitation [documented here](https://github.com/kubernetes/kubernetes/blob/249ad2a6137cc8f1e0ccb7f0aef9ff4ba38927b9/vendor/go.etcd.io/etcd/client/v3/kubernetes/interface.go#L75)

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix unbounded volumesnapshots list call on Snapshot Controller startup
```
