### PR TITLE
Add aggregated RBAC for VolumeSnapshots

### DIFF
--- a/deploy/kubernetes/snapshot-controller/kustomization.yaml
+++ b/deploy/kubernetes/snapshot-controller/kustomization.yaml
@@ -3,4 +3,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - rbac-snapshot-controller.yaml
+  - rbac-snapshot-user.yaml
   - setup-snapshot-controller.yaml

--- a/deploy/kubernetes/snapshot-controller/rbac-snapshot-user.yaml
+++ b/deploy/kubernetes/snapshot-controller/rbac-snapshot-user.yaml
@@ -1,0 +1,90 @@
+# User-facing RBAC ClusterRoles for VolumeSnapshots.
+#
+# These ClusterRoles use label-based aggregation to automatically extend
+# the built-in admin, edit, and view ClusterRoles with permissions for
+# VolumeSnapshot resources. This allows non-admin users to work with
+# VolumeSnapshots in namespaces where they have appropriate roles.
+
+---
+# Aggregates to admin role - full access to volumesnapshots
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: snapshot-admin
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+rules:
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots/status"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["groupsnapshot.storage.k8s.io"]
+    resources: ["volumegroupsnapshots"]
+    verbs: ["create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"]
+  - apiGroups: ["groupsnapshot.storage.k8s.io"]
+    resources: ["volumegroupsnapshots/status"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["groupsnapshot.storage.k8s.io"]
+    resources: ["volumegroupsnapshotclasses"]
+    verbs: ["get", "list", "watch"]
+
+---
+# Aggregates to edit role - full access to volumesnapshots
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: snapshot-edit
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots/status"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["groupsnapshot.storage.k8s.io"]
+    resources: ["volumegroupsnapshots"]
+    verbs: ["create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"]
+  - apiGroups: ["groupsnapshot.storage.k8s.io"]
+    resources: ["volumegroupsnapshots/status"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["groupsnapshot.storage.k8s.io"]
+    resources: ["volumegroupsnapshotclasses"]
+    verbs: ["get", "list", "watch"]
+
+---
+# Aggregates to view role - read-only access to volumesnapshots
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: snapshot-view
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+rules:
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots/status"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["groupsnapshot.storage.k8s.io"]
+    resources: ["volumegroupsnapshots"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["groupsnapshot.storage.k8s.io"]
+    resources: ["volumegroupsnapshots/status"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["groupsnapshot.storage.k8s.io"]
+    resources: ["volumegroupsnapshotclasses"]
+    verbs: ["get", "list", "watch"]


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>

/kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This PR adds aggregated ClusterRoles (snapshot-admin, snapshot-edit, snapshot-view) that automatically extend the built-in Kubernetes admin, edit, and view roles with permissions for VolumeSnapshot resources.

Non-admin users can GET/list PVCs but cannot access VolumeSnapshots, even when they have admin, edit, or view roles in a namespace. This is because PVC permissions are built into Kubernetes core, while VolumeSnapshot (as a CRD) requires explicit aggregated RBAC rules

Non-admin users can GET/list PVCs but cannot access VolumeSnapshots, even when they have admin, edit, or view roles in a namespace. This is because PVC permissions are built into Kubernetes core, while VolumeSnapshot (as a CRD) requires explicit aggregated RBAC rules. Since VolumeSnapshots are created from PVCs and used to restore PVCs, users who can manage PVCs should have equivalent access to VolumeSnapshots.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Users with admin, edit, or view roles in a namespace can now access VolumeSnapshots without requiring cluster-admin privileges.
```
