### PR TITLE
Fix VolumeSnapshot deletion not retrying when used for PVC restore

### DIFF
--- a/pkg/common-controller/framework_test.go
+++ b/pkg/common-controller/framework_test.go
@@ -1678,6 +1678,20 @@ func newClaimArray(name, claimUID, capacity, boundToVolume string, phase v1.Pers
 	}
 }
 
+// newClaimPendingRestoreFromVolumeSnapshot returns a PVC in Pending phase with DataSource
+// pointing at the given VolumeSnapshot name. Used to test snapshot deletion while a
+// volume is still being provisioned from that snapshot.
+func newClaimPendingRestoreFromVolumeSnapshot(name, claimUID, capacity string, volumeSnapshotName string, class *string) *v1.PersistentVolumeClaim {
+	apiGroup := crdv1.GroupName
+	claim := newClaim(name, claimUID, capacity, "", v1.ClaimPending, class, false)
+	claim.Spec.DataSource = &v1.TypedLocalObjectReference{
+		APIGroup: &apiGroup,
+		Kind:     "VolumeSnapshot",
+		Name:     volumeSnapshotName,
+	}
+	return claim
+}
+
 // newClaimCoupleArray returns array with two claims that would be returned by
 // newClaim() with "1-" and "2-" as prefix for names and UID.
 func newClaimCoupleArray(name, claimUID, capacity, boundToVolume string, phase v1.PersistentVolumeClaimPhase, class *string) []*v1.PersistentVolumeClaim {

--- a/pkg/common-controller/groupsnapshot_controller_helper.go
+++ b/pkg/common-controller/groupsnapshot_controller_helper.go
@@ -1611,8 +1611,8 @@ func (ctrl *csiSnapshotCommonController) processGroupSnapshotWithDeletionTimesta
 			msg := fmt.Sprintf("Snapshot %s belonging to VolumeGroupSnapshot %s is being used to restore a PVC", utils.SnapshotKey(snapshot), utils.GroupSnapshotKey(groupSnapshot))
 			klog.V(4).Info(msg)
 			ctrl.eventRecorder.Event(groupSnapshot, v1.EventTypeWarning, "SnapshotDeletePending", msg)
-			// TODO(@xiangqian): should requeue this?
-			return nil
+			// Return error so the workqueue will requeue and retry deletion when the PVC is no longer in use.
+			return fmt.Errorf("%s, will retry deletion", msg)
 		}
 
 	}

--- a/pkg/common-controller/groupsnapshot_controller_helper.go
+++ b/pkg/common-controller/groupsnapshot_controller_helper.go
@@ -1611,8 +1611,8 @@ func (ctrl *csiSnapshotCommonController) processGroupSnapshotWithDeletionTimesta
 			msg := fmt.Sprintf("Snapshot %s belonging to VolumeGroupSnapshot %s is being used to restore a PVC", utils.SnapshotKey(snapshot), utils.GroupSnapshotKey(groupSnapshot))
 			klog.V(4).Info(msg)
 			ctrl.eventRecorder.Event(groupSnapshot, v1.EventTypeWarning, "SnapshotDeletePending", msg)
-			// Return error so the workqueue will requeue and retry deletion when the PVC is no longer in use.
-			return fmt.Errorf("%s, will retry deletion", msg)
+			// Return error so the workqueue requeues until no PVC is still being created from this snapshot.
+			return fmt.Errorf("%s: snapshot is in use, will retry deletion", msg)
 		}
 
 	}

--- a/pkg/common-controller/snapshot_controller.go
+++ b/pkg/common-controller/snapshot_controller.go
@@ -282,13 +282,13 @@ func (ctrl *csiSnapshotCommonController) checkandRemoveSnapshotFinalizersAndChec
 		return nil
 	}
 
-	// check if the snapshot is being used for restore a PVC, if yes, do nothing
-	// and wait until PVC restoration finishes
+	// check if the snapshot is being used for restore a PVC, if yes, return an error
+	// so the workqueue will requeue this snapshot and retry deletion when the PVC
+	// is no longer in use (e.g., binding completed or PVC deleted).
 	if content != nil && ctrl.isVolumeBeingCreatedFromSnapshot(snapshot) {
 		klog.V(4).Infof("checkandRemoveSnapshotFinalizersAndCheckandDeleteContent[%s]: snapshot is being used to restore a PVC", utils.SnapshotKey(snapshot))
 		ctrl.eventRecorder.Event(snapshot, v1.EventTypeWarning, "SnapshotDeletePending", "Snapshot is being used to restore a PVC")
-		// TODO(@xiangqian): should requeue this?
-		return nil
+		return fmt.Errorf("snapshot %s is being used to restore a PVC, will retry deletion", utils.SnapshotKey(snapshot))
 	}
 
 	removeGroupFinalizer := false

