### PR TITLE
Fix data race in metrics test

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -297,18 +297,18 @@ func (opMgr *operationMetricsManager) init() {
 }
 
 func (opMgr *operationMetricsManager) scheduleOpsInFlightMetric(ctx context.Context) {
+	ticker := time.NewTicker(inFlightCheckInterval)
+	defer ticker.Stop()
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		default:
-			for range time.NewTicker(inFlightCheckInterval).C {
-				func() {
-					opMgr.mu.Lock()
-					defer opMgr.mu.Unlock()
-					opMgr.opInFlight.Set(float64(len(opMgr.cache)))
-				}()
-			}
+		case <-ticker.C:
+			func() {
+				opMgr.mu.Lock()
+				defer opMgr.mu.Unlock()
+				opMgr.opInFlight.Set(float64(len(opMgr.cache)))
+			}()
 		}
 	}
 }

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -489,7 +489,9 @@ snapshot_controller_operation_total_seconds_count{driver_name="driver5",operatio
 }
 
 func TestInFlightMetric(t *testing.T) {
+	oldInterval := inFlightCheckInterval
 	inFlightCheckInterval = time.Millisecond * 50
+	defer func() { inFlightCheckInterval = oldInterval }()
 
 	mgr, srv := initMgr()
 	defer shutdown(srv)


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
Fix data race and goroutine leak in metrics operations:
- Fixed a goroutine leak in pkg/metrics/metrics.go: The scheduleOpsInFlightMetric function was trapped in an inner ticker loop, preventing it from ever checking <-ctx.Done() and causing it to run forever in the background. It was refactored to use a proper select statement.
- Fixed a data race in pkg/metrics/metrics_test.go: TestInFlightMetric modifies the global inFlightCheckInterval. By failing to clean up leaked goroutines, older test runs were concurrently reading this variable while new tests modified it. The test now safely restores the original interval via defer.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
This fixes the following test failure.
```
Test failures: test-go expand_less	0s
{  
go test -mod=vendor `go list -mod=vendor ./... | grep -v -e 'vendor' -e '/test/e2e$' ` -race
ok  	github.com/kubernetes-csi/external-snapshotter/v8/cmd/csi-snapshotter	1.292s
?   	github.com/kubernetes-csi/external-snapshotter/v8/cmd/snapshot-controller	[no test files]
?   	github.com/kubernetes-csi/external-snapshotter/v8/cmd/snapshot-conversion-webhook	[no test files]
ok  	github.com/kubernetes-csi/external-snapshotter/v8/pkg/common-controller	2.228s
?   	github.com/kubernetes-csi/external-snapshotter/v8/pkg/features	[no test files]
ok  	github.com/kubernetes-csi/external-snapshotter/v8/pkg/group_snapshotter	1.097s
==================
WARNING: DATA RACE
Write at 0x000001066798 by goroutine 127:
  github.com/kubernetes-csi/external-snapshotter/v8/pkg/metrics.TestInFlightMetric()
      /home/prow/go/src/github.com/kubernetes-csi/external-snapshotter/pkg/metrics/metrics_test.go:492 +0x3d
  testing.tRunner()
      /home/prow/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.8.linux-amd64/src/testing/testing.go:1934 +0x21c
  testing.(*T).Run.gowrap1()
      /home/prow/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.8.linux-amd64/src/testing/testing.go:1997 +0x44

Previous read at 0x000001066798 by goroutine 29:
  github.com/kubernetes-csi/external-snapshotter/v8/pkg/metrics.(*operationMetricsManager).scheduleOpsInFlightMetric()
      /home/prow/go/src/github.com/kubernetes-csi/external-snapshotter/pkg/metrics/metrics.go:305 +0x54
  github.com/kubernetes-csi/external-snapshotter/v8/pkg/metrics.(*operationMetricsManager).init.gowrap1()
      /home/prow/go/src/github.com/kubernetes-csi/external-snapshotter/pkg/metrics/metrics.go:296 +0x4f

Goroutine 127 (running) created at:
  testing.(*T).Run()
      /home/prow/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.8.linux-amd64/src/testing/testing.go:1997 +0x9d2
  testing.runTests.func1()
      /home/prow/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.8.linux-amd64/src/testing/testing.go:2477 +0x85
  testing.tRunner()
      /home/prow/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.8.linux-amd64/src/testing/testing.go:1934 +0x21c
  testing.runTests()
      /home/prow/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.8.linux-amd64/src/testing/testing.go:2475 +0x96c
  testing.(*M).Run()
      /home/prow/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.8.linux-amd64/src/testing/testing.go:2337 +0xed4
  main.main()
      _testmain.go:65 +0x164

Goroutine 29 (running) created at:
  github.com/kubernetes-csi/external-snapshotter/v8/pkg/metrics.(*operationMetricsManager).init()
      /home/prow/go/src/github.com/kubernetes-csi/external-snapshotter/pkg/metrics/metrics.go:296 +0x839
  github.com/kubernetes-csi/external-snapshotter/v8/pkg/metrics.NewMetricsManager()
      /home/prow/go/src/github.com/kubernetes-csi/external-snapshotter/pkg/metrics/metrics.go:185 +0xc4
  github.com/kubernetes-csi/external-snapshotter/v8/pkg/metrics.initMgr()
      /home/prow/go/src/github.com/kubernetes-csi/external-snapshotter/pkg/metrics/metrics_test.go:64 +0x27
  github.com/kubernetes-csi/external-snapshotter/v8/pkg/metrics.TestRecordMetricsForNonExistingOperation()
      /home/prow/go/src/github.com/kubernetes-csi/external-snapshotter/pkg/metrics/metrics_test.go:109 +0x36
  testing.tRunner()
      /home/prow/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.8.linux-amd64/src/testing/testing.go:1934 +0x21c
  testing.(*T).Run.gowrap1()
      /home/prow/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.8.linux-amd64/src/testing/testing.go:1997 +0x44
==================
--- FAIL: TestInFlightMetric (2.03s)
    testing.go:1617: race detected during execution of test
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
