### PR TITLE
fix: preserve wrapped API errors in controllerUpdateError

### DIFF
--- a/pkg/common-controller/groupsnapshot_controller_helper.go
+++ b/pkg/common-controller/groupsnapshot_controller_helper.go
@@ -1066,7 +1066,7 @@ func (ctrl *csiSnapshotCommonController) updateGroupSnapshotStatus(groupSnapshot
 
 		newGroupSnapshotObj, err := ctrl.clientset.GroupsnapshotV1().VolumeGroupSnapshots(groupSnapshotClone.Namespace).UpdateStatus(context.TODO(), groupSnapshotClone, metav1.UpdateOptions{})
 		if err != nil {
-			return nil, newControllerUpdateError(utils.GroupSnapshotKey(groupSnapshot), err.Error())
+			return nil, newControllerUpdateError(utils.GroupSnapshotKey(groupSnapshot), err)
 		}
 
 		return newGroupSnapshotObj, nil
@@ -1198,7 +1198,7 @@ func (ctrl *csiSnapshotCommonController) createGroupSnapshotContent(groupSnapsho
 				"CreateGroupSnapshotContentFailed",
 				strErr,
 			)
-			return nil, newControllerUpdateError(utils.GroupSnapshotKey(groupSnapshot), strErr)
+			return nil, newControllerUpdateError(utils.GroupSnapshotKey(groupSnapshot), errors.New(strErr))
 
 		}
 		volumeHandles = append(volumeHandles, pv.Spec.CSI.VolumeHandle)
@@ -1249,7 +1249,7 @@ func (ctrl *csiSnapshotCommonController) createGroupSnapshotContent(groupSnapsho
 		strerr := fmt.Sprintf("Error creating volume group snapshot content object for group snapshot %s: %v.", utils.GroupSnapshotKey(groupSnapshot), err)
 		klog.Error(strerr)
 		ctrl.eventRecorder.Event(groupSnapshot, v1.EventTypeWarning, "CreateGroupSnapshotContentFailed", strerr)
-		return nil, newControllerUpdateError(utils.GroupSnapshotKey(groupSnapshot), err.Error())
+		return nil, newControllerUpdateError(utils.GroupSnapshotKey(groupSnapshot), err)
 	}
 
 	msg := fmt.Sprintf("Waiting for a group snapshot %s to be created by the CSI driver.", utils.GroupSnapshotKey(groupSnapshot))
@@ -1430,7 +1430,7 @@ func (ctrl *csiSnapshotCommonController) addGroupSnapshotContentFinalizer(groupS
 	}
 	newGroupSnapshotContent, err := utils.PatchVolumeGroupSnapshotContent(groupSnapshotContent, patches, ctrl.clientset)
 	if err != nil {
-		return newControllerUpdateError(groupSnapshotContent.Name, err.Error())
+		return newControllerUpdateError(groupSnapshotContent.Name, err)
 	}
 
 	_, err = ctrl.storeGroupSnapshotContentUpdate(newGroupSnapshotContent)
