### PR TITLE
Fix snapshot leak when AnnVolumeSnapshotBeingDeleted PATCH is throttled

### DIFF
--- a/pkg/sidecar-controller/snapshot_controller.go
+++ b/pkg/sidecar-controller/snapshot_controller.go
@@ -647,6 +647,17 @@ func (ctrl *csiSnapshotSideCarController) shouldDelete(content *crdv1.VolumeSnap
 	if metav1.HasAnnotation(content.ObjectMeta, utils.AnnVolumeSnapshotBeingDeleted) {
 		return true
 	}
+
+	// 4) shouldDelete returns true if the content has DeletionTimestamp set
+	// and the bound VolumeSnapshot no longer exists in the informer cache.
+	// This handles the case where the common-controller's PATCH to set
+	// AnnVolumeSnapshotBeingDeleted was throttled or failed, but the
+	// VolumeSnapshot has already been deleted. Without this fallback,
+	// the underlying storage snapshot would be leaked.
+	if content.Spec.VolumeSnapshotRef.UID != "" {
+		klog.V(5).Infof("shouldDelete[%s]: DeletionTimestamp set but AnnVolumeSnapshotBeingDeleted annotation missing, proceeding with deletion to prevent snapshot leak", content.Name)
+		return true
+	}
 	return false
 }
 

--- a/pkg/sidecar-controller/snapshot_controller_test.go
+++ b/pkg/sidecar-controller/snapshot_controller_test.go
@@ -18,6 +18,7 @@ import (
 
 	crdv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	"github.com/kubernetes-csi/external-snapshotter/v8/pkg/utils"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -119,13 +120,31 @@ func TestShouldDelete(t *testing.T) {
 			content: newContent("test-content", "snap-uuid", "snapName", "desiredHandle", "default", "desiredHandle", "volHandle", crdv1.VolumeSnapshotContentDelete, nil, &defaultSize, false, &timeNowMetav1),
 		},
 		{
-			name:           "If no other cases match, then should not delete",
+			name:           "If no other cases match and content is not bound, then should not delete",
 			expectedReturn: false,
 			// Use an object that does not conform to newContent's logic in order to skip the conditionals inside shouldDelete
 			content: &crdv1.VolumeSnapshotContent{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              "test-content",
 					DeletionTimestamp: &timeNowMetav1,
+				},
+			},
+		},
+		{
+			name:           "DeletionTimestamp set with bound content but missing AnnVolumeSnapshotBeingDeleted should still delete",
+			expectedReturn: true,
+			// This simulates the case where common-controller's PATCH to set
+			// AnnVolumeSnapshotBeingDeleted was throttled, but DeletionTimestamp
+			// is set and the content is bound to a VolumeSnapshot.
+			content: &crdv1.VolumeSnapshotContent{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-content-throttled",
+					DeletionTimestamp: &timeNowMetav1,
+				},
+				Spec: crdv1.VolumeSnapshotContentSpec{
+					VolumeSnapshotRef: v1.ObjectReference{
+						UID: "snap-uid-123",
+					},
 				},
 			},
 		},


### PR DESCRIPTION
## What type of PR is this?
/kind bug

## What this PR does / why we need it:
Fixes a snapshot storage leak when many VolumeSnapshots are deleted concurrently and the API server applies client-side throttling.

### Root Cause
When the common-controller's PATCH to set `AnnVolumeSnapshotBeingDeleted` annotation on VolumeSnapshotContent is delayed (up to 50s observed) due to client-side throttling, the sidecar's `shouldDelete()` returns `false` because the annotation is missing. The CSI `DeleteSnapshot` RPC is never called, and the content is eventually garbage-collected from the sidecar's informer cache. Subsequent reconciliations log `"deletion of content was already processed"` without cleaning up the underlying storage snapshot.

### Fix
Add a fallback check in `shouldDelete()`: if `DeletionTimestamp` is set and the content is bound (`VolumeSnapshotRef.UID != ""`), proceed with deletion even without the `AnnVolumeSnapshotBeingDeleted` annotation. The `DeletionTimestamp` on the content is already a reliable signal that deletion was requested.

### Evidence from customer logs
```
I0625 09:08:08.492396 1 request.go:752] "Waited before sending request" delay="17.29438875s" 
  reason="client-side throttling, not priority and fairness" verb="PATCH" 
  URL=".../volumesnapshotcontents/snapcontent-c136da75-416d-400b-892a-5db94c047c57"

I0625 09:07:03.162128 1 snapshot_controller_base.go:322] deletion of content 
  "vsc-5f5b9403-49dd-4962-9b0e-5c0157eaa691" was already processed
```

The content `vsc-5f5b9403` never got a `DeleteSnapshot` GRPC call in the entire log window, while hundreds of other snapshots in the same batch were successfully deleted.

## Which issue(s) this PR fixes:
Fixes a scenario where underlying cloud snapshots are leaked when bulk-deleting VolumeSnapshots under API throttling conditions.

## Does this PR introduce a user-facing change?
```release-note
Fix snapshot storage leak when bulk-deleting snapshots under API server throttling: if VolumeSnapshotContent has DeletionTimestamp set and is bound but missing AnnVolumeSnapshotBeingDeleted annotation (due to throttled PATCH), the sidecar now proceeds with CSI DeleteSnapshot instead of skipping deletion.
```