### PR TITLE
Add --poll-snapshot-period for periodic readiness requeue check when creating a VolumeSnapshotContent

### DIFF
--- a/cmd/csi-snapshotter/main.go
+++ b/cmd/csi-snapshotter/main.go
@@ -93,6 +93,7 @@ var (
 	metricsAddress              = flag.String("metrics-address", "", "(deprecated) The TCP network address where the prometheus metrics endpoint will listen (example: `:8080`). The default is empty string, which means metrics endpoint is disabled. Only one of `--metrics-address` and `--http-endpoint` can be set.")
 	httpEndpoint                = flag.String("http-endpoint", "", "The TCP network address where the HTTP server for diagnostics, including metrics and leader election health check, will listen (example: `:8080`). The default is empty string, which means the server is disabled. Only one of `--metrics-address` and `--http-endpoint` can be set.")
 	metricsPath                 = flag.String("metrics-path", "/metrics", "The HTTP path where prometheus metrics will be exposed. Default is `/metrics`.")
+	pollSnapshotPeriod          = flag.Duration("poll-snapshot-period", 10*time.Second, "Poll interval to check if a snapshot is ready. Default is 10 seconds.")
 	retryIntervalStart          = flag.Duration("retry-interval-start", time.Second, "Initial retry interval of failed volume snapshot creation or deletion. It doubles with each failure, up to retry-interval-max. Default is 1 second.")
 	retryIntervalMax            = flag.Duration("retry-interval-max", 5*time.Minute, "Maximum retry interval of failed volume snapshot creation or deletion. Default is 5 minutes.")
 	enableNodeDeployment        = flag.Bool("node-deployment", false, "Enables deploying the sidecar controller together with a CSI driver on nodes to manage snapshots for node-local volumes.")
@@ -297,6 +298,7 @@ func main() {
 		snapshotContentfactory.Groupsnapshot().V1beta1().VolumeGroupSnapshotContents(),
 		snapshotContentfactory.Groupsnapshot().V1beta1().VolumeGroupSnapshotClasses(),
 		workqueue.NewTypedItemExponentialFailureRateLimiter[string](*retryIntervalStart, *retryIntervalMax),
+		*pollSnapshotPeriod,
 	)
 
 	run := func(context.Context) {

--- a/pkg/sidecar-controller/framework_test.go
+++ b/pkg/sidecar-controller/framework_test.go
@@ -580,6 +580,7 @@ func newTestController(kubeClient kubernetes.Interface, clientset clientset.Inte
 		informerFactory.Groupsnapshot().V1beta1().VolumeGroupSnapshotContents(),
 		informerFactory.Groupsnapshot().V1beta1().VolumeGroupSnapshotClasses(),
 		workqueue.NewTypedItemExponentialFailureRateLimiter[string](1*time.Millisecond, 1*time.Minute),
+		10*time.Second, /* pollSnapshotPeriod */
 	)
 
 	ctrl.eventRecorder = record.NewFakeRecorder(1000)


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Today, the csi-snapshotter runs with a reconciler pattern when processing VolumeSnapshotContent resources. This follows the familiar `requeue, err` pattern that is followed by other controller frameworks, like controller-runtime.
 * Error Handling: When an error is encountered, VolumeSnapshotContent resources will be requeued with exponential decay. This behavior is desired, as presumably RPC calls to a CSI driver are due to congestion, and the request rate should be reduced.
 * Requeue Processing: In the case of dynamic provisioning, the creation of a VolumeSnapshotContent may require some time until a snapshot is ready in the underlying storage system. This is where the `requeue` field is useful, as the reconciler can periodically attempt to check the status of a snapshot.

The problem with the current requeue implementation is that it relies on the same exponential backoff rate limiter queue as the error handling scenario. This is a problem, as it can lead to non-deterministic ready times, and can lead to significantly higher effective snapshot ready latencies for snapshots that take longer to process (eg: larger snapshots).

To fix this, the requeue logic should use a constant retry period, to allow for more reliable snapshot reconciliation. This PR adds a new command line argument `--poll-snapshot-period` to the csi-snapshotter, with a default of `10 seconds`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1282

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Requeue VolumeSnapshotContent resources based on --poll-snapshot-period in csi-snapshotter
```
