### PR TITLE
deploy: update sidecar image versions

### DIFF
--- a/deploy/kubernetes/csi-snapshotter/setup-csi-snapshotter.yaml
+++ b/deploy/kubernetes/csi-snapshotter/setup-csi-snapshotter.yaml
@@ -72,7 +72,7 @@ spec:
       serviceAccountName: csi-snapshotter
       containers:
         - name: csi-provisioner
-          image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
+          image: registry.k8s.io/sig-storage/csi-provisioner:v6.3.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -84,7 +84,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-snapshotter
-          image: registry.k8s.io/sig-storage/csi-snapshotter:v8.5.0
+          image: registry.k8s.io/sig-storage/csi-snapshotter:v8.6.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"

--- a/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml
+++ b/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml
@@ -34,7 +34,7 @@ spec:
       serviceAccountName: snapshot-controller
       containers:
         - name: snapshot-controller
-          image: registry.k8s.io/sig-storage/snapshot-controller:v8.5.0
+          image: registry.k8s.io/sig-storage/snapshot-controller:v8.6.0
           args:
             - "--v=5"
             - "--leader-election=true"


### PR DESCRIPTION
Update cross-referenced sidecar container images in `deploy/kubernetes/` to their latest stable releases.

## Changes

**`deploy/kubernetes/csi-snapshotter/setup-csi-snapshotter.yaml`:**
- `csi-provisioner`: v6.2.0 → v6.3.0
- `csi-snapshotter`: v8.5.0 → v8.6.0

**`deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml`:**
- `snapshot-controller`: v8.5.0 → v8.6.0

`hostpathplugin` (v1.17.1) is already at its latest stable release and is unchanged.