### PR TITLE
Fix: PVC finalizer not removed due to broken VolumeSnapshots

### DIFF
--- a/pkg/common-controller/snapshot_controller.go
+++ b/pkg/common-controller/snapshot_controller.go
@@ -1050,7 +1050,12 @@ func (ctrl *csiSnapshotCommonController) isPVCBeingUsed(pvc *v1.PersistentVolume
 			klog.V(4).Infof("Skipping static bound snapshot %s when checking PVC %s/%s", snap.Name, pvc.Namespace, pvc.Name)
 			continue
 		}
-		if snap.Spec.Source.PersistentVolumeClaimName != nil && pvc.Name == *snap.Spec.Source.PersistentVolumeClaimName && !utils.IsSnapshotReady(snap) {
+
+		if snap.Spec.Source.PersistentVolumeClaimName != nil &&
+			pvc.Name == *snap.Spec.Source.PersistentVolumeClaimName &&
+			!utils.IsSnapshotReady(snap) &&
+			utils.HasSnapshotFinalizer(snap, utils.PVCFinalizer) {
+
 			klog.V(2).Infof("Keeping PVC %s/%s, it is used by snapshot %s/%s", pvc.Namespace, pvc.Name, snap.Namespace, snap.Name)
 			return true
 		}

--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -611,6 +611,15 @@ func IsBoundVolumeSnapshotContentNameSet(snapshot *crdv1.VolumeSnapshot) bool {
 	return true
 }
 
+func HasSnapshotFinalizer(snapshot *crdv1.VolumeSnapshot, finalizer string) bool {
+	for _, f := range snapshot.ObjectMeta.Finalizers {
+		if f == finalizer {
+			return true
+		}
+	}
+	return false
+}
+
 func IsSnapshotReady(snapshot *crdv1.VolumeSnapshot) bool {
 	if snapshot.Status == nil || snapshot.Status.ReadyToUse == nil || *snapshot.Status.ReadyToUse == false {
 		return false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> /kind bug

**What this PR does / why we need it**:

Fixes a bug where a PVC’s finalizer `snapshot.storage.kubernetes.io/pvc-as-source-protection` is not removed when there are broken or misconfigured VolumeSnapshots that reference the PVC but never transition to `ReadyToUse`.

The snapshot controller currently considers any VolumeSnapshot with `ReadyToUse == false` as blocking PVC deletion — even if the snapshot is invalid and has already failed.

This patch ensures the controller only considers:
- VolumeSnapshots with `ReadyToUse == false`, **and**
- that still retain the `pvc-as-source-protection` finalizer

This avoids permanently stuck PVCs when broken snapshots linger in the namespace.

**Which issue(s) this PR fixes**:
Fixes [#1305](https://github.com/kubernetes-csi/external-snapshotter/issues/1305)

**Special notes for your reviewer**:
- The change preserves the protective behavior for in-progress snapshots.
- The PVC can now be deleted once only broken snapshots remain, and they no longer hold the finalizer.

**Does this PR introduce a user-facing change?**:
```release-note
Fix: PVC finalizer `snapshot.storage.kubernetes.io/pvc-as-source-protection` is now removed even if other VolumeSnapshots are stuck in a failed state, as long as those snapshots no longer hold the finalizer.
