### PR TITLE
Enqueue dangling volumesnapshotcontents through resyncperiod

### DIFF
--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -680,6 +680,10 @@ func GetDynamicSnapshotContentNameForGroupSnapshot(groupSnapshot *crdv1beta1.Vol
 // If the VolumeSnapshotContent object still contains other changes after this sanitization, the changes
 // are potentially meaningful and the object is enqueued to be considered for syncing
 func ShouldEnqueueContentChange(old *crdv1.VolumeSnapshotContent, new *crdv1.VolumeSnapshotContent) bool {
+	if new.ObjectMeta.DeletionTimestamp != nil {
+		// This allows a hanging content to get bailed out eventually through resync period
+		return true
+	}
 	sanitized := new.DeepCopy()
 	// ResourceVersion always changes between revisions
 	sanitized.ResourceVersion = old.ResourceVersion


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
According to testing, it's possible under some conditions to get stuck in a loop where the content never gets deleted.

This should solve https://github.com/kubernetes-csi/external-snapshotter/issues/1258 by enqueuing contents with deletionTimestamp.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
