### PR TITLE
Unit tests: volume group snapshot builder

### DIFF
--- a/pkg/common-controller/builder_test.go
+++ b/pkg/common-controller/builder_test.go
@@ -1,0 +1,343 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common_controller
+
+import (
+	crdv1beta1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumegroupsnapshot/v1beta1"
+	crdv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+	"github.com/kubernetes-csi/external-snapshotter/v8/pkg/utils"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// VolumeGroupSnapshotBuilder is used by the volume group snapshots
+// unit tests to build VolumeGroupSnapshot objects
+type VolumeGroupSnapshotBuilder struct {
+	name string
+	uid  types.UID
+
+	deletionTimestamp      *metav1.Time
+	groupSnapshotClassName string
+	targetContentName      string
+	selectors              map[string]string
+	finalizers             []string
+
+	nilStatus              bool
+	statusBoundContentName string
+	statusError            string
+	statusReadyToUse       *bool
+	statusCreationTime     *metav1.Time
+}
+
+// NewVolumeGroupSnapshotBuilder creates a new builder with the required
+// information
+func NewVolumeGroupSnapshotBuilder(name string, uid types.UID) *VolumeGroupSnapshotBuilder {
+	return &VolumeGroupSnapshotBuilder{
+		name: name,
+		uid:  uid,
+	}
+}
+
+// WithDeletionTimestamp sets the deletion timestamp in the builder
+func (b *VolumeGroupSnapshotBuilder) WithDeletionTimestamp(t metav1.Time) *VolumeGroupSnapshotBuilder {
+	b.deletionTimestamp = &t
+	return b
+}
+
+// WithSelectors set the selectors inside the builder
+func (b *VolumeGroupSnapshotBuilder) WithSelectors(s map[string]string) *VolumeGroupSnapshotBuilder {
+	b.selectors = s
+	return b
+}
+
+// WithGroupSnapshotClass set the group snapshot class inside the buileder
+func (b *VolumeGroupSnapshotBuilder) WithGroupSnapshotClass(n string) *VolumeGroupSnapshotBuilder {
+	b.groupSnapshotClassName = n
+	return b
+}
+
+// WithTargetContentName sets the target volume group snapshot content name
+func (b *VolumeGroupSnapshotBuilder) WithTargetContentName(n string) *VolumeGroupSnapshotBuilder {
+	b.targetContentName = n
+	return b
+}
+
+// WithStatus pre-sets the status in the built object
+func (b *VolumeGroupSnapshotBuilder) WithNilStatus() *VolumeGroupSnapshotBuilder {
+	b.nilStatus = true
+	return b
+}
+
+// WithBoundContentName sets the bound content name in the volume group snapshot object
+func (b *VolumeGroupSnapshotBuilder) WithStatusBoundContentName(n string) *VolumeGroupSnapshotBuilder {
+	b.statusBoundContentName = n
+	return b
+}
+
+// WithStatusError sets the status.error field in the generated object
+func (b *VolumeGroupSnapshotBuilder) WithStatusError(e string) *VolumeGroupSnapshotBuilder {
+	b.statusError = e
+	return b
+}
+
+// WithStatusReadyToUse sets the ready to use boolean indicator to the specified value
+func (b *VolumeGroupSnapshotBuilder) WithStatusReadyToUse(readyToUse bool) *VolumeGroupSnapshotBuilder {
+	b.statusReadyToUse = &readyToUse
+	return b
+}
+
+// WithStatusCreationTime sets the status creation time in the generated object
+func (b *VolumeGroupSnapshotBuilder) WithStatusCreationTime(t metav1.Time) *VolumeGroupSnapshotBuilder {
+	b.statusCreationTime = &t
+	return b
+}
+
+// WithFinalizers sets all the finalizers in the generated object
+func (b *VolumeGroupSnapshotBuilder) WithAllFinalizers() *VolumeGroupSnapshotBuilder {
+	b.finalizers = []string{
+		utils.VolumeGroupSnapshotContentFinalizer,
+		utils.VolumeGroupSnapshotBoundFinalizer,
+	}
+	return b
+}
+
+// WithFinalizers sets the passed finalizers in the generated object
+func (b *VolumeGroupSnapshotBuilder) WithFinalizers(finalizers ...string) *VolumeGroupSnapshotBuilder {
+	b.finalizers = finalizers
+	return b
+}
+
+// Build builds a volume group snapshot
+func (b *VolumeGroupSnapshotBuilder) Build() *crdv1beta1.VolumeGroupSnapshot {
+	groupSnapshot := crdv1beta1.VolumeGroupSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              b.name,
+			Namespace:         testNamespace,
+			UID:               b.uid,
+			ResourceVersion:   "1",
+			SelfLink:          "/apis/groupsnapshot.storage.k8s.io/v1beta1/namespaces/" + testNamespace + "/volumesnapshots/" + b.name,
+			DeletionTimestamp: b.deletionTimestamp,
+		},
+		Spec: crdv1beta1.VolumeGroupSnapshotSpec{
+			VolumeGroupSnapshotClassName: nil,
+		},
+	}
+
+	if len(b.selectors) > 0 {
+		groupSnapshot.Spec.Source.Selector = &metav1.LabelSelector{
+			MatchLabels: b.selectors,
+		}
+	}
+
+	if !b.nilStatus {
+		groupSnapshot.Status = &crdv1beta1.VolumeGroupSnapshotStatus{
+			CreationTime: b.statusCreationTime,
+			ReadyToUse:   b.statusReadyToUse,
+		}
+
+		if b.statusError != "" {
+			groupSnapshot.Status.Error = newVolumeError(b.statusError)
+		}
+
+		if b.statusBoundContentName != "" {
+			groupSnapshot.Status.BoundVolumeGroupSnapshotContentName = &b.statusBoundContentName
+		}
+	}
+
+	if b.groupSnapshotClassName != "" {
+		groupSnapshot.Spec.VolumeGroupSnapshotClassName = &b.groupSnapshotClassName
+	}
+
+	if b.targetContentName != "" {
+		groupSnapshot.Spec.Source.VolumeGroupSnapshotContentName = &b.targetContentName
+	}
+
+	if b.finalizers != nil {
+		groupSnapshot.ObjectMeta.Finalizers = b.finalizers
+	}
+
+	return &groupSnapshot
+}
+
+// BuildArray builds an array of a volume group snapshot with the specified properties
+func (b *VolumeGroupSnapshotBuilder) BuildArray() []*crdv1beta1.VolumeGroupSnapshot {
+	return []*crdv1beta1.VolumeGroupSnapshot{
+		b.Build(),
+	}
+}
+
+// VolumeGroupSnapshotContentBuilder is used by the volume group snapshots
+// unit tests to build VolumeGroupSnapshotContent objects
+type VolumeGroupSnapshotContentBuilder struct {
+	name string
+
+	annotations map[string]string
+	finalizer   bool
+
+	deletionPolicy            crdv1.DeletionPolicy
+	groupSnapshotClassName    string
+	targetGroupSnapshotHandle string
+	desiredVolumeHandles      []string
+	boundGroupSnapshotName    string
+	boundGroupSnapshotUID     types.UID
+
+	setStatus                 bool
+	statusCreationTime        *metav1.Time
+	statusGroupSnapshotHandle string
+}
+
+// NewVolumeGroupSnapshotContentBuilder creates a new helper to create a volume group snapshot content
+// object
+func NewVolumeGroupSnapshotContentBuilder(name string) *VolumeGroupSnapshotContentBuilder {
+	return &VolumeGroupSnapshotContentBuilder{
+		name: name,
+	}
+}
+
+// WithAnnotation attaches an annotation to the built object
+func (b *VolumeGroupSnapshotContentBuilder) WithAnnotation(name, value string) *VolumeGroupSnapshotContentBuilder {
+	if b.annotations == nil {
+		b.annotations = make(map[string]string)
+	}
+
+	b.annotations[name] = value
+	return b
+}
+
+// WithGroupSnapshotClassName sets the group snapshot class name to be used
+// in the built object
+func (b *VolumeGroupSnapshotContentBuilder) WithGroupSnapshotClassName(name string) *VolumeGroupSnapshotContentBuilder {
+	b.groupSnapshotClassName = name
+	return b
+}
+
+// WithTargetGroupSnapshotHandle sets the group snapshot handle to be used
+// in the built object
+func (b *VolumeGroupSnapshotContentBuilder) WithTargetGroupSnapshotHandle(handle string) *VolumeGroupSnapshotContentBuilder {
+	b.targetGroupSnapshotHandle = handle
+	return b
+}
+
+// WithDeletionPolicy sets the deletion policy in the generated object
+func (b *VolumeGroupSnapshotContentBuilder) WithDeletionPolicy(p crdv1.DeletionPolicy) *VolumeGroupSnapshotContentBuilder {
+	b.deletionPolicy = p
+	return b
+}
+
+// WithBoundGroupSnapshot sets the pointer to the bound group snapshot object
+func (b *VolumeGroupSnapshotContentBuilder) WithBoundGroupSnapshot(name string, uid types.UID) *VolumeGroupSnapshotContentBuilder {
+	b.boundGroupSnapshotName = name
+	b.boundGroupSnapshotUID = uid
+	return b
+}
+
+// WithDesiredVolumeHandles sets the desired volume handles
+func (b *VolumeGroupSnapshotContentBuilder) WithDesiredVolumeHandles(handles ...string) *VolumeGroupSnapshotContentBuilder {
+	b.desiredVolumeHandles = handles
+	return b
+}
+
+// WithStatus fills the status subresource and mark the generated object
+// as ready to use
+func (b *VolumeGroupSnapshotContentBuilder) WithStatus() *VolumeGroupSnapshotContentBuilder {
+	b.setStatus = true
+	return b
+}
+
+// WithStatusGroupSnapshotHandle sets the group snapshot handle inside the status section
+func (b *VolumeGroupSnapshotContentBuilder) WithStatusGroupSnapshotHandle(handle string) *VolumeGroupSnapshotContentBuilder {
+	b.statusGroupSnapshotHandle = handle
+	return b
+}
+
+// WithCreationTime sets the creation time in the generated object
+func (b *VolumeGroupSnapshotContentBuilder) WithCreationTime(t metav1.Time) *VolumeGroupSnapshotContentBuilder {
+	b.statusCreationTime = &t
+	return b
+}
+
+// WithFinalizer sets the finalizer in the created object
+func (b *VolumeGroupSnapshotContentBuilder) WithFinalizer() *VolumeGroupSnapshotContentBuilder {
+	return b
+}
+
+// Build builds the object
+func (b *VolumeGroupSnapshotContentBuilder) Build() *crdv1beta1.VolumeGroupSnapshotContent {
+	content := crdv1beta1.VolumeGroupSnapshotContent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            b.name,
+			ResourceVersion: "1",
+			Annotations:     b.annotations,
+		},
+		Spec: crdv1beta1.VolumeGroupSnapshotContentSpec{
+			Driver:         mockDriverName,
+			DeletionPolicy: b.deletionPolicy,
+		},
+	}
+
+	if b.setStatus {
+		ready := true
+		content.Status = &crdv1beta1.VolumeGroupSnapshotContentStatus{
+			CreationTime: b.statusCreationTime,
+			ReadyToUse:   &ready,
+		}
+	}
+
+	if b.setStatus && b.statusGroupSnapshotHandle != "" {
+		content.Status.VolumeGroupSnapshotHandle = &b.statusGroupSnapshotHandle
+	}
+
+	if b.groupSnapshotClassName != "" {
+		content.Spec.VolumeGroupSnapshotClassName = &b.groupSnapshotClassName
+	}
+
+	if b.targetGroupSnapshotHandle != "" {
+		content.Spec.Source.GroupSnapshotHandles = &crdv1beta1.GroupSnapshotHandles{
+			VolumeGroupSnapshotHandle: b.targetGroupSnapshotHandle,
+		}
+	}
+
+	if len(b.desiredVolumeHandles) != 0 {
+		content.Spec.Source.VolumeHandles = b.desiredVolumeHandles
+	}
+
+	if b.boundGroupSnapshotName != "" {
+		content.Spec.VolumeGroupSnapshotRef = v1.ObjectReference{
+			Kind:            "VolumeGroupSnapshot",
+			APIVersion:      "groupsnapshot.storage.k8s.io/v1beta1",
+			UID:             b.boundGroupSnapshotUID,
+			Namespace:       testNamespace,
+			Name:            b.boundGroupSnapshotName,
+			ResourceVersion: "1",
+		}
+	}
+
+	if b.finalizer {
+		content.ObjectMeta.Finalizers = append(content.ObjectMeta.Finalizers, utils.VolumeGroupSnapshotContentFinalizer)
+	}
+
+	return &content
+}
+
+// BuildArray builds an array of a volume group snapshot with the specified properties
+func (b *VolumeGroupSnapshotContentBuilder) BuildArray() []*crdv1beta1.VolumeGroupSnapshotContent {
+	return []*crdv1beta1.VolumeGroupSnapshotContent{
+		b.Build(),
+	}
+}

