### PR TITLE
Move member VolumeSnapshotContents creation to the sidecar

### DIFF
--- a/deploy/kubernetes/csi-snapshotter/rbac-csi-snapshotter.yaml
+++ b/deploy/kubernetes/csi-snapshotter/rbac-csi-snapshotter.yaml
@@ -36,7 +36,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents"]
-    verbs: ["get", "list", "watch", "update", "patch"]
+    verbs: ["create", "get", "list", "watch", "update", "patch"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents/status"]
     verbs: ["update", "patch"]

--- a/pkg/naming/groupsnapshot.go
+++ b/pkg/naming/groupsnapshot.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package naming
+
+import (
+	"crypto/sha256"
+	"fmt"
+)
+
+// GetSnapshotNameForVolumeGroupSnapshotContent returns a unique snapshot name for a VolumeGroupSnapshotContent.
+func GetSnapshotNameForVolumeGroupSnapshotContent(groupSnapshotContentUUID, volumeHandle string) string {
+	return fmt.Sprintf("snapshot-%x", sha256.Sum256([]byte(groupSnapshotContentUUID+volumeHandle)))
+}
+
+// GetSnapshotNameForVolumeGroupSnapshotContent returns a unique content name for the
+// passed in VolumeGroupSnapshotContent.
+func GetSnapshotContentNameForVolumeGroupSnapshotContent(groupSnapshotContentUUID, volumeHandle string) string {
+	return fmt.Sprintf("snapcontent-%x", sha256.Sum256([]byte(groupSnapshotContentUUID+volumeHandle)))
+}

--- a/pkg/naming/groupsnapshot_test.go
+++ b/pkg/naming/groupsnapshot_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package naming
+
+import "testing"
+
+func TestMemberSnapshotsNaming(t *testing.T) {
+	results := []struct {
+		groupSnapshotUUID string
+		volumeHandleUUID  string
+		expectedName      string
+	}{
+		{
+			groupSnapshotUUID: "b0e14ea3-138d-11f0-a142-da4b6452e9d8",
+			volumeHandleUUID:  "e8e932dc-4911-40c7-9da3-3f3d85c49458",
+			expectedName:      "snapshot-a1cafe086c8f775046b4d4f51ae8ee57bd72c595399a04c1ec64eedbed64bc49",
+		},
+		{
+			groupSnapshotUUID: "b0e14ea3-138d-11f0-a142-da4b6452e9d8",
+			volumeHandleUUID:  "054c23b9-d11a-4383-88a1-e1ef2648fb9f",
+			expectedName:      "snapshot-8707de99194420fc588501d1800f11c41046c58810ddd7ac671d0b035b0ce07f",
+		},
+	}
+
+	for _, test := range results {
+		result := GetSnapshotNameForVolumeGroupSnapshotContent(test.groupSnapshotUUID, test.volumeHandleUUID)
+		if result != test.expectedName {
+			t.Errorf("Wrong volume snapshot name:[%s] expected:[%s]", result, test.expectedName)
+		}
+	}
+}
+
+func TestMemberSnapshotContentsNaming(t *testing.T) {
+	results := []struct {
+		groupSnapshotUUID string
+		volumeHandleUUID  string
+		expectedName      string
+	}{
+		{
+			groupSnapshotUUID: "b0e14ea3-138d-11f0-a142-da4b6452e9d8",
+			volumeHandleUUID:  "e8e932dc-4911-40c7-9da3-3f3d85c49458",
+			expectedName:      "snapcontent-a1cafe086c8f775046b4d4f51ae8ee57bd72c595399a04c1ec64eedbed64bc49",
+		},
+		{
+			groupSnapshotUUID: "b0e14ea3-138d-11f0-a142-da4b6452e9d8",
+			volumeHandleUUID:  "054c23b9-d11a-4383-88a1-e1ef2648fb9f",
+			expectedName:      "snapcontent-8707de99194420fc588501d1800f11c41046c58810ddd7ac671d0b035b0ce07f",
+		},
+	}
+
+	for _, test := range results {
+		result := GetSnapshotContentNameForVolumeGroupSnapshotContent(test.groupSnapshotUUID, test.volumeHandleUUID)
+		if result != test.expectedName {
+			t.Errorf("Wrong volume snapshot name:[%s] expected:[%s]", result, test.expectedName)
+		}
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

It allows the use of information from the CreateGroupSnapshot RPC call to fill out the status of VolumeSnapshotContents and set the restoreSize field even when the ListSnapshots GRPC call is not implemented.

**Which issue(s) this PR fixes**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1271

**Special notes for your reviewer**:

A subsequent PR will thread a context to the function where the member VolumeSnapshotContents are created.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The restoreSize field is now set when creating a VolumeGroupSnapshot even if the CSI Driver does not implement the ListSnapshots GRPC call. Starting from this release, the CSI snapshotter sidecar requires RBAC permission to create VolumeSnapshotContents objects.
```
