### PR TITLE
Release tool update

### DIFF
--- a/release-tools/.github/workflows/codespell.yml
+++ b/release-tools/.github/workflows/codespell.yml
@@ -8,7 +8,7 @@ jobs:
     name: Check for spelling errors
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: codespell-project/actions-codespell@master
         with:
           check_filenames: true

--- a/release-tools/.github/workflows/trivy.yaml
+++ b/release-tools/.github/workflows/trivy.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Get Go version
         id: go-version

--- a/release-tools/cloudbuild.yaml
+++ b/release-tools/cloudbuild.yaml
@@ -26,7 +26,7 @@ steps:
   # The image must contain bash and curl. Ideally it should also contain
   # the desired version of Go (currently defined in release-tools/prow.sh),
   # but that just speeds up the build and is not required.
-  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20240718-5ef92b5c36'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20240718-5ef92b5c36'
     entrypoint: ./.cloudbuild.sh
     env:
     - GIT_TAG=${_GIT_TAG}


### PR DESCRIPTION
/kind bug

Squashed 'release-tools/' changes from 5f38a9075..74502e544
74502e544 Merge pull request https://github.com/kubernetes-csi/external-snapshotter/pull/278 from liangyuanpeng/migrate_k8s_testimages
533443055 Merge pull request https://github.com/kubernetes-csi/external-snapshotter/pull/281 from kubernetes-csi/dependabot/github_actions/actions/checkout-5
458ce146f Bump actions/checkout from 4 to 5
5ec1a52b8 use gcr.io/k8s-staging-test-infra instead of gcr.io/k8s-testimages

git-subtree-dir: release-tools
git-subtree-split: 74502e544bc6a17820892c0d490e8f0b59462998
