### PR TITLE
Queue resyncs in `ShouldEnqueueContentChange`

### DIFF
--- a/pkg/utils/util_test.go
+++ b/pkg/utils/util_test.go
@@ -489,9 +489,30 @@ func TestShouldEnqueueContentChange(t *testing.T) {
 			},
 			expectedResult: true,
 		},
+		{
+			name: "resync from informer (old matches new including resource version)",
+			old: &crdv1.VolumeSnapshotContent{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: oldValue,
+				},
+			},
+			new: &crdv1.VolumeSnapshotContent{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: oldValue,
+				},
+			},
+			expectedResult: true,
+		},
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
+			// Inject resource version unless it is already set in test object
+			if tc.old.ResourceVersion == "" {
+				tc.old.ResourceVersion = oldValue
+			}
+			if tc.new.ResourceVersion == "" {
+				tc.old.ResourceVersion = newValue
+			}
 			result := ShouldEnqueueContentChange(tc.old, tc.new)
 			if result != tc.expectedResult {
 				t.Fatalf("Incorrect result: Expected %v received %v", tc.expectedResult, result)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Resyncs are sent to an informer's update handler via a no-diff (i.e. `new` and `old` are identical) update. Currently, `ShouldEnqueueContentChange` will incorrectly return `false` in this case, as it detects no change.

We can reliably determine if an update is caused by a resync by comparing the resource versions, as any normal update will cause these to differ. This is also how the `external-attacher` handles this case in its similar `shouldEnqueueVAChange`: https://github.com/kubernetes-csi/external-attacher/blob/c8f0c14a7d985c33d8fe80a55ebb46a1ee3df877/pkg/controller/controller.go#L288-L291

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Partial fix of #1258

**Special notes for your reviewer**:

N/A

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix a bug preventing VolumeSnapshotContent objects from being re-synced
```