### PR TITLE
Change codes.ResourceExhausted from non-final to final error

### DIFF
--- a/pkg/sidecar-controller/snapshot_controller.go
+++ b/pkg/sidecar-controller/snapshot_controller.go
@@ -735,12 +735,19 @@ func isCSIFinalError(err error) bool {
 	}
 	switch st.Code() {
 	case codes.Canceled, // gRPC: Client Application cancelled the request
-		codes.DeadlineExceeded,  // gRPC: Timeout
-		codes.Unavailable,       // gRPC: Server shutting down, TCP connection broken - previous CreateSnapshot() may be still in progress.
-		codes.ResourceExhausted, // gRPC: Server temporarily out of resources - previous CreateSnapshot() may be still in progress.
-		codes.Aborted:           // CSI: Operation pending for Snapshot
+		codes.DeadlineExceeded, // gRPC: Timeout
+		codes.Unavailable,      // gRPC: Server shutting down, TCP connection broken - previous CreateSnapshot() may be still in progress.
+		codes.Aborted:          // CSI: Operation pending for Snapshot
 		return false
 	}
+	// Note: codes.ResourceExhausted is treated as a final error.
+	// gRPC: Server out of resources.
+	// However, it also could be from the transport layer for "message size exceeded".
+	// Cannot be decided properly here and needs to be resolved in the spec
+	// https://github.com/container-storage-interface/spec/issues/419.
+	// What we assume here for now is that message size limits are large enough that
+	// the error really comes from the CSI driver.
+
 	// All other errors mean that creating snapshot either did not
 	// even start or failed. It is for sure not in progress.
 	return true


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

`external-snapshotter` currently treats `codes.ResourceExhausted` from the CSI driver as a non-final error and keeps retrying. For capacity failures (no pool has enough free space to host the snapshot or clone), the condition is permanent until an operator does something about it, so retrying forever is wasted work on the control-plane and the user never gets a terminal signal on the VolumeSnapshot object.

`external-provisioner` already made the same change in [kubernetes-csi/external-provisioner#675](https://github.com/kubernetes-csi/external-provisioner/pull/675). This PR brings `external-snapshotter` in line with that behavior.

The transport-layer "message size exceeded" interpretation of `ResourceExhausted` is unlikely in practice for snapshot operations. The comment block added in the code calls that out and links the spec discussion ([container-storage-interface/spec#419](https://github.com/container-storage-interface/spec/issues/419)) for posterity.

**Which issue(s) this PR fixes**:

Fixes #1434

**Special notes for your reviewer**:

This carries over the change from [#1334](https://github.com/kubernetes-csi/external-snapshotter/pull/1334) (authored by @xing-yang), which was approved but stayed in WIP and got auto-closed by the triage bot after ~150 days of inactivity. The diff here is identical to xing-yang's.

We've been hitting this in production on OpenEBS Mayastor: snapshot create or restore returns `ResourceExhausted` when a pool is full, and the snapshotter retries forever. We're shipping a `FailedPrecondition` workaround on the driver side ([openebs/mayastor-control-plane#1114](https://github.com/openebs/mayastor-control-plane/pull/1114)) while this lands, and would like to revert that once the side-car is fixed.

**Does this PR introduce a user-facing change?**:

```release-note
Change codes.ResourceExhausted from non-final to final error in the snapshot create path. The side-car no longer retries indefinitely on capacity failures from the CSI driver; the error is surfaced to the VolumeSnapshot status instead. Matches existing external-provisioner behavior.
```