### PR TITLE
deploy: update sidecar image versions

### DIFF
--- a/deploy/kubernetes/csi-snapshotter/setup-csi-snapshotter.yaml
+++ b/deploy/kubernetes/csi-snapshotter/setup-csi-snapshotter.yaml
@@ -72,7 +72,7 @@ spec:
       serviceAccountName: csi-snapshotter
       containers:
         - name: csi-provisioner
-          image: registry.k8s.io/sig-storage/csi-provisioner:v6.1.0
+          image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -84,7 +84,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-snapshotter
-          image: registry.k8s.io/sig-storage/csi-snapshotter:v8.4.0
+          image: registry.k8s.io/sig-storage/csi-snapshotter:v8.5.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -97,7 +97,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: hostpath
-          image: registry.k8s.io/sig-storage/hostpathplugin:v1.11.0
+          image: registry.k8s.io/sig-storage/hostpathplugin:v1.17.1
           args:
             - "--v=5"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml
+++ b/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml
@@ -34,7 +34,7 @@ spec:
       serviceAccountName: snapshot-controller
       containers:
         - name: snapshot-controller
-          image: registry.k8s.io/sig-storage/snapshot-controller:v8.4.0
+          image: registry.k8s.io/sig-storage/snapshot-controller:v8.5.0
           args:
             - "--v=5"
             - "--leader-election=true"


### PR DESCRIPTION
Update cross-referenced sidecar images to latest stable releases:
- csi-provisioner: v6.1.0 -> v6.2.0
- csi-snapshotter: v8.4.0 -> v8.5.0
- snapshot-controller: v8.4.0 -> v8.5.0
- hostpathplugin: v1.11.0 -> v1.17.1

Note: snapshot-conversion-webhook left at v8.0.1 as no published images exist in registry.k8s.io for this component.


> /kind cleanup
-->
```release-note
NONE
```
