### PR TITLE
fix(common-controller): retry conflict updates and dedupe success signais

### DIFF
--- a/pkg/common-controller/snapshot_conflict_test.go
+++ b/pkg/common-controller/snapshot_conflict_test.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common_controller
+
+import (
+	"fmt"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/kubernetes-csi/external-snapshotter/client/v8/clientset/versioned/fake"
+	v1 "k8s.io/api/core/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+func newConflictTestController(
+	t *testing.T,
+	test controllerTest,
+) (*csiSnapshotCommonController, *snapshotReactor) {
+	t.Helper()
+
+	kubeClient := &kubefake.Clientset{}
+	client := &fake.Clientset{}
+
+	ctrl, err := newTestController(kubeClient, client, nil, t, test)
+	if err != nil {
+		t.Fatalf("construct controller failed: %v", err)
+	}
+
+	reactor := newSnapshotReactor(kubeClient, client, ctrl, nil, nil, test.errors)
+	for _, snapshot := range test.initialSnapshots {
+		ctrl.snapshotStore.Add(snapshot)
+		reactor.snapshots[snapshot.Name] = snapshot
+	}
+	for _, content := range test.initialContents {
+		ctrl.contentStore.Add(content)
+		reactor.contents[content.Name] = content
+	}
+
+	pvcIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	for _, claim := range test.initialClaims {
+		reactor.claims[claim.Name] = claim
+		pvcIndexer.Add(claim)
+	}
+	ctrl.pvcLister = corelisters.NewPersistentVolumeClaimLister(pvcIndexer)
+
+	return ctrl, reactor
+}
+
+func newConflict(resource, name string) error {
+	return apierrs.NewConflict(schema.GroupResource{Resource: resource}, name, fmt.Errorf("resource version conflict"))
+}
+
+func TestEnsurePVCFinalizerConflictIsRetriedAndSucceeds(t *testing.T) {
+	test := controllerTest{
+		name:             "ensure pvc finalizer retries on conflict",
+		initialSnapshots: newSnapshotArray("snap-conflict-1", "snapuid-conflict-1", "claim-conflict-1", "", classSilver, "", &False, nil, nil, nil, false, true, nil),
+		initialClaims:    newClaimArray("claim-conflict-1", "pvcuid-conflict-1", "1Gi", "volume-conflict-1", v1.ClaimBound, &classEmpty),
+		errors: []reactorError{
+			{"update", "persistentvolumeclaims", newConflict("persistentvolumeclaims", "claim-conflict-1")},
+		},
+	}
+	ctrl, reactor := newConflictTestController(t, test)
+
+	err := ctrl.ensurePVCFinalizer(test.initialSnapshots[0])
+	if err != nil {
+		t.Fatalf("expected retry to succeed after one conflict, got: %v", err)
+	}
+
+	claim := reactor.claims["claim-conflict-1"]
+	if claim == nil {
+		t.Fatalf("expected claim to exist in reactor store")
+	}
+	if !slices.Contains(claim.Finalizers, "snapshot.storage.kubernetes.io/pvc-as-source-protection") {
+		t.Fatalf("expected pvc finalizer to be present after retry, got: %v", claim.Finalizers)
+	}
+}
+
+func TestUpdateSnapshotStatusConflictIsRetriedAndSucceeds(t *testing.T) {
+	created := time.Now()
+	createdNano := created.UnixNano()
+	size := int64(1)
+	ready := true
+	test := controllerTest{
+		name:             "update snapshot status retries on conflict",
+		initialSnapshots: newSnapshotArray("snap-conflict-2", "snapuid-conflict-2", "claim-conflict-2", "", classSilver, "", &False, nil, nil, nil, false, true, nil),
+		initialContents:  newContentArrayWithReadyToUse("snapcontent-snapuid-conflict-2", "snapuid-conflict-2", "snap-conflict-2", "sid-conflict-2", classSilver, "", "pv-handle-conflict-2", deletionPolicy, &createdNano, &size, &ready, false),
+		errors: []reactorError{
+			{"update", "volumesnapshots", newConflict("volumesnapshots", "snap-conflict-2")},
+		},
+	}
+	ctrl, _ := newConflictTestController(t, test)
+
+	snapshot, err := ctrl.updateSnapshotStatus(test.initialSnapshots[0], test.initialContents[0])
+	if err != nil {
+		t.Fatalf("expected retry to succeed after one conflict, got: %v", err)
+	}
+	if snapshot.Status == nil || snapshot.Status.BoundVolumeSnapshotContentName == nil || *snapshot.Status.BoundVolumeSnapshotContentName != "snapcontent-snapuid-conflict-2" {
+		t.Fatalf("expected snapshot status to be updated, got: %#v", snapshot.Status)
+	}
+}
+
+func TestAddSnapshotFinalizerConflictIsRetriedAndSucceeds(t *testing.T) {
+	test := controllerTest{
+		name:             "add snapshot finalizer retries on conflict",
+		initialSnapshots: newSnapshotArray("snap-conflict-3", "snapuid-conflict-3", "claim-conflict-3", "", classSilver, "", &False, nil, nil, nil, false, false, nil),
+		errors: []reactorError{
+			{"update", "volumesnapshots", newConflict("volumesnapshots", "snap-conflict-3")},
+		},
+	}
+	ctrl, reactor := newConflictTestController(t, test)
+
+	err := ctrl.addSnapshotFinalizer(test.initialSnapshots[0], true, true)
+	if err != nil {
+		t.Fatalf("expected retry to succeed after one conflict, got: %v", err)
+	}
+	snapshot := reactor.snapshots["snap-conflict-3"]
+	if snapshot == nil {
+		t.Fatalf("expected snapshot to exist in reactor store")
+	}
+	if !slices.Contains(snapshot.Finalizers, "snapshot.storage.kubernetes.io/volumesnapshot-as-source-protection") ||
+		!slices.Contains(snapshot.Finalizers, "snapshot.storage.kubernetes.io/volumesnapshot-bound-protection") {
+		t.Fatalf("expected both snapshot finalizers to be present after retry, got: %v", snapshot.Finalizers)
+	}
+}

