### PR TITLE
Retain volumesnapshot-being-created annotation until readyToUse=true

### DIFF
--- a/pkg/sidecar-controller/content_create_test.go
+++ b/pkg/sidecar-controller/content_create_test.go
@@ -205,7 +205,7 @@ func TestSyncContent(t *testing.T) {
 				nil),
 			expectedContents: withContentAnnotations(withContentStatus(newContentArray("content1-7", "snapuid1-7", "snap1-7", "sid1-7", defaultClass, "", "volume-handle-1-7", retainPolicy, nil, &defaultSize, true),
 				&crdv1.VolumeSnapshotContentStatus{SnapshotHandle: toStringPointer("snapuid1-7"), RestoreSize: &defaultSize, ReadyToUse: &False}),
-				map[string]string{}),
+				map[string]string{"snapshot.storage.kubernetes.io/volumesnapshot-being-created": "yes"}),
 			expectedEvents: noevents,
 			expectedCreateCalls: []createCall{
 				{
@@ -236,7 +236,7 @@ func TestSyncContent(t *testing.T) {
 				map[string]string{}),
 			expectedContents: withContentAnnotations(withContentStatus(newContentArray("content1-8", "snapuid1-8", "snap1-8", "sid1-8", defaultClass, "", "volume-handle-1-8", retainPolicy, nil, &defaultSize, true),
 				&crdv1.VolumeSnapshotContentStatus{SnapshotHandle: toStringPointer("snapuid1-8"), RestoreSize: &defaultSize, ReadyToUse: &False}),
-				map[string]string{}),
+				map[string]string{"snapshot.storage.kubernetes.io/volumesnapshot-being-created": "yes"}),
 			expectedEvents: noevents,
 			expectedCreateCalls: []createCall{
 				{

--- a/pkg/sidecar-controller/snapshot_controller.go
+++ b/pkg/sidecar-controller/snapshot_controller.go
@@ -385,12 +385,14 @@ func (ctrl *csiSnapshotSideCarController) createSnapshotWrapper(content *crdv1.V
 	}
 	content = newContent
 
-	// NOTE(xyang): handle create timeout
-	// Remove annotation to indicate storage system has successfully
-	// cut the snapshot
-	content, err = ctrl.removeAnnVolumeSnapshotBeingCreated(content)
-	if err != nil {
-		return content, fmt.Errorf("failed to remove VolumeSnapshotBeingCreated annotation on the content %s: %q", content.Name, err)
+	if contentIsReady(content) {
+		// NOTE(xyang): handle create timeout
+		// Remove annotation to indicate storage system has successfully
+		// cut the snapshot
+		content, err = ctrl.removeAnnVolumeSnapshotBeingCreated(content)
+		if err != nil {
+			return content, fmt.Errorf("failed to remove VolumeSnapshotBeingCreated annotation on the content %s: %q", content.Name, err)
+		}
 	}
 
 	return content, nil


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
In `createSnapshotWrapper()`, the `snapshot.storage.kubernetes.io/volumesnapshot-being-created` annotation is removed even if the snapshot is not marked as `readyToUse` true. This is inconsistent with the same logic in `syncContent()` where we only remove the annotation if the snapshot content is ready: https://github.com/kubernetes-csi/external-snapshotter/blob/59d72977e7a24ccdfabed3a20720e41beddc8216/pkg/sidecar-controller/snapshot_controller.go#L102

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
This change may reduce symptoms seen in #1282. However this does not fix the root cause of immedate vs. scheduled exponential backoff requeuing.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Remove VolumeSnapshotContent ``snapshot.storage.kubernetes.io/volumesnapshot-being-created annotation only when status.readyToUse is true
```