--- a/pkg/common-controller/snapshot_controller.go
+++ b/pkg/common-controller/snapshot_controller.go
@@ -288,7 +288,7 @@ func (ctrl *csiSnapshotCommonController) checkandRemoveSnapshotFinalizersAndChec
 	if content != nil && ctrl.isVolumeBeingCreatedFromSnapshot(snapshot) {
 		klog.V(4).Infof("checkandRemoveSnapshotFinalizersAndCheckandDeleteContent[%s]: snapshot is being used to restore a PVC", utils.SnapshotKey(snapshot))
 		ctrl.eventRecorder.Event(snapshot, v1.EventTypeWarning, "SnapshotDeletePending", "Snapshot is being used to restore a PVC")
-		return fmt.Errorf("snapshot %s is being used to restore a PVC, will retry deletion", utils.SnapshotKey(snapshot))
+		return fmt.Errorf("snapshot %s is in use (being used to restore a PVC), will retry deletion", utils.SnapshotKey(snapshot))
 	}
 
 	removeGroupFinalizer := false

--- a/pkg/common-controller/snapshot_delete_test.go
+++ b/pkg/common-controller/snapshot_delete_test.go
@@ -171,6 +171,24 @@ func TestDeleteSync(t *testing.T) {
 			test:              testSyncContent,
 		},
 		{
+			// Snapshot is being deleted while a PVC in Pending still uses it as DataSource for restore.
+			// syncSnapshot must return an error so the workqueue retries (regression test for #1366).
+			name:              "3-1a - (dynamic) snapshot deletion returns error when a PVC is still restoring from the snapshot",
+			initialContents:   newContentArray("snapcontent-snapuid3-1a", "snapuid3-1a", "snap3-1a", "sid3-1a", validSecretClass, "", "volume3-1a", deletePolicy, nil, nil, true),
+			expectedContents:  newContentArray("snapcontent-snapuid3-1a", "snapuid3-1a", "snap3-1a", "sid3-1a", validSecretClass, "", "volume3-1a", deletePolicy, nil, nil, true),
+			initialSnapshots:  newSnapshotArray("snap3-1a", "snapuid3-1a", "claim3-1a", "", validSecretClass, "snapcontent-snapuid3-1a", &True, nil, nil, nil, false, true, &timeNowMetav1),
+			expectedSnapshots: newSnapshotArray("snap3-1a", "snapuid3-1a", "claim3-1a", "", validSecretClass, "snapcontent-snapuid3-1a", &True, nil, nil, nil, false, true, &timeNowMetav1),
+			initialClaims: []*v1.PersistentVolumeClaim{
+				newClaim("claim3-1a", "pvc-uid3-1a", "1Gi", "volume3-1a", v1.ClaimBound, &classEmpty, false),
+				newClaimPendingRestoreFromVolumeSnapshot("claim-restore-pending-1a", "pvc-uid-restore-1a", "1Gi", "snap3-1a", &classEmpty),
+			},
+			expectedEvents: []string{"Warning SnapshotDeletePending"},
+			initialSecrets: []*v1.Secret{secret()},
+			errors:         noerrors,
+			expectSuccess:  false,
+			test:           testSyncSnapshotError,
+		},
+		{
 			name:             "3-1 - (dynamic) content will be deleted if snapshot deletion timestamp is set",
 			initialContents:  newContentArray("snapcontent-snapuid3-1", "snapuid3-1", "snap3-1", "sid3-1", validSecretClass, "", "volume3-1", deletePolicy, nil, nil, true),
 			expectedContents: nocontents,


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When a VolumeSnapshot is deleted while a PVC is still being created from it, the controller blocked deletion but returned `nil`, so the workqueue never retried. This change returns an error instead so the snapshot is requeued and deletion is retried once the PVC is no longer in use.

The same fix is applied for VolumeGroupSnapshot in the group snapshot helper.

**Which issue(s) this PR fixes**:
Fixes #1366

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Fixed VolumeSnapshot (and VolumeGroupSnapshot) deletion getting stuck when the snapshot was in use for a PVC restore. The controller now requeues and retries deletion until the PVC is no longer in use.```