--- a/pkg/common-controller/snapshot_controller.go
+++ b/pkg/common-controller/snapshot_controller.go
@@ -992,17 +992,29 @@ func (ctrl *csiSnapshotCommonController) ensurePVCFinalizer(snapshot *crdv1.Volu
 	if pvc.ObjectMeta.DeletionTimestamp != nil {
 		klog.Errorf("cannot add finalizer on claim [%s/%s] for snapshot [%s/%s]: claim is being deleted", pvc.Namespace, pvc.Name, snapshot.Namespace, snapshot.Name)
 		return newControllerUpdateError(pvc.Name, "cannot add finalizer on claim because it is being deleted")
-	} else {
-		// If PVC is not being deleted and PVCFinalizer is not added yet, add the PVCFinalizer.
-		pvcClone := pvc.DeepCopy()
+	}
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		// Get the latest version from API server before attempting update.
+		newPvc, err := ctrl.client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(context.TODO(), pvc.Name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if slices.Contains(newPvc.ObjectMeta.Finalizers, utils.PVCFinalizer) {
+			return nil
+		}
+		if newPvc.ObjectMeta.DeletionTimestamp != nil {
+			return fmt.Errorf("cannot add finalizer on claim because it is being deleted")
+		}
+		pvcClone := newPvc.DeepCopy()
 		pvcClone.ObjectMeta.Finalizers = append(pvcClone.ObjectMeta.Finalizers, utils.PVCFinalizer)
 		_, err = ctrl.client.CoreV1().PersistentVolumeClaims(pvcClone.Namespace).Update(context.TODO(), pvcClone, metav1.UpdateOptions{})
-		if err != nil {
-			klog.Errorf("cannot add finalizer on claim [%s/%s] for snapshot [%s/%s]: [%v]", pvc.Namespace, pvc.Name, snapshot.Namespace, snapshot.Name, err)
-			return newControllerUpdateError(pvcClone.Name, err.Error())
-		}
-		klog.Infof("Added protection finalizer to persistent volume claim %s/%s", pvc.Namespace, pvc.Name)
+		return err
+	})
+	if err != nil {
+		klog.Errorf("cannot add finalizer on claim [%s/%s] for snapshot [%s/%s]: [%v]", pvc.Namespace, pvc.Name, snapshot.Namespace, snapshot.Name, err)
+		return newControllerUpdateError(pvc.Name, err.Error())
 	}
+	klog.Infof("Added protection finalizer to persistent volume claim %s/%s", pvc.Namespace, pvc.Name)
 
 	return nil
 }
