### PR TITLE
fix(sidecar-controller): retry conflict when clearing content status

### DIFF
--- a/pkg/sidecar-controller/snapshot_controller.go
+++ b/pkg/sidecar-controller/snapshot_controller.go
@@ -27,6 +27,7 @@ import (
 	"google.golang.org/grpc/status"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
 	klog "k8s.io/klog/v2"
 
 	crdv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
@@ -437,18 +438,27 @@ func (ctrl *csiSnapshotSideCarController) deleteCSISnapshotOperation(content *cr
 func (ctrl *csiSnapshotSideCarController) clearVolumeContentStatus(
 	contentName string) (*crdv1.VolumeSnapshotContent, error) {
 	klog.V(5).Infof("cleanVolumeSnapshotStatus content [%s]", contentName)
-	// get the latest version from API server
-	content, err := ctrl.clientset.SnapshotV1().VolumeSnapshotContents().Get(context.TODO(), contentName, metav1.GetOptions{})
-	if err != nil {
-		return nil, fmt.Errorf("error get snapshot content %s from api server: %v", contentName, err)
-	}
-	if content.Status != nil {
-		content.Status.SnapshotHandle = nil
-		content.Status.ReadyToUse = nil
-		content.Status.CreationTime = nil
-		content.Status.RestoreSize = nil
-	}
-	newContent, err := ctrl.clientset.SnapshotV1().VolumeSnapshotContents().UpdateStatus(context.TODO(), content, metav1.UpdateOptions{})
+	var (
+		content    *crdv1.VolumeSnapshotContent
+		newContent *crdv1.VolumeSnapshotContent
+	)
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		// get the latest version from API server
+		var err error
+		content, err = ctrl.clientset.SnapshotV1().VolumeSnapshotContents().Get(context.TODO(), contentName, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("error get snapshot content %s from api server: %v", contentName, err)
+		}
+		content = content.DeepCopy()
+		if content.Status != nil {
+			content.Status.SnapshotHandle = nil
+			content.Status.ReadyToUse = nil
+			content.Status.CreationTime = nil
+			content.Status.RestoreSize = nil
+		}
+		newContent, err = ctrl.clientset.SnapshotV1().VolumeSnapshotContents().UpdateStatus(context.TODO(), content, metav1.UpdateOptions{})
+		return err
+	})
 	if err != nil {
 		return content, newControllerUpdateError(contentName, err.Error())
 	}

--- a/pkg/sidecar-controller/snapshot_delete_test.go
+++ b/pkg/sidecar-controller/snapshot_delete_test.go
@@ -25,7 +25,9 @@ import (
 	crdv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	"github.com/kubernetes-csi/external-snapshotter/v8/pkg/utils"
 	v1 "k8s.io/api/core/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 var (
@@ -73,6 +75,10 @@ var class6Parameters = map[string]string{
 var class7Annotations = map[string]string{
 	utils.AnnDeletionSecretRefName:      "secret-x",
 	utils.AnnDeletionSecretRefNamespace: "default-x",
+}
+
+func newConflict(resource, name string) error {
+	return apierrs.NewConflict(schema.GroupResource{Resource: resource}, name, fmt.Errorf("resource version conflict"))
 }
 
 var snapshotClasses = []*crdv1.VolumeSnapshotClass{
@@ -220,6 +226,20 @@ func TestDeleteSync(t *testing.T) {
 			expectedEvents:      []string{"Warning SnapshotDeleteError"},
 			expectedListCalls:   []listCall{{"sid1-3", map[string]string{}, true, time.Now(), 1, nil, ""}},
 			test:                testSyncContent,
+		},
+		{
+			name:            "1-3b - clear content status update conflict should be retried and succeed",
+			initialContents: newContentArrayWithDeletionTimestamp("content1-3b", "snapuid1-3b", "snap1-3b", "sid1-3b", validSecretClass, "", "snap1-3b-volumehandle", deletePolicy, nil, nil, true, &nonFractionalTime),
+			// After UpdateStatus eventually succeeds, the delete flow proceeds and removes
+			// the bound finalizer for Delete policy content.
+			expectedContents:    newContentArrayWithDeletionTimestamp("content1-3b", "snapuid1-3b", "snap1-3b", "", validSecretClass, "", "snap1-3b-volumehandle", deletePolicy, nil, nil, false, &nonFractionalTime),
+			expectedDeleteCalls: []deleteCall{{"sid1-3b", nil, nil}},
+			expectedEvents:      noevents,
+			errors: []reactorError{
+				{"update", "volumesnapshotcontents", newConflict("volumesnapshotcontents", "content1-3b")},
+			},
+			expectSuccess: true,
+			test:          testSyncContent,
 		},
 		{
 			name:                "1-4 - fail to delete with a snapshot class which has invalid secret parameter, bound finalizer should remain",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new  line, and remove leading whitespaces from that line:
>
> /kind api-change

 /kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake


**What this PR does / why we need it**:
This PR adds `RetryOnConflict` handling to the sidecar delete flow.

Specifically, it ensures that clearing `VolumeSnapshotContent` status
after CSI delete succeeds is retried on transient conflicts.

Changes include:
- `clearVolumeContentStatus` now uses `retry.RetryOnConflict`.
- Re-fetch the latest `VolumeSnapshotContent` on each retry before calling `UpdateStatus`.

Tests:
- Updated delete sync tests in `pkg/sidecar-controller/snapshot_delete_test.go`.
- Added case `1-3b` to verify that a transient `UpdateStatus` conflict is retried and eventually succeeds.
- Conflict injection uses Kubernetes conflict errors (`apierrors.NewConflict`) to align with `RetryOnConflict` behavior.
- Added inline comment clarifying expected finalizer removal after status clear succeeds in the delete-policy flow.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related to https://github.com/kubernetes-csi/external-snapshotter/issues/748

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
