### PR TITLE
[release-8.1] Bump to go v1.23.1 to fix trivy

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Install go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.5
+          go-version: 1.23.1
 
       - name: Build images from Dockerfile
         run: |

--- a/CHANGELOG/CHANGELOG-8.1.md
+++ b/CHANGELOG/CHANGELOG-8.1.md
@@ -1,0 +1,102 @@
+# Release notes for v8.1.0
+
+[Documentation](https://kubernetes-csi.github.io)
+
+# Changelog since v8.0.0
+
+## Changes by Kind
+
+### Documentation
+
+- Document Volume Group Snapshot feature in the README file ([#1120](https://github.com/kubernetes-csi/external-snapshotter/pull/1120), [@leonardoce](https://github.com/leonardoce))
+
+### Bug or Regression
+
+- Look for a VolumeGroupSnapshotClass instead of a VolumeSnapshotClass when getting metrics data for VolumeGroupSnapshot metrics. ([#1115](https://github.com/kubernetes-csi/external-snapshotter/pull/1115), [@leonardoce](https://github.com/leonardoce))
+- Prevents a VolumeGroupSnapshot to be provisioned when the volumes' CSI driver is different from the one referenced in the VolumeGroupSnapshotClass resource ([#1098](https://github.com/kubernetes-csi/external-snapshotter/pull/1098), [@leonardoce](https://github.com/leonardoce))
+- The controller will now detect new default VolumeSnapshotClasses and VolumeGroupSnapshotClasses.
+  If multiple classes exist for the same CSI driver, VolumeSnapshot and VolumeGroupSnapshots
+  will be marked as failed when provisioned dynamically. ([#1100](https://github.com/kubernetes-csi/external-snapshotter/pull/1100), [@leonardoce](https://github.com/leonardoce))
+
+### Other (Cleanup or Flake)
+
+- Updates Kubernetes dependencies to v1.31.0 ([#1139](https://github.com/kubernetes-csi/external-snapshotter/pull/1139), [@dfajmon](https://github.com/dfajmon))
+
+### Uncategorized
+
+- Cleanup: Update csi release tools ([#1137](https://github.com/kubernetes-csi/external-snapshotter/pull/1137), [@andyzhangx](https://github.com/andyzhangx))
+- Fixes a race condition where the PVC finalizer could end up not being removed by the snapshot-controller if the update had a conflict. ([#1133](https://github.com/kubernetes-csi/external-snapshotter/pull/1133), [@Fricounet](https://github.com/Fricounet))
+- It exposes the metrics for volumegroupsnapshot operations on passing flags like --http-endpoint and --metrics-path to the snapshot controller. These are the command line arguments for the users to enable metrics and start the sever.
+  The metric `snapshot_controller_operation_total_seconds` has been added for the volumegroupsnapshot operations:
+  1. CreateGroupSnapshot
+  2. DeleteGroupSnapshot
+  3. CreateSnapshotAndReady ([#1107](https://github.com/kubernetes-csi/external-snapshotter/pull/1107), [@yati1998](https://github.com/yati1998))
+
+## Dependencies
+
+### Added
+- cel.dev/expr: v0.15.0
+- github.com/go-task/slim-sprig/v3: [v3.0.0](https://github.com/go-task/slim-sprig/tree/v3.0.0)
+- github.com/klauspost/compress: [v1.17.9](https://github.com/klauspost/compress/tree/v1.17.9)
+- github.com/kylelemons/godebug: [v1.1.0](https://github.com/kylelemons/godebug/tree/v1.1.0)
+- gopkg.in/evanphx/json-patch.v4: v4.12.0
+
+### Changed
+- github.com/cenkalti/backoff/v4: [v4.2.1 → v4.3.0](https://github.com/cenkalti/backoff/compare/v4.2.1...v4.3.0)
+- github.com/cncf/xds/go: [8a4994d → 555b57e](https://github.com/cncf/xds/compare/8a4994d...555b57e)
+- github.com/cpuguy83/go-md2man/v2: [v2.0.3 → v2.0.4](https://github.com/cpuguy83/go-md2man/compare/v2.0.3...v2.0.4)
+- github.com/davecgh/go-spew: [v1.1.1 → d8f796a](https://github.com/davecgh/go-spew/compare/v1.1.1...d8f796a)
+- github.com/emicklei/go-restful/v3: [v3.12.0 → v3.12.1](https://github.com/emicklei/go-restful/compare/v3.12.0...v3.12.1)
+- github.com/felixge/httpsnoop: [v1.0.3 → v1.0.4](https://github.com/felixge/httpsnoop/compare/v1.0.3...v1.0.4)
+- github.com/fxamacker/cbor/v2: [v2.6.0 → v2.7.0](https://github.com/fxamacker/cbor/compare/v2.6.0...v2.7.0)
+- github.com/go-logr/logr: [v1.4.1 → v1.4.2](https://github.com/go-logr/logr/compare/v1.4.1...v1.4.2)
+- github.com/golang/glog: [v1.2.0 → v1.2.1](https://github.com/golang/glog/compare/v1.2.0...v1.2.1)
+- github.com/google/pprof: [4bb14d4 → 4bfdf5a](https://github.com/google/pprof/compare/4bb14d4...4bfdf5a)
+- github.com/grpc-ecosystem/grpc-gateway/v2: [v2.16.0 → v2.20.0](https://github.com/grpc-ecosystem/grpc-gateway/compare/v2.16.0...v2.20.0)
+- github.com/kubernetes-csi/csi-lib-utils: [v0.18.0 → v0.19.0](https://github.com/kubernetes-csi/csi-lib-utils/compare/v0.18.0...v0.19.0)
+- github.com/moby/spdystream: [v0.2.0 → v0.4.0](https://github.com/moby/spdystream/compare/v0.2.0...v0.4.0)
+- github.com/moby/term: [1aeaba8 → v0.5.0](https://github.com/moby/term/compare/1aeaba8...v0.5.0)
+- github.com/onsi/ginkgo/v2: [v2.15.0 → v2.19.0](https://github.com/onsi/ginkgo/compare/v2.15.0...v2.19.0)
+- github.com/onsi/gomega: [v1.31.0 → v1.33.1](https://github.com/onsi/gomega/compare/v1.31.0...v1.33.1)
+- github.com/pmezard/go-difflib: [v1.0.0 → 5d4384e](https://github.com/pmezard/go-difflib/compare/v1.0.0...5d4384e)
+- github.com/prometheus/client_golang: [v1.19.1 → v1.20.2](https://github.com/prometheus/client_golang/compare/v1.19.1...v1.20.2)
+- github.com/prometheus/common: [v0.53.0 → v0.55.0](https://github.com/prometheus/common/compare/v0.53.0...v0.55.0)
+- github.com/prometheus/procfs: [v0.15.0 → v0.15.1](https://github.com/prometheus/procfs/compare/v0.15.0...v0.15.1)
+- github.com/rogpeppe/go-internal: [v1.11.0 → v1.12.0](https://github.com/rogpeppe/go-internal/compare/v1.11.0...v1.12.0)
+- github.com/spf13/cobra: [v1.8.0 → v1.8.1](https://github.com/spf13/cobra/compare/v1.8.0...v1.8.1)
+- go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc: v0.51.0 → v0.54.0
+- go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp: v0.44.0 → v0.53.0
+- go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc: v1.19.0 → v1.27.0
+- go.opentelemetry.io/otel/exporters/otlp/otlptrace: v1.19.0 → v1.28.0
+- go.opentelemetry.io/otel/metric: v1.26.0 → v1.29.0
+- go.opentelemetry.io/otel/sdk: v1.19.0 → v1.28.0
+- go.opentelemetry.io/otel/trace: v1.26.0 → v1.29.0
+- go.opentelemetry.io/otel: v1.26.0 → v1.29.0
+- go.opentelemetry.io/proto/otlp: v1.0.0 → v1.3.1
+- golang.org/x/crypto: v0.23.0 → v0.26.0
+- golang.org/x/mod: v0.15.0 → v0.17.0
+- golang.org/x/net: v0.25.0 → v0.28.0
+- golang.org/x/oauth2: v0.20.0 → v0.22.0
+- golang.org/x/sync: v0.7.0 → v0.8.0
+- golang.org/x/sys: v0.20.0 → v0.24.0
+- golang.org/x/term: v0.20.0 → v0.23.0
+- golang.org/x/text: v0.15.0 → v0.17.0
+- golang.org/x/time: v0.5.0 → v0.6.0
+- golang.org/x/tools: v0.18.0 → e35e4cc
+- google.golang.org/appengine: v1.6.8 → v1.6.7
+- google.golang.org/genproto/googleapis/api: 94a12d6 → 5315273
+- google.golang.org/genproto/googleapis/rpc: 94a12d6 → fc7c04a
+- google.golang.org/grpc: v1.64.0 → v1.65.0
+- google.golang.org/protobuf: v1.34.1 → v1.34.2
+- k8s.io/api: v0.30.0 → v0.31.0
+- k8s.io/apimachinery: v0.30.0 → v0.31.0
+- k8s.io/client-go: v0.30.0 → v0.31.0
+- k8s.io/code-generator: v0.30.0 → v0.31.0
+- k8s.io/component-base: v0.30.0 → v0.31.0
+- k8s.io/component-helpers: v0.30.0 → v0.31.0
+- k8s.io/klog/v2: v2.120.1 → v2.130.1
+- k8s.io/utils: 3b25d92 → 18e509b
+
+### Removed
+- cloud.google.com/go/compute: v1.25.1
+- github.com/matttproud/golang_protobuf_extensions: [v1.0.4](https://github.com/matttproud/golang_protobuf_extensions/tree/v1.0.4)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubernetes-csi/external-snapshotter/v8
 
-go 1.22.5
+go 1.23.1
 
 require (
 	github.com/container-storage-interface/spec v1.9.0

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/kubernetes-csi/csi-lib-utils v0.19.0
 	github.com/kubernetes-csi/csi-test/v5 v5.2.0
 	github.com/kubernetes-csi/external-snapshotter/client/v8 v8.0.0
-	github.com/prometheus/client_golang v1.20.2
+	github.com/prometheus/client_golang v1.20.5
 	github.com/prometheus/client_model v0.6.1
 	github.com/prometheus/common v0.55.0
 	github.com/spf13/cobra v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -93,8 +93,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/prometheus/client_golang v1.20.2 h1:5ctymQzZlyOON1666svgwn3s6IKWgfbjsejTMiXIyjg=
-github.com/prometheus/client_golang v1.20.2/go.mod h1:PIEt8X02hGcP8JWbeHyeZ53Y/jReSnHgO035n//V5WE=
+github.com/prometheus/client_golang v1.20.5 h1:cxppBPuYhUnsO6yo/aoRol4L7q7UFfdm+bR9r+8l63Y=
+github.com/prometheus/client_golang v1.20.5/go.mod h1:PIEt8X02hGcP8JWbeHyeZ53Y/jReSnHgO035n//V5WE=
 github.com/prometheus/client_model v0.6.1 h1:ZKSh/rekM+n3CeS952MLRAdFwIKqeY8b62p8ais2e9E=
 github.com/prometheus/client_model v0.6.1/go.mod h1:OrxVMOVHjw3lKMa8+x6HeMGkHMQyHDk9E3jmP2AmGiY=
 github.com/prometheus/common v0.55.0 h1:KEi6DK7lXW/m7Ig5i47x0vRzuBsHuvJdi5ee6Y3G1dc=

--- a/release-tools/build.make
+++ b/release-tools/build.make
@@ -45,9 +45,10 @@ REV=$(shell git describe --long --tags --match='v*' --dirty 2>/dev/null || git r
 # Determined dynamically.
 IMAGE_TAGS=
 
-# A "canary" image gets built if the current commit is the head of the remote "master" branch.
+# A "canary" image gets built if the current commit is the head of the remote "master" or "main" branch.
 # That branch does not exist when building some other branch in TravisCI.
 IMAGE_TAGS+=$(shell if [ "$$(git rev-list -n1 HEAD)" = "$$(git rev-list -n1 origin/master 2>/dev/null)" ]; then echo "canary"; fi)
+IMAGE_TAGS+=$(shell if [ "$$(git rev-list -n1 HEAD)" = "$$(git rev-list -n1 origin/main 2>/dev/null)" ]; then echo "canary"; fi)
 
 # A "X.Y.Z-canary" image gets built if the current commit is the head of a "origin/release-X.Y.Z" branch.
 # The actual suffix does not matter, only the "release-" prefix is checked.
@@ -62,9 +63,9 @@ IMAGE_NAME=$(REGISTRY_NAME)/$*
 
 ifdef V
 # Adding "-alsologtostderr" assumes that all test binaries contain glog. This is not guaranteed.
-TESTARGS = -v -args -alsologtostderr -v 5
+TESTARGS = -race -v -args -alsologtostderr -v 5
 else
-TESTARGS =
+TESTARGS = -race
 endif
 
 # Specific packages can be excluded from each of the tests below by setting the *_FILTER_CMD variables
@@ -143,7 +144,7 @@ DOCKER_BUILDX_CREATE_ARGS ?=
 # Windows binaries can be built before adding a Dockerfile for it.
 #
 # BUILD_PLATFORMS determines which individual images are included in the multiarch image.
-# PULL_BASE_REF must be set to 'master', 'release-x.y', or a tag name, and determines
+# PULL_BASE_REF must be set to 'master', 'main', 'release-x.y', or a tag name, and determines
 # the tag for the resulting multiarch image.
 $(CMDS:%=push-multiarch-%): push-multiarch-%: check-pull-base-ref build-%
 	set -ex; \
@@ -191,7 +192,7 @@ $(CMDS:%=push-multiarch-%): push-multiarch-%: check-pull-base-ref build-%
 		done; \
 		docker manifest push -p $(IMAGE_NAME):$$tag; \
 	}; \
-	if [ $(PULL_BASE_REF) = "master" ]; then \
+	if [ $(PULL_BASE_REF) = "master" ] || [ $(PULL_BASE_REF) = "main" ]; then \
 			: "creating or overwriting canary image"; \
 			pushMultiArch canary; \
 	elif echo $(PULL_BASE_REF) | grep -q -e 'release-*' ; then \
@@ -209,7 +210,7 @@ $(CMDS:%=push-multiarch-%): push-multiarch-%: check-pull-base-ref build-%
 .PHONY: check-pull-base-ref
 check-pull-base-ref:
 	if ! [ "$(PULL_BASE_REF)" ]; then \
-		echo >&2 "ERROR: PULL_BASE_REF must be set to 'master', 'release-x.y', or a tag name."; \
+		echo >&2 "ERROR: PULL_BASE_REF must be set to 'master', 'main', 'release-x.y', or a tag name."; \
 		exit 1; \
 	fi
 

--- a/release-tools/prow.sh
+++ b/release-tools/prow.sh
@@ -86,7 +86,7 @@ configvar CSI_PROW_BUILD_PLATFORMS "linux amd64 amd64; linux ppc64le ppc64le -pp
 # which is disabled with GOFLAGS=-mod=vendor).
 configvar GOFLAGS_VENDOR "$( [ -d vendor ] && echo '-mod=vendor' )" "Go flags for using the vendor directory"
 
-configvar CSI_PROW_GO_VERSION_BUILD "1.22.5" "Go version for building the component" # depends on component's source code
+configvar CSI_PROW_GO_VERSION_BUILD "1.23.1" "Go version for building the component" # depends on component's source code
 configvar CSI_PROW_GO_VERSION_E2E "" "override Go version for building the Kubernetes E2E test suite" # normally doesn't need to be set, see install_e2e
 configvar CSI_PROW_GO_VERSION_SANITY "${CSI_PROW_GO_VERSION_BUILD}" "Go version for building the csi-sanity test suite" # depends on CSI_PROW_SANITY settings below
 configvar CSI_PROW_GO_VERSION_KIND "${CSI_PROW_GO_VERSION_BUILD}" "Go version for building 'kind'" # depends on CSI_PROW_KIND_VERSION below
@@ -199,7 +199,7 @@ kindest/node:v1.18.20@sha256:738cdc23ed4be6cc0b7ea277a2ebcc454c8373d7d8fb991a7fc
 # If the deployment script is called with CSI_PROW_TEST_DRIVER=<file name> as
 # environment variable, then it must write a suitable test driver configuration
 # into that file in addition to installing the driver.
-configvar CSI_PROW_DRIVER_VERSION "v1.12.0" "CSI driver version"
+configvar CSI_PROW_DRIVER_VERSION "v1.15.0" "CSI driver version"
 configvar CSI_PROW_DRIVER_REPO https://github.com/kubernetes-csi/csi-driver-host-path "CSI driver repo"
 configvar CSI_PROW_DEPLOYMENT "" "deployment"
 configvar CSI_PROW_DEPLOYMENT_SUFFIX "" "additional suffix in kubernetes-x.yy[suffix].yaml files"
@@ -425,7 +425,7 @@ die () {
     exit 1
 }
 
-# Ensure that PATH has the desired version of the Go tools, then run command given as argument.
+# Ensure we use the desired version of the Go tools, then run command given as argument.
 # Empty parameter uses the already installed Go. In Prow, that version is kept up-to-date by
 # bumping the container image regularly.
 run_with_go () {
@@ -433,15 +433,16 @@ run_with_go () {
     version="$1"
     shift
 
-    if ! [ "$version" ] || go version 2>/dev/null | grep -q "go$version"; then
-        run "$@"
-    else
-        if ! [ -d "${CSI_PROW_WORK}/go-$version" ];  then
-            run curl --fail --location "https://dl.google.com/go/go$version.linux-amd64.tar.gz" | tar -C "${CSI_PROW_WORK}" -zxf - || die "installation of Go $version failed"
-            mv "${CSI_PROW_WORK}/go" "${CSI_PROW_WORK}/go-$version"
+    if [ "$version" ]; then
+        version=go$version
+        if [ "$(GOTOOLCHAIN=$version go version | cut -d' ' -f3)" != "$version" ]; then
+            die "Please install Go 1.21+"
         fi
-        PATH="${CSI_PROW_WORK}/go-$version/bin:$PATH" run "$@"
+    else
+        version=local
     fi
+    # Set GOMODCACHE to make sure Kubernetes does not need to download again.
+    GOTOOLCHAIN=$version GOMODCACHE="$(go env GOMODCACHE)" run "$@"
 }
 
 # Ensure that we have the desired version of kind.
@@ -624,7 +625,7 @@ start_cluster () {
             go_version="$(go_version_for_kubernetes "${CSI_PROW_WORK}/src/kubernetes" "$version")" || die "cannot proceed without knowing Go version for Kubernetes"
             # Changing into the Kubernetes source code directory is a workaround for https://github.com/kubernetes-sigs/kind/issues/1910
             # shellcheck disable=SC2046
-            (cd "${CSI_PROW_WORK}/src/kubernetes" && run_with_go "$go_version" kind build node-image --image csiprow/node:latest --kube-root "${CSI_PROW_WORK}/src/kubernetes") || die "'kind build node-image' failed"
+            (cd "${CSI_PROW_WORK}/src/kubernetes" && run_with_go "$go_version" kind build node-image "${CSI_PROW_WORK}/src/kubernetes" --image csiprow/node:latest) || die "'kind build node-image' failed"
             csi_prow_kind_have_kubernetes=true
         fi
         image="csiprow/node:latest"

--- a/release-tools/pull-test.sh
+++ b/release-tools/pull-test.sh
@@ -20,6 +20,11 @@
 
 set -ex
 
+# Prow checks out repos with --filter=blob:none. This breaks
+# "git subtree pull" unless we enable fetching missing file content.
+GIT_NO_LAZY_FETCH=0
+export GIT_NO_LAZY_FETCH
+
 # It must be called inside the updated csi-release-tools repo.
 CSI_RELEASE_TOOLS_DIR="$(pwd)"
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -153,7 +153,7 @@ github.com/munnerz/goautoneg
 # github.com/pkg/errors v0.9.1
 ## explicit
 github.com/pkg/errors
-# github.com/prometheus/client_golang v1.20.2
+# github.com/prometheus/client_golang v1.20.5
 ## explicit; go 1.20
 github.com/prometheus/client_golang/internal/github.com/golang/gddo/httputil
 github.com/prometheus/client_golang/internal/github.com/golang/gddo/httputil/header


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

#1242 fails due to Trivy detecting CVEs in go v1.22.5. Release-8.0 does not have these CVEs because they do not exist in go v1.22.3.

This PR:
- cherry-picks #1156 
- Updates release-tools subtree
- Fixes data race by bumping prometheus/client_golang 

```
Squashed 'release-tools/' changes from 988496a1..406a79ac

    Squashed 'release-tools/' changes from 988496a1..406a79ac

    Squashed 'release-tools/' changes from 988496a1..406a79ac

    406a79ac Merge pull request #267 from huww98/gomodcache
    9cec273d Set GOMODCACHE to avoid re-download toolchain
    98f23071 Merge pull request #260 from TerryHowe/update-csi-driver-version
    e9d8712d Merge pull request #259 from stmcginnis/deprecated-kind-kube-root
    faf79ff6 Remove --kube-root deprecated kind argument
    734c2b95 Merge pull request #265 from Rakshith-R/consider-main-branch
    f95c855b Merge pull request #262 from huww98/golang-toolchain
    3c8d966f Treat main branch as equivalent to master branch
    e31de525 Merge pull request #261 from huww98/golang
    fd153a9e Bump golang to 1.23.1
    a8b3d050 pull-test.sh: fix "git subtree pull" errors
    6b05f0fc use new GOTOOLCHAIN env to manage go version
    18b6ac6d chore: update CSI driver version to 1.15
    227577e0 Merge pull request #258 from gnufied/enable-race-detection
    e1ceee28 Always enable race detection while running tests

    git-subtree-dir: release-tools
    git-subtree-split: 406a79acf021b5564108afebeea7d0ed44648d3f
```


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
