### PR TITLE
Added validation that creation time is not zero (epoch)

### DIFF
--- a/pkg/common-controller/snapshot_controller.go
+++ b/pkg/common-controller/snapshot_controller.go
@@ -1189,7 +1189,7 @@ func (ctrl *csiSnapshotCommonController) needsUpdateSnapshotStatus(snapshot *crd
 	if snapshot.Status.BoundVolumeSnapshotContentName == nil {
 		return true
 	}
-	if snapshot.Status.CreationTime == nil && content.Status.CreationTime != nil {
+	if snapshot.Status.CreationTime == nil && content.Status.CreationTime != nil && *content.Status.CreationTime != 0 {
 		return true
 	}
 	if snapshot.Status.ReadyToUse == nil && content.Status.ReadyToUse != nil {
@@ -1214,7 +1214,7 @@ func (ctrl *csiSnapshotCommonController) updateSnapshotStatus(snapshot *crdv1.Vo
 
 	boundContentName := content.Name
 	var createdAt *time.Time
-	if content.Status != nil && content.Status.CreationTime != nil {
+	if content.Status != nil && content.Status.CreationTime != nil && *content.Status.CreationTime != 0 {
 		unixTime := time.Unix(0, *content.Status.CreationTime)
 		createdAt = &unixTime
 	}

--- a/pkg/sidecar-controller/snapshot_controller.go
+++ b/pkg/sidecar-controller/snapshot_controller.go
@@ -475,10 +475,12 @@ func (ctrl *csiSnapshotSideCarController) updateSnapshotContentStatus(
 		newStatus = &crdv1.VolumeSnapshotContentStatus{
 			SnapshotHandle: &snapshotHandle,
 			ReadyToUse:     &readyToUse,
-			CreationTime:   &createdAt,
 		}
 		if groupSnapshotID != "" {
 			newStatus.VolumeGroupSnapshotHandle = &groupSnapshotID
+		}
+		if createdAt > 0 {
+			newStatus.CreationTime = &createdAt
 		}
 		if size > 0 {
 			newStatus.RestoreSize = &size
@@ -497,7 +499,7 @@ func (ctrl *csiSnapshotSideCarController) updateSnapshotContentStatus(
 				newStatus.Error = nil
 			}
 		}
-		if newStatus.CreationTime == nil {
+		if newStatus.CreationTime == nil && createdAt > 0 {
 			newStatus.CreationTime = &createdAt
 			updated = true
 		}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you: 1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide 2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md 3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests -->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR updates the handling of `CreationTime` in the snapshot controller to avoid persisting a zero value (`*int64 == 0`) when returned by the CSI driver.

Currently, if the CSI driver returns `CreationTime = 0`, the snapshot controller treats it as a valid value and sets it on `VolumeSnapshotContent` and `VolumeSnapshot`. Since `CreationTime` is only set once, this prevents any future updates with the actual timestamp.

Some CSI drivers create snapshots asynchronously and cannot determine the creation time at the moment of the initial `CreateSnapshot` call. In such cases, returning `0` is used to indicate that the real value is not yet available.

Persisting this zero value results in incorrect snapshot metadata (epoch time) and prevents updating the field later when the actual creation time becomes available.

This PR changes the behavior so that a zero value is treated as "not set":
- If the CSI driver returns `CreationTime = 0`, the field is not set on `VolumeSnapshotContent` and `VolumeSnapshot`
- This allows the controller to populate it later when a valid timestamp is returned

**Which issue(s) this PR fixes**:

NONE

**Special notes for your reviewer**:

This change preserves existing behavior for drivers that return a valid `CreationTime`, and improves compatibility with drivers that perform asynchronous snapshot creation.

**Does this PR introduce a user-facing change?**:
<!-- If no, just write "NONE" in the release-note block below. If yes, a release note is required: Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required". -->
```release-note
Fix handling of CreationTime in external-snapshotter: zero values returned by CSI drivers are now treated as "not set" and will not be persisted, allowing the field to be updated later when a valid timestamp is available.