--- a/pkg/common-controller/groupsnapshot_create_test.go
+++ b/pkg/common-controller/groupsnapshot_create_test.go
@@ -68,25 +68,28 @@ func TestCreateGroupSnapshotSync(t *testing.T) {
 	tests := []controllerTest{
 		{
 			name: "1-1 - successful dynamically-provisioned create group snapshot with group snapshot class gold",
-			initialGroupSnapshots: newGroupSnapshotArray(
-				"group-snap-1-1", "group-snapuid1-1", map[string]string{
+			initialGroupSnapshots: NewVolumeGroupSnapshotBuilder("group-snap-1-1", "group-snapuid1-1").
+				WithSelectors(map[string]string{
 					"app.kubernetes.io/name": "postgresql",
-				},
-				"", classGold, "", nil, nil, nil, true, false, nil,
-			),
-			expectedGroupSnapshots: newGroupSnapshotArray(
-				"group-snap-1-1", "group-snapuid1-1", map[string]string{
+				}).
+				WithGroupSnapshotClass(classGold).
+				WithNilStatus().
+				BuildArray(),
+			expectedGroupSnapshots: NewVolumeGroupSnapshotBuilder("group-snap-1-1", "group-snapuid1-1").
+				WithSelectors(map[string]string{
 					"app.kubernetes.io/name": "postgresql",
-				},
-				"", classGold, "groupsnapcontent-group-snapuid1-1", &False, nil, nil, false, false, nil,
-			),
+				}).
+				WithGroupSnapshotClass(classGold).
+				WithStatusBoundContentName("groupsnapcontent-group-snapuid1-1").
+				WithStatusReadyToUse(false).
+				BuildArray(),
 			initialGroupContents: nogroupcontents,
-			expectedGroupContents: newGroupSnapshotContentArray(
-				"groupsnapcontent-group-snapuid1-1", "group-snapuid1-1", "group-snap-1-1", "group-snapshot-handle", classGold, []string{
-					"1-pv-handle6-1",
-					"2-pv-handle6-1",
-				}, "", deletionPolicy, nil, false, false,
-			),
+			expectedGroupContents: NewVolumeGroupSnapshotContentBuilder("groupsnapcontent-group-snapuid1-1").
+				WithBoundGroupSnapshot("group-snap-1-1", "group-snapuid1-1").
+				WithDeletionPolicy(deletionPolicy).
+				WithGroupSnapshotClassName(classGold).
+				WithDesiredVolumeHandles("1-pv-handle6-1", "2-pv-handle6-1").
+				BuildArray(),
 			initialClaims: withClaimLabels(
 				newClaimCoupleArray("claim1-1", "pvc-uid6-1", "1Gi", "volume6-1", v1.ClaimBound, &classGold),
 				map[string]string{
@@ -99,20 +102,21 @@ func TestCreateGroupSnapshotSync(t *testing.T) {
 		},
 		{
 			name: "1-2 - unsuccessful create group snapshot with no existent group snapshot class",
-			initialGroupSnapshots: newGroupSnapshotArray(
-				"group-snap-1-1", "group-snapuid1-1", map[string]string{
+			initialGroupSnapshots: NewVolumeGroupSnapshotBuilder("group-snap-1-1", "group-snapuid1-1").
+				WithSelectors(map[string]string{
 					"app.kubernetes.io/name": "postgresql",
-				},
-				"", classNonExisting, "", nil, nil, nil, true, false, nil,
-			),
-			expectedGroupSnapshots: newGroupSnapshotArray(
-				"group-snap-1-1", "group-snapuid1-1", map[string]string{
+				}).
+				WithGroupSnapshotClass(classNonExisting).
+				WithNilStatus().
+				BuildArray(),
+			expectedGroupSnapshots: NewVolumeGroupSnapshotBuilder("group-snap-1-1", "group-snapuid1-1").
+				WithSelectors(map[string]string{
 					"app.kubernetes.io/name": "postgresql",
-				},
-				"", classNonExisting, "", &False, nil,
-				newVolumeError(`failed to create group snapshot content with error failed to get input parameters to create group snapshot group-snap-1-1: "volumegroupsnapshotclass.groupsnapshot.storage.k8s.io \"non-existing\" not found"`),
-				false, false, nil,
-			),
+				}).
+				WithGroupSnapshotClass(classNonExisting).
+				WithStatusError(`failed to create group snapshot content with error failed to get input parameters to create group snapshot group-snap-1-1: "volumegroupsnapshotclass.groupsnapshot.storage.k8s.io \"non-existing\" not found"`).
+				WithStatusReadyToUse(false).
+				BuildArray(),
 			initialGroupContents:  nogroupcontents,
 			expectedGroupContents: nogroupcontents,
 			initialClaims: withClaimLabels(
@@ -127,20 +131,19 @@ func TestCreateGroupSnapshotSync(t *testing.T) {
 		},
 		{
 			name: "1-3 - fail to create group snapshot without group snapshot class",
-			initialGroupSnapshots: newGroupSnapshotArray(
-				"group-snap-1-1", "group-snapuid1-1", map[string]string{
+			initialGroupSnapshots: NewVolumeGroupSnapshotBuilder("group-snap-1-1", "group-snapuid1-1").
+				WithSelectors(map[string]string{
 					"app.kubernetes.io/name": "postgresql",
-				},
-				"", "", "", nil, nil, nil, true, false, nil,
-			),
-			expectedGroupSnapshots: newGroupSnapshotArray(
-				"group-snap-1-1", "group-snapuid1-1", map[string]string{
+				}).
+				WithNilStatus().
+				BuildArray(),
+			expectedGroupSnapshots: NewVolumeGroupSnapshotBuilder("group-snap-1-1", "group-snapuid1-1").
+				WithSelectors(map[string]string{
 					"app.kubernetes.io/name": "postgresql",
-				},
-				"", "", "", &False, nil,
-				newVolumeError(`failed to create group snapshot content with error failed to get input parameters to create group snapshot group-snap-1-1: "failed to take group snapshot group-snap-1-1 without a group snapshot class"`),
-				false, false, nil,
-			),
+				}).
+				WithStatusError(`failed to create group snapshot content with error failed to get input parameters to create group snapshot group-snap-1-1: "failed to take group snapshot group-snap-1-1 without a group snapshot class"`).
+				WithStatusReadyToUse(false).
+				BuildArray(),
 			initialGroupContents:  nogroupcontents,
 			expectedGroupContents: nogroupcontents,
 			initialClaims: withClaimLabels(
@@ -155,20 +158,21 @@ func TestCreateGroupSnapshotSync(t *testing.T) {
 		},
 		{
 			name: "1-4 - fail to create group snapshot with no existing volumes",
-			initialGroupSnapshots: newGroupSnapshotArray(
-				"group-snap-1-1", "group-snapuid1-1", map[string]string{
+			initialGroupSnapshots: NewVolumeGroupSnapshotBuilder("group-snap-1-1", "group-snapuid1-1").
+				WithSelectors(map[string]string{
 					"app.kubernetes.io/name": "postgresql",
-				},
-				"", classGold, "", nil, nil, nil, true, false, nil,
-			),
-			expectedGroupSnapshots: newGroupSnapshotArray(
-				"group-snap-1-1", "group-snapuid1-1", map[string]string{
+				}).
+				WithGroupSnapshotClass(classGold).
+				WithNilStatus().
+				BuildArray(),
+			expectedGroupSnapshots: NewVolumeGroupSnapshotBuilder("group-snap-1-1", "group-snapuid1-1").
+				WithSelectors(map[string]string{
 					"app.kubernetes.io/name": "postgresql",
-				},
-				"", classGold, "", &False, nil,
-				newVolumeError(`failed to create group snapshot content with error failed to get input parameters to create group snapshot group-snap-1-1: "label selector app.kubernetes.io/name=postgresql for group snapshot not applied to any PVC"`),
-				false, false, nil,
-			),
+				}).
+				WithGroupSnapshotClass(classGold).
+				WithStatusError(`failed to create group snapshot content with error failed to get input parameters to create group snapshot group-snap-1-1: "label selector app.kubernetes.io/name=postgresql for group snapshot not applied to any PVC"`).
+				WithStatusReadyToUse(false).
+				BuildArray(),
 			initialGroupContents:  nogroupcontents,
 			expectedGroupContents: nogroupcontents,
 			initialClaims:         nil,
@@ -179,20 +183,21 @@ func TestCreateGroupSnapshotSync(t *testing.T) {
 		},
 		{
 			name: "1-5 - fail to create group snapshot with volumes that are not bound",
-			initialGroupSnapshots: newGroupSnapshotArray(
-				"group-snap-1-1", "group-snapuid1-1", map[string]string{
+			initialGroupSnapshots: NewVolumeGroupSnapshotBuilder("group-snap-1-1", "group-snapuid1-1").
+				WithSelectors(map[string]string{
 					"app.kubernetes.io/name": "postgresql",
-				},
-				"", classGold, "", nil, nil, nil, true, false, nil,
-			),
-			expectedGroupSnapshots: newGroupSnapshotArray(
-				"group-snap-1-1", "group-snapuid1-1", map[string]string{
+				}).
+				WithGroupSnapshotClass(classGold).
+				WithNilStatus().
+				BuildArray(),
+			expectedGroupSnapshots: NewVolumeGroupSnapshotBuilder("group-snap-1-1", "group-snapuid1-1").
+				WithSelectors(map[string]string{
 					"app.kubernetes.io/name": "postgresql",
-				},
-				"", classGold, "", &False, nil,
-				newVolumeError(`failed to create group snapshot content with error failed to get input parameters to create group snapshot group-snap-1-1: "the PVC claim1-1 is not yet bound to a PV, will not attempt to take a group snapshot"`),
-				false, false, nil,
-			),
+				}).
+				WithGroupSnapshotClass(classGold).
+				WithStatusError(`failed to create group snapshot content with error failed to get input parameters to create group snapshot group-snap-1-1: "the PVC claim1-1 is not yet bound to a PV, will not attempt to take a group snapshot"`).
+				WithStatusReadyToUse(false).
+				BuildArray(),
 			initialGroupContents:  nogroupcontents,
 			expectedGroupContents: nogroupcontents,
 			initialClaims: withClaimLabels(
@@ -207,20 +212,21 @@ func TestCreateGroupSnapshotSync(t *testing.T) {
 		},
 		{
 			name: "1-6 - fail to create group snapshot with volumes that are not created by a CSI driver",
-			initialGroupSnapshots: newGroupSnapshotArray(
-				"group-snap-1-1", "group-snapuid1-1", map[string]string{
+			initialGroupSnapshots: NewVolumeGroupSnapshotBuilder("group-snap-1-1", "group-snapuid1-1").
+				WithSelectors(map[string]string{
 					"app.kubernetes.io/name": "postgresql",
-				},
-				"", classGold, "", nil, nil, nil, true, false, nil,
-			),
-			expectedGroupSnapshots: newGroupSnapshotArray(
-				"group-snap-1-1", "group-snapuid1-1", map[string]string{
+				}).
+				WithGroupSnapshotClass(classGold).
+				WithNilStatus().
+				BuildArray(),
+			expectedGroupSnapshots: NewVolumeGroupSnapshotBuilder("group-snap-1-1", "group-snapuid1-1").
+				WithSelectors(map[string]string{
 					"app.kubernetes.io/name": "postgresql",
-				},
-				"", classGold, "", &False, nil,
-				newVolumeError("failed to create group snapshot content with error cannot snapshot a non-CSI volume for group snapshot default/group-snap-1-1: volume6-1"),
-				false, false, nil,
-			),
+				}).
+				WithGroupSnapshotClass(classGold).
+				WithStatusError("failed to create group snapshot content with error cannot snapshot a non-CSI volume for group snapshot default/group-snap-1-1: volume6-1").
+				WithStatusReadyToUse(false).
+				BuildArray(),
 			initialGroupContents:  nogroupcontents,
 			expectedGroupContents: nogroupcontents,
 			initialClaims: withClaimLabels(
@@ -238,20 +244,21 @@ func TestCreateGroupSnapshotSync(t *testing.T) {
 		},
 		{
 			name: "1-7 - fail to create group snapshot with volumes that are created by a different CSI driver",
-			initialGroupSnapshots: newGroupSnapshotArray(
-				"group-snap-1-1", "group-snapuid1-1", map[string]string{
+			initialGroupSnapshots: NewVolumeGroupSnapshotBuilder("group-snap-1-1", "group-snapuid1-1").
+				WithSelectors(map[string]string{
 					"app.kubernetes.io/name": "postgresql",
-				},
-				"", classGold, "", nil, nil, nil, true, false, nil,
-			),
-			expectedGroupSnapshots: newGroupSnapshotArray(
-				"group-snap-1-1", "group-snapuid1-1", map[string]string{
+				}).
+				WithGroupSnapshotClass(classGold).
+				WithNilStatus().
+				BuildArray(),
+			expectedGroupSnapshots: NewVolumeGroupSnapshotBuilder("group-snap-1-1", "group-snapuid1-1").
+				WithSelectors(map[string]string{
 					"app.kubernetes.io/name": "postgresql",
-				},
-				"", classGold, "", &False, nil,
-				newVolumeError("failed to create group snapshot content with error snapshot controller failed to update default/group-snap-1-1 on API server: Volume CSI driver (test.csi.driver.name) mismatch with VolumeGroupSnapshotClass (csi-mock-plugin) default/group-snap-1-1: volume6-1"),
-				false, false, nil,
-			),
+				}).
+				WithGroupSnapshotClass(classGold).
+				WithStatusError("failed to create group snapshot content with error snapshot controller failed to update default/group-snap-1-1 on API server: Volume CSI driver (test.csi.driver.name) mismatch with VolumeGroupSnapshotClass (csi-mock-plugin) default/group-snap-1-1: volume6-1").
+				WithStatusReadyToUse(false).
+				BuildArray(),
 			initialGroupContents:  nogroupcontents,
 			expectedGroupContents: nogroupcontents,
 			initialClaims: withClaimLabels(
@@ -269,22 +276,31 @@ func TestCreateGroupSnapshotSync(t *testing.T) {
 		},
 		{
 			name: "1-8 - successful pre-provisioned group snapshot",
-			initialGroupSnapshots: newGroupSnapshotArray(
-				"group-snap-1-1", "group-snapuid1-1", nil,
-				"groupsnapcontent-snapuid1-1", classGold, "", &False, nil, nil, false, false, nil,
-			),
-			expectedGroupSnapshots: newGroupSnapshotArray(
-				"group-snap-1-1", "group-snapuid1-1", nil,
-				"groupsnapcontent-snapuid1-1", classGold, "groupsnapcontent-snapuid1-1", &True, nil, nil, false, false, nil,
-			),
-			initialGroupContents: newGroupSnapshotContentArray(
-				"groupsnapcontent-snapuid1-1", "group-snapuid1-1", "group-snap-1-1", "", classGold, nil,
-				"group-snapshot-handle", deletionPolicy, nil, false, true,
-			),
-			expectedGroupContents: newGroupSnapshotContentArray(
-				"groupsnapcontent-snapuid1-1", "group-snapuid1-1", "group-snap-1-1", "", classGold, nil,
-				"group-snapshot-handle", deletionPolicy, nil, false, true,
-			),
+			initialGroupSnapshots: NewVolumeGroupSnapshotBuilder("group-snap-1-1", "group-snapuid1-1").
+				WithGroupSnapshotClass(classGold).
+				WithTargetContentName("groupsnapcontent-snapuid1-1").
+				WithNilStatus().
+				BuildArray(),
+			expectedGroupSnapshots: NewVolumeGroupSnapshotBuilder("group-snap-1-1", "group-snapuid1-1").
+				WithGroupSnapshotClass(classGold).
+				WithTargetContentName("groupsnapcontent-snapuid1-1").
+				WithStatusReadyToUse(true).
+				WithStatusBoundContentName("groupsnapcontent-snapuid1-1").
+				BuildArray(),
+			initialGroupContents: NewVolumeGroupSnapshotContentBuilder("groupsnapcontent-snapuid1-1").
+				WithBoundGroupSnapshot("group-snap-1-1", "group-snapuid1-1").
+				WithDeletionPolicy(deletionPolicy).
+				WithGroupSnapshotClassName(classGold).
+				WithTargetGroupSnapshotHandle("group-snapshot-handle").
+				WithStatus().
+				BuildArray(),
+			expectedGroupContents: NewVolumeGroupSnapshotContentBuilder("groupsnapcontent-snapuid1-1").
+				WithBoundGroupSnapshot("group-snap-1-1", "group-snapuid1-1").
+				WithDeletionPolicy(deletionPolicy).
+				WithGroupSnapshotClassName(classGold).
+				WithTargetGroupSnapshotHandle("group-snapshot-handle").
+				WithStatus().
+				BuildArray(),
 			initialClaims: withClaimLabels(
 				newClaimCoupleArray("claim1-1", "pvc-uid6-1", "1Gi", "volume6-1", v1.ClaimBound, &classGold),
 				map[string]string{
@@ -297,16 +313,17 @@ func TestCreateGroupSnapshotSync(t *testing.T) {
 		},
 		{
 			name: "1-9 - unsuccessful pre-provisioned group snapshot (no content)",
-			initialGroupSnapshots: newGroupSnapshotArray(
-				"group-snap-1-1", "group-snapuid1-1", nil,
-				"groupsnapcontent-snapuid1-1", classGold, "", &False, nil, nil, false, false, nil,
-			),
-			expectedGroupSnapshots: newGroupSnapshotArray(
-				"group-snap-1-1", "group-snapuid1-1", nil,
-				"groupsnapcontent-snapuid1-1", classGold, "", &False, nil,
-				newVolumeError(`VolumeGroupSnapshotContent is missing`),
-				false, false, nil,
-			),
+			initialGroupSnapshots: NewVolumeGroupSnapshotBuilder("group-snap-1-1", "group-snapuid1-1").
+				WithGroupSnapshotClass(classGold).
+				WithTargetContentName("groupsnapcontent-snapuid1-1").
+				WithNilStatus().
+				BuildArray(),
+			expectedGroupSnapshots: NewVolumeGroupSnapshotBuilder("group-snap-1-1", "group-snapuid1-1").
+				WithGroupSnapshotClass(classGold).
+				WithTargetContentName("groupsnapcontent-snapuid1-1").
+				WithStatusReadyToUse(false).
+				WithStatusError(`VolumeGroupSnapshotContent is missing`).
+				BuildArray(),
 			initialGroupContents:  nogroupcontents,
 			expectedGroupContents: nogroupcontents,
 			initialClaims: withClaimLabels(
@@ -321,22 +338,31 @@ func TestCreateGroupSnapshotSync(t *testing.T) {
 		},
 		{
 			name: "1-10 - unsuccessful pre-provisioned group snapshot (wrong back-ref)",
-			initialGroupSnapshots: newGroupSnapshotArray(
-				"group-snap-1-1", "group-snapuid1-1", nil,
-				"groupsnapcontent-snapuid1-1", classGold, "", &False, nil, nil, false, false, nil,
-			),
-			expectedGroupSnapshots: newGroupSnapshotArray(
-				"group-snap-1-1", "group-snapuid1-1", nil,
-				"groupsnapcontent-snapuid1-1", classGold, "", &False, nil, newVolumeError(`VolumeGroupSnapshotContent [groupsnapcontent-snapuid1-1] is bound to a different group snapshot`), false, false, nil,
-			),
-			initialGroupContents: newGroupSnapshotContentArray(
-				"groupsnapcontent-snapuid1-1", "group-snapuid1-1", "group-wrong-snap-1-1", "", classGold, nil,
-				"group-snapshot-handle", deletionPolicy, nil, false, true,
-			),
-			expectedGroupContents: newGroupSnapshotContentArray(
-				"groupsnapcontent-snapuid1-1", "group-snapuid1-1", "group-wrong-snap-1-1", "", classGold, nil,
-				"group-snapshot-handle", deletionPolicy, nil, false, true,
-			),
+			initialGroupSnapshots: NewVolumeGroupSnapshotBuilder("group-snap-1-1", "group-snapuid1-1").
+				WithGroupSnapshotClass(classGold).
+				WithTargetContentName("groupsnapcontent-snapuid1-1").
+				WithNilStatus().
+				BuildArray(),
+			expectedGroupSnapshots: NewVolumeGroupSnapshotBuilder("group-snap-1-1", "group-snapuid1-1").
+				WithGroupSnapshotClass(classGold).
+				WithTargetContentName("groupsnapcontent-snapuid1-1").
+				WithStatusReadyToUse(false).
+				WithStatusError(`VolumeGroupSnapshotContent [groupsnapcontent-snapuid1-1] is bound to a different group snapshot`).
+				BuildArray(),
+			initialGroupContents: NewVolumeGroupSnapshotContentBuilder("groupsnapcontent-snapuid1-1").
+				WithBoundGroupSnapshot("group-wrong-snap-1-1", "group-snapuid1-1").
+				WithDeletionPolicy(deletionPolicy).
+				WithGroupSnapshotClassName(classGold).
+				WithTargetGroupSnapshotHandle("group-snapshot-handle").
+				WithStatus().
+				BuildArray(),
+			expectedGroupContents: NewVolumeGroupSnapshotContentBuilder("groupsnapcontent-snapuid1-1").
+				WithBoundGroupSnapshot("group-wrong-snap-1-1", "group-snapuid1-1").
+				WithDeletionPolicy(deletionPolicy).
+				WithGroupSnapshotClassName(classGold).
+				WithTargetGroupSnapshotHandle("group-snapshot-handle").
+				WithStatus().
+				BuildArray(),
 			initialClaims: withClaimLabels(
 				newClaimCoupleArray("claim1-1", "pvc-uid6-1", "1Gi", "volume6-1", v1.ClaimBound, &classGold),
 				map[string]string{
@@ -349,22 +375,27 @@ func TestCreateGroupSnapshotSync(t *testing.T) {
 		},
 		{
 			name: "1-11 - mismatch between pre-provisioned group snapshot and dynamically provisioned group snapshot content",
-			initialGroupSnapshots: newGroupSnapshotArray(
-				"group-snap-1-1", "group-snapuid1-1", nil,
-				"groupsnapcontent-snapuid1-1", classGold, "", &False, nil, nil, false, false, nil,
-			),
-			expectedGroupSnapshots: newGroupSnapshotArray(
-				"group-snap-1-1", "group-snapuid1-1", nil,
-				"groupsnapcontent-snapuid1-1", classGold, "", &False, nil, newVolumeError(`VolumeGroupSnapshotContent is dynamically provisioned while expecting a pre-provisioned one`), false, false, nil,
-			),
-			initialGroupContents: newGroupSnapshotContentArray(
-				"groupsnapcontent-snapuid1-1", "group-snapuid1-1", "group-snap-1-1", "", classGold, nil,
-				"", deletionPolicy, nil, false, false,
-			),
-			expectedGroupContents: newGroupSnapshotContentArray(
-				"groupsnapcontent-snapuid1-1", "group-snapuid1-1", "group-snap-1-1", "", classGold, nil,
-				"", deletionPolicy, nil, false, false,
-			),
+			initialGroupSnapshots: NewVolumeGroupSnapshotBuilder("group-snap-1-1", "group-snapuid1-1").
+				WithGroupSnapshotClass(classGold).
+				WithTargetContentName("groupsnapcontent-snapuid1-1").
+				WithNilStatus().
+				BuildArray(),
+			expectedGroupSnapshots: NewVolumeGroupSnapshotBuilder("group-snap-1-1", "group-snapuid1-1").
+				WithGroupSnapshotClass(classGold).
+				WithTargetContentName("groupsnapcontent-snapuid1-1").
+				WithStatusReadyToUse(false).
+				WithStatusError(`VolumeGroupSnapshotContent is dynamically provisioned while expecting a pre-provisioned one`).
+				BuildArray(),
+			initialGroupContents: NewVolumeGroupSnapshotContentBuilder("groupsnapcontent-snapuid1-1").
+				WithBoundGroupSnapshot("group-snap-1-1", "group-snapuid1-1").
+				WithDeletionPolicy(deletionPolicy).
+				WithGroupSnapshotClassName(classGold).
+				BuildArray(),
+			expectedGroupContents: NewVolumeGroupSnapshotContentBuilder("groupsnapcontent-snapuid1-1").
+				WithBoundGroupSnapshot("group-snap-1-1", "group-snapuid1-1").
+				WithDeletionPolicy(deletionPolicy).
+				WithGroupSnapshotClassName(classGold).
+				BuildArray(),
 			initialClaims: withClaimLabels(
 				newClaimCoupleArray("claim1-1", "pvc-uid6-1", "1Gi", "volume6-1", v1.ClaimBound, &classGold),
 				map[string]string{

--- a/pkg/common-controller/groupsnapshot_finalizer_test.go
+++ b/pkg/common-controller/groupsnapshot_finalizer_test.go
@@ -28,33 +28,35 @@ func TestGroupSnapshotFinalizer(t *testing.T) {
 	tests := []controllerTest{
 		{
 			name: "3-1 - finalizer is added on dynamically provisioned group contents if the volume group snapshot class specify a Deletion retain policy",
-			initialGroupSnapshots: newGroupSnapshotArray(
-				"group-snap-1-1", "group-snapuid1-1", map[string]string{
+			initialGroupSnapshots: NewVolumeGroupSnapshotBuilder("group-snap-1-1", "group-snapuid1-1").
+				WithSelectors(map[string]string{
 					"app.kubernetes.io/name": "postgresql",
-				},
-				"", classGold, "groupsnapcontent-group-snapuid1-1", &False, nil, nil, false, false, nil,
-			),
-			expectedGroupSnapshots: withGroupSnapshotFinalizers(
-				newGroupSnapshotArray(
-					"group-snap-1-1", "group-snapuid1-1", map[string]string{
-						"app.kubernetes.io/name": "postgresql",
-					},
-					"", classGold, "groupsnapcontent-group-snapuid1-1", &False, nil, nil, false, false, nil,
-				),
-				utils.VolumeGroupSnapshotBoundFinalizer,
-			),
-			initialGroupContents: newGroupSnapshotContentArray(
-				"groupsnapcontent-group-snapuid1-1", "group-snapuid1-1", "group-snap-1-1", "group-snapshot-handle", classGold, []string{
-					"1-pv-handle6-1",
-					"2-pv-handle6-1",
-				}, "", deletionPolicy, nil, false, false,
-			),
-			expectedGroupContents: newGroupSnapshotContentArray(
-				"groupsnapcontent-group-snapuid1-1", "group-snapuid1-1", "group-snap-1-1", "group-snapshot-handle", classGold, []string{
-					"1-pv-handle6-1",
-					"2-pv-handle6-1",
-				}, "", deletionPolicy, nil, false, false,
-			),
+				}).
+				WithGroupSnapshotClass(classGold).
+				WithStatusReadyToUse(false).
+				WithStatusBoundContentName("groupsnapcontent-group-snapuid1-1").
+				BuildArray(),
+			expectedGroupSnapshots: NewVolumeGroupSnapshotBuilder("group-snap-1-1", "group-snapuid1-1").
+				WithSelectors(map[string]string{
+					"app.kubernetes.io/name": "postgresql",
+				}).
+				WithGroupSnapshotClass(classGold).
+				WithStatusReadyToUse(false).
+				WithStatusBoundContentName("groupsnapcontent-group-snapuid1-1").
+				WithFinalizers(utils.VolumeGroupSnapshotBoundFinalizer).
+				BuildArray(),
+			initialGroupContents: NewVolumeGroupSnapshotContentBuilder("groupsnapcontent-group-snapuid1-1").
+				WithBoundGroupSnapshot("group-snap-1-1", "group-snapuid1-1").
+				WithDeletionPolicy(deletionPolicy).
+				WithGroupSnapshotClassName(classGold).
+				WithDesiredVolumeHandles("1-pv-handle6-1", "2-pv-handle6-1").
+				BuildArray(),
+			expectedGroupContents: NewVolumeGroupSnapshotContentBuilder("groupsnapcontent-group-snapuid1-1").
+				WithBoundGroupSnapshot("group-snap-1-1", "group-snapuid1-1").
+				WithDeletionPolicy(deletionPolicy).
+				WithGroupSnapshotClassName(classGold).
+				WithDesiredVolumeHandles("1-pv-handle6-1", "2-pv-handle6-1").
+				BuildArray(),
 			initialClaims: withClaimLabels(
 				newClaimCoupleArray("claim1-1", "pvc-uid6-1", "1Gi", "volume6-1", v1.ClaimBound, &classGold),
 				map[string]string{
@@ -66,34 +68,36 @@ func TestGroupSnapshotFinalizer(t *testing.T) {
 			expectSuccess:  true,
 		},
 		{
-			name: "3-2 - finalizer is not added on dynamically provisioned group contents if the volume group snapshot class specify the Retain retain policy",
-			initialGroupSnapshots: newGroupSnapshotArray(
-				"group-snap-1-1", "group-snapuid1-1", map[string]string{
+			name: "3-2 - finalizer is added on dynamically provisioned group contents if the volume group snapshot class specify the Retain retain policy",
+			initialGroupSnapshots: NewVolumeGroupSnapshotBuilder("group-snap-1-1", "group-snapuid1-1").
+				WithSelectors(map[string]string{
 					"app.kubernetes.io/name": "postgresql",
-				},
-				"", classSilver, "groupsnapcontent-group-snapuid1-1", &False, nil, nil, false, false, nil,
-			),
-			expectedGroupSnapshots: withGroupSnapshotFinalizers(
-				newGroupSnapshotArray(
-					"group-snap-1-1", "group-snapuid1-1", map[string]string{
-						"app.kubernetes.io/name": "postgresql",
-					},
-					"", classSilver, "groupsnapcontent-group-snapuid1-1", &False, nil, nil, false, false, nil,
-				),
-				utils.VolumeGroupSnapshotBoundFinalizer,
-			),
-			initialGroupContents: newGroupSnapshotContentArray(
-				"groupsnapcontent-group-snapuid1-1", "group-snapuid1-1", "group-snap-1-1", "group-snapshot-handle", classSilver, []string{
-					"1-pv-handle6-1",
-					"2-pv-handle6-1",
-				}, "", deletionPolicy, nil, false, false,
-			),
-			expectedGroupContents: newGroupSnapshotContentArray(
-				"groupsnapcontent-group-snapuid1-1", "group-snapuid1-1", "group-snap-1-1", "group-snapshot-handle", classSilver, []string{
-					"1-pv-handle6-1",
-					"2-pv-handle6-1",
-				}, "", deletionPolicy, nil, false, false,
-			),
+				}).
+				WithGroupSnapshotClass(classSilver).
+				WithStatusReadyToUse(false).
+				WithStatusBoundContentName("groupsnapcontent-group-snapuid1-1").
+				BuildArray(),
+			expectedGroupSnapshots: NewVolumeGroupSnapshotBuilder("group-snap-1-1", "group-snapuid1-1").
+				WithSelectors(map[string]string{
+					"app.kubernetes.io/name": "postgresql",
+				}).
+				WithGroupSnapshotClass(classSilver).
+				WithStatusReadyToUse(false).
+				WithStatusBoundContentName("groupsnapcontent-group-snapuid1-1").
+				WithFinalizers(utils.VolumeGroupSnapshotBoundFinalizer).
+				BuildArray(),
+			initialGroupContents: NewVolumeGroupSnapshotContentBuilder("groupsnapcontent-group-snapuid1-1").
+				WithBoundGroupSnapshot("group-snap-1-1", "group-snapuid1-1").
+				WithDeletionPolicy(deletionPolicy).
+				WithGroupSnapshotClassName(classSilver).
+				WithDesiredVolumeHandles("1-pv-handle6-1", "2-pv-handle6-1").
+				BuildArray(),
+			expectedGroupContents: NewVolumeGroupSnapshotContentBuilder("groupsnapcontent-group-snapuid1-1").
+				WithBoundGroupSnapshot("group-snap-1-1", "group-snapuid1-1").
+				WithDeletionPolicy(deletionPolicy).
+				WithGroupSnapshotClassName(classSilver).
+				WithDesiredVolumeHandles("1-pv-handle6-1", "2-pv-handle6-1").
+				BuildArray(),
 			initialClaims: withClaimLabels(
 				newClaimCoupleArray("claim1-1", "pvc-uid6-1", "1Gi", "volume6-1", v1.ClaimBound, &classSilver),
 				map[string]string{
@@ -106,38 +110,38 @@ func TestGroupSnapshotFinalizer(t *testing.T) {
 		},
 		{
 			name: "3-3 - dynamic group snapshot have been deleted, retention policy set to Delete - the finalizer will be removed",
-			initialGroupSnapshots: withGroupSnapshotFinalizers(
-				newGroupSnapshotArray(
-					"group-snap-1-1", "group-snapuid1-1", map[string]string{
-						"app.kubernetes.io/name": "postgresql",
-					},
-					"", classGold, "groupsnapcontent-group-snapuid1-1", &False, nil, nil, false, false, &timeNowMetav1,
-				),
-				utils.VolumeGroupSnapshotBoundFinalizer,
-			),
-			expectedGroupSnapshots: newGroupSnapshotArray(
-				"group-snap-1-1", "group-snapuid1-1", map[string]string{
+			initialGroupSnapshots: NewVolumeGroupSnapshotBuilder("group-snap-1-1", "group-snapuid1-1").
+				WithSelectors(map[string]string{
 					"app.kubernetes.io/name": "postgresql",
-				},
-				"", classGold, "groupsnapcontent-group-snapuid1-1", &False, nil, nil, false, false, &timeNowMetav1,
-			),
-			initialGroupContents: newGroupSnapshotContentArray(
-				"groupsnapcontent-group-snapuid1-1", "group-snapuid1-1", "group-snap-1-1", "group-snapshot-handle", classGold, []string{
-					"1-pv-handle6-1",
-					"2-pv-handle6-1",
-				}, "", crdv1.VolumeSnapshotContentRetain, nil, false, false,
-			),
-			expectedGroupContents: withGroupContentAnnotations(
-				newGroupSnapshotContentArray(
-					"groupsnapcontent-group-snapuid1-1", "group-snapuid1-1", "group-snap-1-1", "group-snapshot-handle", classGold, []string{
-						"1-pv-handle6-1",
-						"2-pv-handle6-1",
-					}, "", crdv1.VolumeSnapshotContentRetain, nil, false, false,
-				),
-				map[string]string{
-					utils.AnnVolumeGroupSnapshotBeingDeleted: "yes",
-				},
-			),
+				}).
+				WithGroupSnapshotClass(classGold).
+				WithDeletionTimestamp(timeNowMetav1).
+				WithStatusReadyToUse(false).
+				WithStatusBoundContentName("groupsnapcontent-group-snapuid1-1").
+				WithFinalizers(utils.VolumeGroupSnapshotBoundFinalizer).
+				BuildArray(),
+			expectedGroupSnapshots: NewVolumeGroupSnapshotBuilder("group-snap-1-1", "group-snapuid1-1").
+				WithSelectors(map[string]string{
+					"app.kubernetes.io/name": "postgresql",
+				}).
+				WithGroupSnapshotClass(classGold).
+				WithDeletionTimestamp(timeNowMetav1).
+				WithStatusReadyToUse(false).
+				WithStatusBoundContentName("groupsnapcontent-group-snapuid1-1").
+				BuildArray(),
+			initialGroupContents: NewVolumeGroupSnapshotContentBuilder("groupsnapcontent-group-snapuid1-1").
+				WithBoundGroupSnapshot("group-snap-1-1", "group-snapuid1-1").
+				WithDeletionPolicy(crdv1.VolumeSnapshotContentRetain).
+				WithGroupSnapshotClassName(classGold).
+				WithDesiredVolumeHandles("1-pv-handle6-1", "2-pv-handle6-1").
+				BuildArray(),
+			expectedGroupContents: NewVolumeGroupSnapshotContentBuilder("groupsnapcontent-group-snapuid1-1").
+				WithAnnotation(utils.AnnVolumeGroupSnapshotBeingDeleted, "yes").
+				WithBoundGroupSnapshot("group-snap-1-1", "group-snapuid1-1").
+				WithDeletionPolicy(crdv1.VolumeSnapshotContentRetain).
+				WithGroupSnapshotClassName(classGold).
+				WithDesiredVolumeHandles("1-pv-handle6-1", "2-pv-handle6-1").
+				BuildArray(),
 			initialClaims: withClaimLabels(
 				newClaimCoupleArray("claim1-1", "pvc-uid6-1", "1Gi", "volume6-1", v1.ClaimBound, &classGold),
 				map[string]string{

--- a/pkg/common-controller/groupsnapshot_update_test.go
+++ b/pkg/common-controller/groupsnapshot_update_test.go
@@ -27,28 +27,32 @@ func TestUpdateGroupSnapshotSync(t *testing.T) {
 	tests := []controllerTest{
 		{
 			name: "4-1 - successful pre-provisioned group snapshot but not ready, no-op",
-			initialGroupSnapshots: withGroupSnapshotFinalizers(
-				newGroupSnapshotArray(
-					"group-snap-1-1", "group-snapuid1-1", nil,
-					"groupsnapcontent-snapuid1-1", classGold, "groupsnapcontent-snapuid1-1", &False, nil, nil, false, false, nil,
-				),
-				utils.VolumeGroupSnapshotBoundFinalizer,
-			),
-			expectedGroupSnapshots: withGroupSnapshotFinalizers(
-				newGroupSnapshotArray(
-					"group-snap-1-1", "group-snapuid1-1", nil,
-					"groupsnapcontent-snapuid1-1", classGold, "groupsnapcontent-snapuid1-1", &False, nil, nil, false, false, nil,
-				),
-				utils.VolumeGroupSnapshotBoundFinalizer,
-			),
-			initialGroupContents: newGroupSnapshotContentArray(
-				"groupsnapcontent-snapuid1-1", "group-snapuid1-1", "group-snap-1-1", "", classGold, nil,
-				"group-snapshot-handle", deletionPolicy, nil, false, false,
-			),
-			expectedGroupContents: newGroupSnapshotContentArray(
-				"groupsnapcontent-snapuid1-1", "group-snapuid1-1", "group-snap-1-1", "", classGold, nil,
-				"group-snapshot-handle", deletionPolicy, nil, false, false,
-			),
+			initialGroupSnapshots: NewVolumeGroupSnapshotBuilder("group-snap-1-1", "group-snapuid1-1").
+				WithGroupSnapshotClass(classGold).
+				WithTargetContentName("groupsnapcontent-snapuid1-1").
+				WithStatusReadyToUse(false).
+				WithStatusBoundContentName("groupsnapcontent-snapuid1-1").
+				WithFinalizers(utils.VolumeGroupSnapshotBoundFinalizer).
+				BuildArray(),
+			expectedGroupSnapshots: NewVolumeGroupSnapshotBuilder("group-snap-1-1", "group-snapuid1-1").
+				WithGroupSnapshotClass(classGold).
+				WithTargetContentName("groupsnapcontent-snapuid1-1").
+				WithStatusReadyToUse(false).
+				WithStatusBoundContentName("groupsnapcontent-snapuid1-1").
+				WithFinalizers(utils.VolumeGroupSnapshotBoundFinalizer).
+				BuildArray(),
+			initialGroupContents: NewVolumeGroupSnapshotContentBuilder("groupsnapcontent-snapuid1-1").
+				WithBoundGroupSnapshot("group-snap-1-1", "group-snapuid1-1").
+				WithDeletionPolicy(deletionPolicy).
+				WithGroupSnapshotClassName(classGold).
+				WithTargetGroupSnapshotHandle("group-snapshot-handle").
+				BuildArray(),
+			expectedGroupContents: NewVolumeGroupSnapshotContentBuilder("groupsnapcontent-snapuid1-1").
+				WithBoundGroupSnapshot("group-snap-1-1", "group-snapuid1-1").
+				WithDeletionPolicy(deletionPolicy).
+				WithGroupSnapshotClassName(classGold).
+				WithTargetGroupSnapshotHandle("group-snapshot-handle").
+				BuildArray(),
 			initialClaims: withClaimLabels(
 				newClaimCoupleArray("claim1-1", "pvc-uid6-1", "1Gi", "volume6-1", v1.ClaimBound, &classGold),
 				map[string]string{
@@ -61,36 +65,36 @@ func TestUpdateGroupSnapshotSync(t *testing.T) {
 		},
 		{
 			name: "4-2 - successful dynamically-provisioned create group snapshot with group snapshot class gold but not ready, no-op",
-			initialGroupSnapshots: withGroupSnapshotFinalizers(
-				newGroupSnapshotArray(
-					"group-snap-1-1", "group-snapuid1-1", map[string]string{
-						"app.kubernetes.io/name": "postgresql",
-					},
-					"", classGold, "groupsnapcontent-group-snapuid1-1", &False, nil, nil, false, false, nil,
-				),
-				utils.VolumeGroupSnapshotBoundFinalizer,
-			),
-			expectedGroupSnapshots: withGroupSnapshotFinalizers(
-				newGroupSnapshotArray(
-					"group-snap-1-1", "group-snapuid1-1", map[string]string{
-						"app.kubernetes.io/name": "postgresql",
-					},
-					"", classGold, "groupsnapcontent-group-snapuid1-1", &False, nil, nil, false, false, nil,
-				),
-				utils.VolumeGroupSnapshotBoundFinalizer,
-			),
-			initialGroupContents: newGroupSnapshotContentArray(
-				"groupsnapcontent-group-snapuid1-1", "group-snapuid1-1", "group-snap-1-1", "snapshot-handle", classGold, []string{
-					"1-pv-handle6-1",
-					"2-pv-handle6-1",
-				}, "", deletionPolicy, nil, false, false,
-			),
-			expectedGroupContents: newGroupSnapshotContentArray(
-				"groupsnapcontent-group-snapuid1-1", "group-snapuid1-1", "group-snap-1-1", "snapshot-handle", classGold, []string{
-					"1-pv-handle6-1",
-					"2-pv-handle6-1",
-				}, "", deletionPolicy, nil, false, false,
-			),
+			initialGroupSnapshots: NewVolumeGroupSnapshotBuilder("group-snap-1-1", "group-snapuid1-1").
+				WithGroupSnapshotClass(classGold).
+				WithSelectors(map[string]string{
+					"app.kubernetes.io/name": "postgresql",
+				}).
+				WithStatusReadyToUse(false).
+				WithStatusBoundContentName("groupsnapcontent-group-snapuid1-1").
+				WithFinalizers(utils.VolumeGroupSnapshotBoundFinalizer).
+				BuildArray(),
+			expectedGroupSnapshots: NewVolumeGroupSnapshotBuilder("group-snap-1-1", "group-snapuid1-1").
+				WithGroupSnapshotClass(classGold).
+				WithSelectors(map[string]string{
+					"app.kubernetes.io/name": "postgresql",
+				}).
+				WithStatusReadyToUse(false).
+				WithStatusBoundContentName("groupsnapcontent-group-snapuid1-1").
+				WithFinalizers(utils.VolumeGroupSnapshotBoundFinalizer).
+				BuildArray(),
+			initialGroupContents: NewVolumeGroupSnapshotContentBuilder("groupsnapcontent-group-snapuid1-1").
+				WithBoundGroupSnapshot("group-snap-1-1", "group-snapuid1-1").
+				WithDeletionPolicy(deletionPolicy).
+				WithGroupSnapshotClassName(classGold).
+				WithDesiredVolumeHandles("1-pv-handle6-1", "2-pv-handle6-1").
+				BuildArray(),
+			expectedGroupContents: NewVolumeGroupSnapshotContentBuilder("groupsnapcontent-group-snapuid1-1").
+				WithBoundGroupSnapshot("group-snap-1-1", "group-snapuid1-1").
+				WithDeletionPolicy(deletionPolicy).
+				WithGroupSnapshotClassName(classGold).
+				WithDesiredVolumeHandles("1-pv-handle6-1", "2-pv-handle6-1").
+				BuildArray(),
 			initialClaims: withClaimLabels(
 				newClaimCoupleArray("claim1-1", "pvc-uid6-1", "1Gi", "volume6-1", v1.ClaimBound, &classGold),
 				map[string]string{
@@ -103,36 +107,38 @@ func TestUpdateGroupSnapshotSync(t *testing.T) {
 		},
 		{
 			name: "4-3 - group snapshot, setting it ready",
-			initialGroupSnapshots: withGroupSnapshotFinalizers(
-				newGroupSnapshotArray(
-					"group-snap-1-1", "group-snapuid1-1", map[string]string{
-						"app.kubernetes.io/name": "postgresql",
-					},
-					"", classGold, "groupsnapcontent-group-snapuid1-1", &False, nil, nil, false, false, nil,
-				),
-				utils.VolumeGroupSnapshotBoundFinalizer,
-			),
-			expectedGroupSnapshots: withGroupSnapshotFinalizers(
-				newGroupSnapshotArray(
-					"group-snap-1-1", "group-snapuid1-1", map[string]string{
-						"app.kubernetes.io/name": "postgresql",
-					},
-					"", classGold, "groupsnapcontent-group-snapuid1-1", &True, nil, nil, false, false, nil,
-				),
-				utils.VolumeGroupSnapshotBoundFinalizer,
-			),
-			initialGroupContents: newGroupSnapshotContentArray(
-				"groupsnapcontent-group-snapuid1-1", "group-snapuid1-1", "group-snap-1-1", "snapshot-handle", classGold, []string{
-					"1-pv-handle6-1",
-					"2-pv-handle6-1",
-				}, "", deletionPolicy, nil, false, true,
-			),
-			expectedGroupContents: newGroupSnapshotContentArray(
-				"groupsnapcontent-group-snapuid1-1", "group-snapuid1-1", "group-snap-1-1", "snapshot-handle", classGold, []string{
-					"1-pv-handle6-1",
-					"2-pv-handle6-1",
-				}, "", deletionPolicy, nil, false, true,
-			),
+			initialGroupSnapshots: NewVolumeGroupSnapshotBuilder("group-snap-1-1", "group-snapuid1-1").
+				WithGroupSnapshotClass(classGold).
+				WithSelectors(map[string]string{
+					"app.kubernetes.io/name": "postgresql",
+				}).
+				WithStatusReadyToUse(false).
+				WithStatusBoundContentName("groupsnapcontent-group-snapuid1-1").
+				WithFinalizers(utils.VolumeGroupSnapshotBoundFinalizer).
+				BuildArray(),
+			expectedGroupSnapshots: NewVolumeGroupSnapshotBuilder("group-snap-1-1", "group-snapuid1-1").
+				WithGroupSnapshotClass(classGold).
+				WithSelectors(map[string]string{
+					"app.kubernetes.io/name": "postgresql",
+				}).
+				WithStatusReadyToUse(true).
+				WithStatusBoundContentName("groupsnapcontent-group-snapuid1-1").
+				WithFinalizers(utils.VolumeGroupSnapshotBoundFinalizer).
+				BuildArray(),
+			initialGroupContents: NewVolumeGroupSnapshotContentBuilder("groupsnapcontent-group-snapuid1-1").
+				WithBoundGroupSnapshot("group-snap-1-1", "group-snapuid1-1").
+				WithDeletionPolicy(deletionPolicy).
+				WithGroupSnapshotClassName(classGold).
+				WithDesiredVolumeHandles("1-pv-handle6-1", "2-pv-handle6-1").
+				WithStatus().
+				BuildArray(),
+			expectedGroupContents: NewVolumeGroupSnapshotContentBuilder("groupsnapcontent-group-snapuid1-1").
+				WithBoundGroupSnapshot("group-snap-1-1", "group-snapuid1-1").
+				WithDeletionPolicy(deletionPolicy).
+				WithGroupSnapshotClassName(classGold).
+				WithDesiredVolumeHandles("1-pv-handle6-1", "2-pv-handle6-1").
+				WithStatus().
+				BuildArray(),
 			initialClaims: withClaimLabels(
 				newClaimCoupleArray("claim1-1", "pvc-uid6-1", "1Gi", "volume6-1", v1.ClaimBound, &classGold),
 				map[string]string{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup

> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

Enhance the readability of volume group snapshot unit tests by removing the `newGroupSnapshotContent` and the `newGroupSnapshot` functions which had way too many arguments, [as referred in a previous code review](https://github.com/kubernetes-csi/external-snapshotter/pull/1231#discussion_r1869866186).

To make the review easier, this patch addresses only the group snapshot functions, a next one will clean up `newSnapshot` and `newContent` too, fully addressing #1232.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