@@ -1485,7 +1485,7 @@ func (ctrl *csiSnapshotCommonController) addGroupSnapshotFinalizer(groupSnapshot
 		}
 		updatedGroupSnapshot, err = ctrl.clientset.GroupsnapshotV1().VolumeGroupSnapshots(groupSnapshotClone.Namespace).Update(context.TODO(), groupSnapshotClone, metav1.UpdateOptions{})
 		if err != nil {
-			return newControllerUpdateError(utils.GroupSnapshotKey(groupSnapshot), err.Error())
+			return newControllerUpdateError(utils.GroupSnapshotKey(groupSnapshot), err)
 		}
 	} else {
 		// Otherwise, perform a patch
@@ -1501,7 +1501,7 @@ func (ctrl *csiSnapshotCommonController) addGroupSnapshotFinalizer(groupSnapshot
 
 		updatedGroupSnapshot, err = utils.PatchVolumeGroupSnapshot(groupSnapshot, patches, ctrl.clientset)
 		if err != nil {
-			return newControllerUpdateError(utils.GroupSnapshotKey(groupSnapshot), err.Error())
+			return newControllerUpdateError(utils.GroupSnapshotKey(groupSnapshot), err)
 		}
 	}
 
@@ -1693,7 +1693,7 @@ func (ctrl *csiSnapshotCommonController) setAnnVolumeGroupSnapshotBeingDeleted(g
 
 		patchedGroupSnapshotContent, err := utils.PatchVolumeGroupSnapshotContent(groupSnapshotContent, patches, ctrl.clientset)
 		if err != nil {
-			return groupSnapshotContent, newControllerUpdateError(groupSnapshotContent.Name, err.Error())
+			return groupSnapshotContent, newControllerUpdateError(groupSnapshotContent.Name, err)
 		}
 
 		// update group snapshot content if update is successful
@@ -1747,7 +1747,7 @@ func (ctrl *csiSnapshotCommonController) removeGroupSnapshotFinalizer(groupSnaps
 	groupSnapshotClone.ObjectMeta.Finalizers = utils.RemoveString(groupSnapshotClone.ObjectMeta.Finalizers, utils.VolumeGroupSnapshotBoundFinalizer)
 	newGroupSnapshot, err := ctrl.clientset.GroupsnapshotV1().VolumeGroupSnapshots(groupSnapshotClone.Namespace).Update(context.TODO(), groupSnapshotClone, metav1.UpdateOptions{})
 	if err != nil {
-		return newControllerUpdateError(groupSnapshot.Name, err.Error())
+		return newControllerUpdateError(groupSnapshot.Name, err)
 	}
 
 	_, err = ctrl.storeGroupSnapshotUpdate(newGroupSnapshot)

--- a/pkg/common-controller/snapshot_controller.go
+++ b/pkg/common-controller/snapshot_controller.go
@@ -806,7 +806,7 @@ func (ctrl *csiSnapshotCommonController) createSnapshotContent(snapshot *crdv1.V
 		strerr := fmt.Sprintf("Error creating volume snapshot content object for snapshot %s: %v.", utils.SnapshotKey(snapshot), err)
 		klog.Error(strerr)
 		ctrl.eventRecorder.Event(snapshot, v1.EventTypeWarning, "CreateSnapshotContentFailed", strerr)
-		return nil, newControllerUpdateError(utils.SnapshotKey(snapshot), err.Error())
+		return nil, newControllerUpdateError(utils.SnapshotKey(snapshot), err)
 	}
 
 	msg := fmt.Sprintf("Waiting for a snapshot %s to be created by the CSI driver.", utils.SnapshotKey(snapshot))
@@ -935,7 +935,7 @@ func (ctrl *csiSnapshotCommonController) addContentFinalizer(content *crdv1.Volu
 	}
 	newContent, err := utils.PatchVolumeSnapshotContent(content, patches, ctrl.clientset)
 	if err != nil {
-		return newControllerUpdateError(content.Name, err.Error())
+		return newControllerUpdateError(content.Name, err)
 	}
 
 	_, err = ctrl.storeContentUpdate(newContent)
@@ -981,7 +981,7 @@ func (ctrl *csiSnapshotCommonController) ensurePVCFinalizer(snapshot *crdv1.Volu
 	pvc, err := ctrl.getClaimFromVolumeSnapshot(snapshot)
 	if err != nil {
 		klog.Infof("cannot get claim from snapshot [%s]: [%v] Claim may be deleted already.", snapshot.Name, err)
-		return newControllerUpdateError(snapshot.Name, "cannot get claim from snapshot")
+		return newControllerUpdateError(snapshot.Name, fmt.Errorf("cannot get claim from snapshot"))
 	}
 
 	if slices.Contains(pvc.ObjectMeta.Finalizers, utils.PVCFinalizer) {
@@ -991,7 +991,7 @@ func (ctrl *csiSnapshotCommonController) ensurePVCFinalizer(snapshot *crdv1.Volu
 
 	if pvc.ObjectMeta.DeletionTimestamp != nil {
 		klog.Errorf("cannot add finalizer on claim [%s/%s] for snapshot [%s/%s]: claim is being deleted", pvc.Namespace, pvc.Name, snapshot.Namespace, snapshot.Name)
-		return newControllerUpdateError(pvc.Name, "cannot add finalizer on claim because it is being deleted")
+		return newControllerUpdateError(pvc.Name, fmt.Errorf("cannot add finalizer on claim because it is being deleted"))
 	} else {
 		// If PVC is not being deleted and PVCFinalizer is not added yet, add the PVCFinalizer.
 		pvcClone := pvc.DeepCopy()
@@ -999,7 +999,7 @@ func (ctrl *csiSnapshotCommonController) ensurePVCFinalizer(snapshot *crdv1.Volu
 		_, err = ctrl.client.CoreV1().PersistentVolumeClaims(pvcClone.Namespace).Update(context.TODO(), pvcClone, metav1.UpdateOptions{})
 		if err != nil {
 			klog.Errorf("cannot add finalizer on claim [%s/%s] for snapshot [%s/%s]: [%v]", pvc.Namespace, pvc.Name, snapshot.Namespace, snapshot.Name, err)
-			return newControllerUpdateError(pvcClone.Name, err.Error())
+			return newControllerUpdateError(pvcClone.Name, err)
 		}
 		klog.Infof("Added protection finalizer to persistent volume claim %s/%s", pvc.Namespace, pvc.Name)
 	}
@@ -1026,7 +1026,7 @@ func (ctrl *csiSnapshotCommonController) removePVCFinalizer(pvc *v1.PersistentVo
 		return nil
 	})
 	if err != nil {
-		return newControllerUpdateError(pvc.Name, err.Error())
+		return newControllerUpdateError(pvc.Name, err)
 	}
 	return nil
 }
@@ -1338,7 +1338,7 @@ func (ctrl *csiSnapshotCommonController) updateSnapshotStatus(snapshot *crdv1.Vo
 
 		newSnapshotObj, err := ctrl.clientset.SnapshotV1().VolumeSnapshots(snapshotClone.Namespace).UpdateStatus(context.TODO(), snapshotClone, metav1.UpdateOptions{})
 		if err != nil {
-			return nil, newControllerUpdateError(utils.SnapshotKey(snapshot), err.Error())
+			return nil, newControllerUpdateError(utils.SnapshotKey(snapshot), err)
 		}
 
 		return newSnapshotObj, nil
@@ -1549,16 +1549,22 @@ var _ error = controllerUpdateError{}
 
 type controllerUpdateError struct {
 	message string
+	err     error
 }
 
-func newControllerUpdateError(name, message string) error {
+func newControllerUpdateError(name string, err error) error {
 	return controllerUpdateError{
-		message: fmt.Sprintf("%s %s on API server: %s", controllerUpdateFailMsg, name, message),
+		message: fmt.Sprintf("%s %s on API server: %s", controllerUpdateFailMsg, name, err.Error()),
+		err:     err,
 	}
 }
 
 func (e controllerUpdateError) Error() string {
 	return e.message
+}
+
+func (e controllerUpdateError) Unwrap() error {
+	return e.err
 }
 
 // addSnapshotFinalizer adds a Finalizer for VolumeSnapshot.
@@ -1578,7 +1584,7 @@ func (ctrl *csiSnapshotCommonController) addSnapshotFinalizer(snapshot *crdv1.Vo
 		}
 		updatedSnapshot, err = ctrl.clientset.SnapshotV1().VolumeSnapshots(snapshotClone.Namespace).Update(context.TODO(), snapshotClone, metav1.UpdateOptions{})
 		if err != nil {
-			return newControllerUpdateError(utils.SnapshotKey(snapshot), err.Error())
+			return newControllerUpdateError(utils.SnapshotKey(snapshot), err)
 		}
 	} else {
 		// Otherwise, perform a patch
@@ -1602,7 +1608,7 @@ func (ctrl *csiSnapshotCommonController) addSnapshotFinalizer(snapshot *crdv1.Vo
 
 		updatedSnapshot, err = utils.PatchVolumeSnapshot(snapshot, patches, ctrl.clientset)
 		if err != nil {
-			return newControllerUpdateError(utils.SnapshotKey(snapshot), err.Error())
+			return newControllerUpdateError(utils.SnapshotKey(snapshot), err)
 		}
 	}
 
@@ -1635,7 +1641,7 @@ func (ctrl *csiSnapshotCommonController) removeSnapshotFinalizer(snapshot *crdv1
 		klog.Errorf("removeSnapshotFinalizer: error check and remove PVC finalizer for snapshot [%s]: %v", snapshot.Name, err)
 		// Log an event and keep the original error from checkandRemovePVCFinalizer
 		ctrl.eventRecorder.Event(snapshot, v1.EventTypeWarning, "ErrorPVCFinalizer", "Error check and remove PVC Finalizer for VolumeSnapshot")
-		return newControllerUpdateError(snapshot.Name, err.Error())
+		return newControllerUpdateError(snapshot.Name, err)
 	}
 
 	snapshotClone := snapshot.DeepCopy()
@@ -1650,7 +1656,7 @@ func (ctrl *csiSnapshotCommonController) removeSnapshotFinalizer(snapshot *crdv1
 	}
 	newSnapshot, err := ctrl.clientset.SnapshotV1().VolumeSnapshots(snapshotClone.Namespace).Update(context.TODO(), snapshotClone, metav1.UpdateOptions{})
 	if err != nil {
-		return newControllerUpdateError(snapshot.Name, err.Error())
+		return newControllerUpdateError(snapshot.Name, err)
 	}
 
 	_, err = ctrl.storeSnapshotUpdate(newSnapshot)
@@ -1704,7 +1710,7 @@ func (ctrl *csiSnapshotCommonController) setAnnVolumeSnapshotBeingDeleted(conten
 
 		patchedContent, err := utils.PatchVolumeSnapshotContent(content, patches, ctrl.clientset)
 		if err != nil {
-			return content, newControllerUpdateError(content.Name, err.Error())
+			return content, newControllerUpdateError(content.Name, err)
 		}
 
 		// update content if update is successful

--- a/pkg/common-controller/snapshot_controller_test.go
+++ b/pkg/common-controller/snapshot_controller_test.go
@@ -17,13 +17,16 @@ limitations under the License.
 package common_controller
 
 import (
+	"errors"
 	"testing"
 
 	crdv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	"github.com/kubernetes-csi/external-snapshotter/v8/pkg/utils"
 	v1 "k8s.io/api/core/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/cache"
 )
 
@@ -174,5 +177,40 @@ func TestGetManagedByNode(t *testing.T) {
 	nodeName, _ = ctrl.getManagedByNode(pv)
 	if nodeName != "" {
 		t.Errorf("Expected no node, Found node(%s)", nodeName)
+	}
+}
+
+func TestControllerUpdateErrorUnwrapsConflict(t *testing.T) {
+	conflictErr := apierrs.NewConflict(
+		schema.GroupResource{Group: "snapshot.storage.k8s.io", Resource: "volumesnapshots"},
+		"test-snapshot",
+		errors.New("the object has been modified; please apply your changes to the latest version"),
+	)
+
+	wrappedErr := newControllerUpdateError("test-snapshot", conflictErr)
+
+	if !apierrs.IsConflict(wrappedErr) {
+		t.Errorf("apierrs.IsConflict() returned false for controllerUpdateError wrapping a conflict error; error chain is broken")
+	}
+
+	var statusErr *apierrs.StatusError
+	if !errors.As(wrappedErr, &statusErr) {
+		t.Errorf("errors.As() could not find *StatusError in controllerUpdateError chain")
+	}
+}
+
+func TestControllerUpdateErrorPreservesNonConflict(t *testing.T) {
+	notFoundErr := apierrs.NewNotFound(
+		schema.GroupResource{Group: "snapshot.storage.k8s.io", Resource: "volumesnapshots"},
+		"test-snapshot",
+	)
+
+	wrappedErr := newControllerUpdateError("test-snapshot", notFoundErr)
+
+	if apierrs.IsConflict(wrappedErr) {
+		t.Errorf("apierrs.IsConflict() returned true for a NotFound error wrapped in controllerUpdateError")
+	}
+	if !apierrs.IsNotFound(wrappedErr) {
+		t.Errorf("apierrs.IsNotFound() returned false for controllerUpdateError wrapping a NotFound error; error chain is broken")
 	}
 }

--- a/pkg/sidecar-controller/groupsnapshot_helper.go
+++ b/pkg/sidecar-controller/groupsnapshot_helper.go
@@ -226,7 +226,7 @@ func (ctrl csiSnapshotSideCarController) removeGroupSnapshotContentFinalizer(gro
 
 	updatedGroupSnapshotContent, err := utils.PatchVolumeGroupSnapshotContent(groupSnapshotContentClone, patches, ctrl.clientset)
 	if err != nil {
-		return newControllerUpdateError(groupSnapshotContent.Name, err.Error())
+		return newControllerUpdateError(groupSnapshotContent.Name, err)
 	}
 
 	klog.V(5).Infof("Removed protection finalizer from volume group snapshot content %s", updatedGroupSnapshotContent.Name)
@@ -302,7 +302,7 @@ func (ctrl *csiSnapshotSideCarController) clearGroupSnapshotContentStatus(
 	}
 	newContent, err := ctrl.clientset.GroupsnapshotV1().VolumeGroupSnapshotContents().UpdateStatus(context.TODO(), groupSnapshotContent, metav1.UpdateOptions{})
 	if err != nil {
-		return groupSnapshotContent, newControllerUpdateError(groupSnapshotContentName, err.Error())
+		return groupSnapshotContent, newControllerUpdateError(groupSnapshotContentName, err)
 	}
 	return newContent, nil
 }
@@ -534,7 +534,7 @@ func (ctrl *csiSnapshotSideCarController) setAnnVolumeGroupSnapshotBeingCreated(
 
 	patchedGroupSnapshotContent, err := utils.PatchVolumeGroupSnapshotContent(groupSnapshotContent, patches, ctrl.clientset)
 	if err != nil {
-		return groupSnapshotContent, newControllerUpdateError(groupSnapshotContent.Name, err.Error())
+		return groupSnapshotContent, newControllerUpdateError(groupSnapshotContent.Name, err)
 	}
 	// update groupSnapshotContent if update is successful
 	groupSnapshotContent = patchedGroupSnapshotContent
@@ -566,7 +566,7 @@ func (ctrl csiSnapshotSideCarController) removeAnnVolumeGroupSnapshotBeingCreate
 
 	updatedGroupSnapshotContent, err := utils.PatchVolumeGroupSnapshotContent(groupSnapshotContentClone, patches, ctrl.clientset)
 	if err != nil {
-		return groupSnapshotContent, newControllerUpdateError(groupSnapshotContent.Name, err.Error())
+		return groupSnapshotContent, newControllerUpdateError(groupSnapshotContent.Name, err)
 	}
 
 	klog.V(5).Infof("Removed VolumeGroupSnapshotBeingCreated annotation from volume group snapshot content %s", groupSnapshotContent.Name)
@@ -646,7 +646,7 @@ func (ctrl *csiSnapshotSideCarController) updateGroupSnapshotContentStatus(
 		groupSnapshotContentClone.Status = newStatus
 		newContent, err := ctrl.clientset.GroupsnapshotV1().VolumeGroupSnapshotContents().UpdateStatus(context.TODO(), groupSnapshotContentClone, metav1.UpdateOptions{})
 		if err != nil {
-			return groupSnapshotContentObj, newControllerUpdateError(groupSnapshotContent.Name, err.Error())
+			return groupSnapshotContentObj, newControllerUpdateError(groupSnapshotContent.Name, err)
 		}
 		return newContent, nil
 	}

--- a/pkg/sidecar-controller/snapshot_controller.go
+++ b/pkg/sidecar-controller/snapshot_controller.go
@@ -450,7 +450,7 @@ func (ctrl *csiSnapshotSideCarController) clearVolumeContentStatus(
 	}
 	newContent, err := ctrl.clientset.SnapshotV1().VolumeSnapshotContents().UpdateStatus(context.TODO(), content, metav1.UpdateOptions{})
 	if err != nil {
-		return content, newControllerUpdateError(contentName, err.Error())
+		return content, newControllerUpdateError(contentName, err)
 	}
 	return newContent, nil
 }
@@ -524,7 +524,7 @@ func (ctrl *csiSnapshotSideCarController) updateSnapshotContentStatus(
 
 		newContent, err := utils.PatchVolumeSnapshotContent(contentClone, patches, ctrl.clientset, "status")
 		if err != nil {
-			return contentObj, newControllerUpdateError(content.Name, err.Error())
+			return contentObj, newControllerUpdateError(content.Name, err)
 		}
 		return newContent, nil
 	}
@@ -549,16 +549,22 @@ var _ error = controllerUpdateError{}
 
 type controllerUpdateError struct {
 	message string
+	err     error
 }
 
-func newControllerUpdateError(name, message string) error {
+func newControllerUpdateError(name string, err error) error {
 	return controllerUpdateError{
-		message: fmt.Sprintf("%s %s on API server: %s", controllerUpdateFailMsg, name, message),
+		message: fmt.Sprintf("%s %s on API server: %s", controllerUpdateFailMsg, name, err.Error()),
+		err:     err,
 	}
 }
 
 func (e controllerUpdateError) Error() string {
 	return e.message
+}
+
+func (e controllerUpdateError) Unwrap() error {
+	return e.err
 }
 
 func (ctrl *csiSnapshotSideCarController) GetCredentialsFromAnnotation(content *crdv1.VolumeSnapshotContent) (map[string]string, error) {
@@ -609,7 +615,7 @@ func (ctrl csiSnapshotSideCarController) removeContentFinalizer(content *crdv1.V
 
 	updatedContent, err := utils.PatchVolumeSnapshotContent(contentClone, patches, ctrl.clientset)
 	if err != nil {
-		return newControllerUpdateError(content.Name, err.Error())
+		return newControllerUpdateError(content.Name, err)
 	}
 
 	klog.V(5).Infof("Removed protection finalizer from volume snapshot content %s", updatedContent.Name)
@@ -678,7 +684,7 @@ func (ctrl *csiSnapshotSideCarController) setAnnVolumeSnapshotBeingCreated(conte
 
 	patchedContent, err := utils.PatchVolumeSnapshotContent(content, patches, ctrl.clientset)
 	if err != nil {
-		return content, newControllerUpdateError(content.Name, err.Error())
+		return content, newControllerUpdateError(content.Name, err)
 	}
 	// update content if update is successful
 	content = patchedContent
@@ -710,7 +716,7 @@ func (ctrl csiSnapshotSideCarController) removeAnnVolumeSnapshotBeingCreated(con
 
 	updatedContent, err := utils.PatchVolumeSnapshotContent(contentClone, patches, ctrl.clientset)
 	if err != nil {
-		return content, newControllerUpdateError(content.Name, err.Error())
+		return content, newControllerUpdateError(content.Name, err)
 	}
 
 	klog.V(5).Infof("Removed VolumeSnapshotBeingCreated annotation from volume snapshot content %s", content.Name)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

 /kind bug

**What this PR does / why we need it**:

`newControllerUpdateError` previously took a string and was filled with `err.Error()` at call sites, so the underlying client error (for example, an apiserver 409 Conflict as a `StatusError`) was not part of the returned error’s unwrap chain. Workers in `snapshot_controller_base` use `errors.IsConflict` on sync errors to log routine conflicts at a lower level; after stringifying, that check could not see the real API error.
This PR stores the original `error` on `controllerUpdateError`, implements `Unwrap`, and updates all `newControllerUpdateError` call sites in the common and sidecar controllers to pass the `error` value. Unit tests assert that `apierrs.IsConflict` / `IsNotFound` and `errors.As` work through the wrapper.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

**Special notes for your reviewer**:
1) Behavior change is mainly correct error typing and log severity for API conflicts on update/patch paths; retries were already happening on error.
2) Sidecar defines a duplicate `newControllerUpdateError` with the same pattern; only common-controller has new tests (same mechanism under test).

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