@@ -1254,97 +1266,106 @@ func (ctrl *csiSnapshotCommonController) updateSnapshotStatus(snapshot *crdv1.Vo
 
 	klog.V(5).Infof("updateSnapshotStatus: updating VolumeSnapshot [%+v] based on VolumeSnapshotContentStatus [%+v]", snapshot, content.Status)
 
-	snapshotObj, err := ctrl.clientset.SnapshotV1().VolumeSnapshots(snapshot.Namespace).Get(context.TODO(), snapshot.Name, metav1.GetOptions{})
-	if err != nil {
-		return nil, fmt.Errorf("error get snapshot %s from api server: %v", utils.SnapshotKey(snapshot), err)
-	}
+	var resultSnapshot *crdv1.VolumeSnapshot
+	emitCreatedMetricAndEvent := false
+	emitReadyMetricAndEvent := false
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		snapshotObj, err := ctrl.clientset.SnapshotV1().VolumeSnapshots(snapshot.Namespace).Get(context.TODO(), snapshot.Name, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("error get snapshot %s from api server: %v", utils.SnapshotKey(snapshot), err)
+		}
 
-	var newStatus *crdv1.VolumeSnapshotStatus
-	updated := false
-	if snapshotObj.Status == nil {
-		newStatus = &crdv1.VolumeSnapshotStatus{
-			BoundVolumeSnapshotContentName: &boundContentName,
-			ReadyToUse:                     &readyToUse,
-		}
-		if createdAt != nil {
-			newStatus.CreationTime = &metav1.Time{Time: *createdAt}
-		}
-		if size != nil {
-			newStatus.RestoreSize = resource.NewQuantity(*size, resource.BinarySI)
-		}
-		if volumeSnapshotErr != nil {
-			newStatus.Error = volumeSnapshotErr
-		}
-		if groupSnapshotName != "" {
-			newStatus.VolumeGroupSnapshotName = &groupSnapshotName
-		}
-		updated = true
-	} else {
-		newStatus = snapshotObj.Status.DeepCopy()
-		if newStatus.BoundVolumeSnapshotContentName == nil {
-			newStatus.BoundVolumeSnapshotContentName = &boundContentName
+		var newStatus *crdv1.VolumeSnapshotStatus
+		updated := false
+		if snapshotObj.Status == nil {
+			newStatus = &crdv1.VolumeSnapshotStatus{
+				BoundVolumeSnapshotContentName: &boundContentName,
+				ReadyToUse:                     &readyToUse,
+			}
+			if createdAt != nil {
+				newStatus.CreationTime = &metav1.Time{Time: *createdAt}
+			}
+			if size != nil {
+				newStatus.RestoreSize = resource.NewQuantity(*size, resource.BinarySI)
+			}
+			if volumeSnapshotErr != nil {
+				newStatus.Error = volumeSnapshotErr
+			}
+			if groupSnapshotName != "" {
+				newStatus.VolumeGroupSnapshotName = &groupSnapshotName
+			}
 			updated = true
-		}
-		if newStatus.CreationTime == nil && createdAt != nil {
-			newStatus.CreationTime = &metav1.Time{Time: *createdAt}
-			updated = true
-		}
-		if newStatus.ReadyToUse == nil || *newStatus.ReadyToUse != readyToUse {
-			newStatus.ReadyToUse = &readyToUse
-			updated = true
-			if readyToUse && newStatus.Error != nil {
-				newStatus.Error = nil
+		} else {
+			newStatus = snapshotObj.Status.DeepCopy()
+			if newStatus.BoundVolumeSnapshotContentName == nil {
+				newStatus.BoundVolumeSnapshotContentName = &boundContentName
+				updated = true
+			}
+			if newStatus.CreationTime == nil && createdAt != nil {
+				newStatus.CreationTime = &metav1.Time{Time: *createdAt}
+				updated = true
+			}
+			if newStatus.ReadyToUse == nil || *newStatus.ReadyToUse != readyToUse {
+				newStatus.ReadyToUse = &readyToUse
+				updated = true
+				if readyToUse && newStatus.Error != nil {
+					newStatus.Error = nil
+				}
+			}
+			if (newStatus.RestoreSize == nil && size != nil) || (newStatus.RestoreSize != nil && newStatus.RestoreSize.IsZero() && size != nil && *size > 0) {
+				newStatus.RestoreSize = resource.NewQuantity(*size, resource.BinarySI)
+				updated = true
+			}
+			if (newStatus.Error == nil && volumeSnapshotErr != nil) || (newStatus.Error != nil && volumeSnapshotErr != nil && newStatus.Error.Time != nil && volumeSnapshotErr.Time != nil && &newStatus.Error.Time != &volumeSnapshotErr.Time) || (newStatus.Error != nil && volumeSnapshotErr == nil) {
+				newStatus.Error = volumeSnapshotErr
+				updated = true
+			}
+			if newStatus.VolumeGroupSnapshotName == nil && groupSnapshotName != "" {
+				newStatus.VolumeGroupSnapshotName = &groupSnapshotName
+				updated = true
 			}
 		}
-		if (newStatus.RestoreSize == nil && size != nil) || (newStatus.RestoreSize != nil && newStatus.RestoreSize.IsZero() && size != nil && *size > 0) {
-			newStatus.RestoreSize = resource.NewQuantity(*size, resource.BinarySI)
-			updated = true
-		}
-		if (newStatus.Error == nil && volumeSnapshotErr != nil) || (newStatus.Error != nil && volumeSnapshotErr != nil && newStatus.Error.Time != nil && volumeSnapshotErr.Time != nil && &newStatus.Error.Time != &volumeSnapshotErr.Time) || (newStatus.Error != nil && volumeSnapshotErr == nil) {
-			newStatus.Error = volumeSnapshotErr
-			updated = true
-		}
-		if newStatus.VolumeGroupSnapshotName == nil && groupSnapshotName != "" {
-			newStatus.VolumeGroupSnapshotName = &groupSnapshotName
-			updated = true
-		}
-	}
 
-	if updated {
+		if !updated {
+			resultSnapshot = snapshotObj
+			return nil
+		}
+
 		snapshotClone := snapshotObj.DeepCopy()
 		snapshotClone.Status = newStatus
 
-		// We need to record metrics before updating the status due to a bug causing cache entries after a failed UpdateStatus call.
-		// Must meet the following criteria to emit a successful CreateSnapshot status
-		// 1. Previous status was nil OR Previous status had a nil CreationTime
-		// 2. New status must be non-nil with a non-nil CreationTime
-		driverName := content.Spec.Driver
-		createOperationKey := metrics.NewOperationKey(metrics.CreateSnapshotOperationName, snapshot.UID)
-		if !utils.IsSnapshotCreated(snapshotObj) && utils.IsSnapshotCreated(snapshotClone) {
-			ctrl.metricsManager.RecordMetrics(createOperationKey, metrics.NewSnapshotOperationStatus(metrics.SnapshotStatusTypeSuccess), driverName)
-			msg := fmt.Sprintf("Snapshot %s was successfully created by the CSI driver.", utils.SnapshotKey(snapshot))
-			ctrl.eventRecorder.Event(snapshot, v1.EventTypeNormal, "SnapshotCreated", msg)
-		}
-
-		// Must meet the following criteria to emit a successful CreateSnapshotAndReady status
-		// 1. Previous status was nil OR Previous status had a nil ReadyToUse OR Previous status had a false ReadyToUse
-		// 2. New status must be non-nil with a ReadyToUse as true
-		if !utils.IsSnapshotReady(snapshotObj) && utils.IsSnapshotReady(snapshotClone) {
-			createAndReadyOperation := metrics.NewOperationKey(metrics.CreateSnapshotAndReadyOperationName, snapshot.UID)
-			ctrl.metricsManager.RecordMetrics(createAndReadyOperation, metrics.NewSnapshotOperationStatus(metrics.SnapshotStatusTypeSuccess), driverName)
-			msg := fmt.Sprintf("Snapshot %s is ready to use.", utils.SnapshotKey(snapshot))
-			ctrl.eventRecorder.Event(snapshot, v1.EventTypeNormal, "SnapshotReady", msg)
-		}
+		shouldEmitCreated := !utils.IsSnapshotCreated(snapshotObj) && utils.IsSnapshotCreated(snapshotClone)
+		shouldEmitReady := !utils.IsSnapshotReady(snapshotObj) && utils.IsSnapshotReady(snapshotClone)
 
 		newSnapshotObj, err := ctrl.clientset.SnapshotV1().VolumeSnapshots(snapshotClone.Namespace).UpdateStatus(context.TODO(), snapshotClone, metav1.UpdateOptions{})
 		if err != nil {
-			return nil, newControllerUpdateError(utils.SnapshotKey(snapshot), err.Error())
+			return err
 		}
-
-		return newSnapshotObj, nil
+		resultSnapshot = newSnapshotObj
+		emitCreatedMetricAndEvent = shouldEmitCreated
+		emitReadyMetricAndEvent = shouldEmitReady
+		return nil
+	})
+	if err != nil {
+		return nil, newControllerUpdateError(utils.SnapshotKey(snapshot), err.Error())
 	}
 
-	return snapshotObj, nil
+	driverName := content.Spec.Driver
+	// Emit success metrics/events only after UpdateStatus succeeds to avoid duplicate firing across conflict retries.
+	if emitCreatedMetricAndEvent {
+		createOperationKey := metrics.NewOperationKey(metrics.CreateSnapshotOperationName, snapshot.UID)
+		ctrl.metricsManager.RecordMetrics(createOperationKey, metrics.NewSnapshotOperationStatus(metrics.SnapshotStatusTypeSuccess), driverName)
+		msg := fmt.Sprintf("Snapshot %s was successfully created by the CSI driver.", utils.SnapshotKey(snapshot))
+		ctrl.eventRecorder.Event(snapshot, v1.EventTypeNormal, "SnapshotCreated", msg)
+	}
+	if emitReadyMetricAndEvent {
+		createAndReadyOperation := metrics.NewOperationKey(metrics.CreateSnapshotAndReadyOperationName, snapshot.UID)
+		ctrl.metricsManager.RecordMetrics(createAndReadyOperation, metrics.NewSnapshotOperationStatus(metrics.SnapshotStatusTypeSuccess), driverName)
+		msg := fmt.Sprintf("Snapshot %s is ready to use.", utils.SnapshotKey(snapshot))
+		ctrl.eventRecorder.Event(snapshot, v1.EventTypeNormal, "SnapshotReady", msg)
+	}
+
+	return resultSnapshot, nil
 }
 
 func (ctrl *csiSnapshotCommonController) getVolumeFromVolumeSnapshot(snapshot *crdv1.VolumeSnapshot) (*v1.PersistentVolume, error) {
@@ -1569,14 +1590,21 @@ func (ctrl *csiSnapshotCommonController) addSnapshotFinalizer(snapshot *crdv1.Vo
 	// NOTE(ggriffiths): Must perform an update if no finalizers exist.
 	// Unable to find a patch that correctly updated the finalizers if none currently exist.
 	if len(snapshot.ObjectMeta.Finalizers) == 0 {
-		snapshotClone := snapshot.DeepCopy()
-		if addSourceFinalizer {
-			snapshotClone.ObjectMeta.Finalizers = append(snapshotClone.ObjectMeta.Finalizers, utils.VolumeSnapshotAsSourceFinalizer)
-		}
-		if addBoundFinalizer {
-			snapshotClone.ObjectMeta.Finalizers = append(snapshotClone.ObjectMeta.Finalizers, utils.VolumeSnapshotBoundFinalizer)
-		}
-		updatedSnapshot, err = ctrl.clientset.SnapshotV1().VolumeSnapshots(snapshotClone.Namespace).Update(context.TODO(), snapshotClone, metav1.UpdateOptions{})
+		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			latestSnapshot, err := ctrl.clientset.SnapshotV1().VolumeSnapshots(snapshot.Namespace).Get(context.TODO(), snapshot.Name, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			snapshotClone := latestSnapshot.DeepCopy()
+			if addSourceFinalizer && !slices.Contains(snapshotClone.ObjectMeta.Finalizers, utils.VolumeSnapshotAsSourceFinalizer) {
+				snapshotClone.ObjectMeta.Finalizers = append(snapshotClone.ObjectMeta.Finalizers, utils.VolumeSnapshotAsSourceFinalizer)
+			}
+			if addBoundFinalizer && !slices.Contains(snapshotClone.ObjectMeta.Finalizers, utils.VolumeSnapshotBoundFinalizer) {
+				snapshotClone.ObjectMeta.Finalizers = append(snapshotClone.ObjectMeta.Finalizers, utils.VolumeSnapshotBoundFinalizer)
+			}
+			updatedSnapshot, err = ctrl.clientset.SnapshotV1().VolumeSnapshots(snapshotClone.Namespace).Update(context.TODO(), snapshotClone, metav1.UpdateOptions{})
+			return err
+		})
 		if err != nil {
 			return newControllerUpdateError(utils.SnapshotKey(snapshot), err.Error())
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new  line, and remove leading whitespaces from that line:
>
> /kind api-change

 /kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake


**What this PR does / why we need it**:
  This PR improves conflict handling in common-controller update paths that were
  frequently hitting transient `the object has been modified` errors.

  Changes:
  - Add `RetryOnConflict` handling to:
    - `ensurePVCFinalizer`
    - `updateSnapshotStatus`
    - `addSnapshotFinalizer` (update path when finalizers are initially empty)
  - Prevent duplicate success metrics/events in `updateSnapshotStatus` by emitting
  them only after `UpdateStatus` succeeds.
  - Add conflict-focused regression tests:
    - `TestEnsurePVCFinalizerConflictIsRetriedAndSucceeds`
    - `TestUpdateSnapshotStatusConflictIsRetriedAndSucceeds`
    - `TestAddSnapshotFinalizerConflictIsRetriedAndSucceeds`


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related to #748


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
