### PR TITLE
Requeue VolumeGroupSnapshotContent with backoff when not ready to use

### DIFF
--- a/pkg/sidecar-controller/groupsnapshot_controller_test.go
+++ b/pkg/sidecar-controller/groupsnapshot_controller_test.go
@@ -20,7 +20,9 @@ import (
 	"context"
 	"slices"
 	"testing"
+	"time"
 
+	"github.com/container-storage-interface/spec/lib/go/csi"
 	groupsnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumegroupsnapshot/v1"
 	crdv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	"github.com/kubernetes-csi/external-snapshotter/client/v8/clientset/versioned/fake"
@@ -31,6 +33,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	kubefake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
@@ -1026,10 +1029,11 @@ func TestRemoveAnnVolumeGroupSnapshotBeingCreated(t *testing.T) {
 func TestSyncGroupSnapshotContent(t *testing.T) {
 	classLister := groupsnapshotlisters.NewVolumeGroupSnapshotClassLister(cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{}))
 	tests := []struct {
-		name        string
-		content     *groupsnapshotv1.VolumeGroupSnapshotContent
-		ctrl        *csiSnapshotSideCarController
-		expectError bool
+		name          string
+		content       *groupsnapshotv1.VolumeGroupSnapshotContent
+		ctrl          *csiSnapshotSideCarController
+		expectError   bool
+		expectRequeue bool
 	}{
 		{
 			name: "shouldDelete with Retain policy removes finalizer",
@@ -1094,9 +1098,12 @@ func TestSyncGroupSnapshotContent(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.ctrl.syncGroupSnapshotContent(tt.content)
+			requeue, err := tt.ctrl.syncGroupSnapshotContent(tt.content)
 			if (err != nil) != tt.expectError {
 				t.Errorf("syncGroupSnapshotContent() error = %v, wantErr %v", err, tt.expectError)
+			}
+			if requeue != tt.expectRequeue {
+				t.Errorf("syncGroupSnapshotContent() requeue = %v, want %v", requeue, tt.expectRequeue)
 			}
 		})
 	}
@@ -1124,9 +1131,12 @@ func TestUpdateGroupSnapshotContentInInformerCache(t *testing.T) {
 		groupSnapshotClassLister:  groupsnapshotlisters.NewVolumeGroupSnapshotClassLister(cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})),
 	}
 
-	err := ctrl.updateGroupSnapshotContentInInformerCache(content)
+	requeue, err := ctrl.updateGroupSnapshotContentInInformerCache(content)
 	if err != nil {
 		t.Errorf("updateGroupSnapshotContentInInformerCache failed: %v", err)
+	}
+	if requeue {
+		t.Error("expected no requeue for a group snapshot content that is already ready to use")
 	}
 }
 
@@ -1253,9 +1263,12 @@ func TestSyncGroupSnapshotContentByKeyInvalidKey(t *testing.T) {
 	}
 
 	// Invalid key (e.g. missing namespace/name) causes SplitMetaNamespaceKey to fail and returns nil
-	err := ctrl.syncGroupSnapshotContentByKey("invalid-key-without-slash")
+	requeue, err := ctrl.syncGroupSnapshotContentByKey("invalid-key-without-slash")
 	if err != nil {
 		t.Errorf("expected nil error for invalid key, got: %v", err)
+	}
+	if requeue {
+		t.Error("expected no requeue for an invalid key")
 	}
 }
 
@@ -1293,9 +1306,12 @@ func TestSyncGroupSnapshotContentByKeyNotFoundRemovesFromCache(t *testing.T) {
 		groupSnapshotContentLister: contentLister,
 	}
 
-	err := ctrl.syncGroupSnapshotContentByKey(key)
+	requeue, err := ctrl.syncGroupSnapshotContentByKey(key)
 	if err != nil {
 		t.Errorf("syncGroupSnapshotContentByKey failed: %v", err)
+	}
+	if requeue {
+		t.Error("expected no requeue after a deleted group snapshot content is removed from the store")
 	}
 
 	_, found, _ := store.GetByKey(contentName)
@@ -1335,9 +1351,12 @@ func TestSyncGroupSnapshotContentByKeyListerErrorNonNotFound(t *testing.T) {
 		groupSnapshotContentLister: fakeLister,
 	}
 
-	err := ctrl.syncGroupSnapshotContentByKey(key)
+	requeue, err := ctrl.syncGroupSnapshotContentByKey(key)
 	if err != nil {
 		t.Errorf("expected nil error when lister returns non-NotFound error, got: %v", err)
+	}
+	if requeue {
+		t.Error("expected no requeue when lister returns non-NotFound error")
 	}
 	// Content should still be in store (we don't delete on arbitrary errors)
 	_, found, _ := store.GetByKey(contentName)
@@ -1436,6 +1455,53 @@ func TestGroupSnapshotContentWorker(t *testing.T) {
 		_, found, _ := store.GetByKey(key)
 		if !found {
 			t.Error("expected content to remain in store when sync (delete) fails")
+		}
+	})
+
+	// A driver is allowed to answer CreateVolumeGroupSnapshot with success and
+	// ready_to_use=false while the group snapshot is still being completed on the
+	// storage system. The worker must requeue such a content with rate-limited
+	// backoff rather than forgetting it until the next informer resync.
+	t.Run("not ready path - worker requeues when readyToUse is false", func(t *testing.T) {
+		// Rate limiter with no delay so the requeued item is immediately available.
+		queue := workqueue.NewTypedRateLimitingQueue[string](workqueue.NewTypedItemExponentialFailureRateLimiter[string](0, 0))
+		content := newGroupSnapshotContent(
+			contentName,
+			"uid", "snap", testNamespace,
+			"", "class-a", []string{"vol-1"},
+			crdv1.VolumeSnapshotContentDelete, nil, false, nil,
+		)
+		contentIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+		if err := contentIndexer.Add(content); err != nil {
+			t.Fatalf("contentIndexer.Add: %v", err)
+		}
+		classIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+		_ = classIndexer.Add(newVolumeGroupSnapshotClass("class-a", mockDriverName))
+
+		queue.Add(key)
+		ctrl := &csiSnapshotSideCarController{
+			driverName:                 mockDriverName,
+			groupSnapshotContentQueue:  queue,
+			groupSnapshotContentStore:  cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc),
+			contentStore:               cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc),
+			groupSnapshotContentLister: groupsnapshotlisters.NewVolumeGroupSnapshotContentLister(contentIndexer),
+			groupSnapshotClassLister:   groupsnapshotlisters.NewVolumeGroupSnapshotClassLister(classIndexer),
+			clientset:                  fake.NewSimpleClientset(content),
+			handler: &fakeGroupSnapshotHandler{
+				createGroupSnapshotResult: func() (string, string, []*csi.Snapshot, time.Time, bool, error) {
+					return mockDriverName, "group-id", nil, time.Now(), false, nil
+				},
+			},
+			eventRecorder: record.NewFakeRecorder(10),
+		}
+
+		ctrl.groupSnapshotContentWorker()
+
+		if err := wait.PollUntilContextTimeout(context.Background(), 10*time.Millisecond, 5*time.Second, true,
+			func(context.Context) (bool, error) {
+				return queue.Len() > 0, nil
+			}); err != nil {
+			t.Error("expected group snapshot content to be requeued when readyToUse is false")
 		}
 	})
 }

--- a/pkg/sidecar-controller/groupsnapshot_helper.go
+++ b/pkg/sidecar-controller/groupsnapshot_helper.go
@@ -73,11 +73,15 @@ func (ctrl *csiSnapshotSideCarController) groupSnapshotContentWorker() {
 	}
 	defer ctrl.groupSnapshotContentQueue.Done(key)
 
-	if err := ctrl.syncGroupSnapshotContentByKey(key); err != nil {
+	requeue, err := ctrl.syncGroupSnapshotContentByKey(key)
+	if err != nil {
+		klog.V(4).Infof("Failed to sync group snapshot content %q, will retry again: %v", key, err)
+		requeue = true
+	}
+	if requeue {
 		// Rather than wait for a full resync, re-add the key to the
 		// queue to be processed.
 		ctrl.groupSnapshotContentQueue.AddRateLimited(key)
-		klog.V(4).Infof("Failed to sync group snapshot content %q, will retry again: %v", key, err)
 		return
 	}
 
@@ -87,30 +91,33 @@ func (ctrl *csiSnapshotSideCarController) groupSnapshotContentWorker() {
 	return
 }
 
-func (ctrl *csiSnapshotSideCarController) syncGroupSnapshotContentByKey(key string) error {
+// syncGroupSnapshotContentByKey syncs a single group snapshot content. It returns
+// true if the controller should requeue the item again. On error, the group
+// snapshot content is always requeued.
+func (ctrl *csiSnapshotSideCarController) syncGroupSnapshotContentByKey(key string) (requeue bool, err error) {
 	klog.V(5).Infof("syncGroupSnapshotContentByKey[%s]", key)
 
 	_, name, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
 		klog.V(4).Infof("error getting name of groupSnapshotContent %q from informer: %v", key, err)
-		return nil
+		return false, nil
 	}
 	groupSnapshotContent, err := ctrl.groupSnapshotContentLister.Get(name)
 	// The group snapshot content still exists in informer cache, the event must
 	// have been add/update/sync
 	if err == nil {
 		if ctrl.isDriverMatch(groupSnapshotContent) {
-			err = ctrl.updateGroupSnapshotContentInInformerCache(groupSnapshotContent)
+			requeue, err = ctrl.updateGroupSnapshotContentInInformerCache(groupSnapshotContent)
 		}
 		if err != nil {
 			// If error occurs we add this item back to the queue
-			return err
+			return true, err
 		}
-		return nil
+		return requeue, nil
 	}
 	if !errors.IsNotFound(err) {
 		klog.V(2).Infof("error getting group snapshot content %q from informer: %v", key, err)
-		return nil
+		return false, nil
 	}
 
 	// The groupSnapshotContent is not in informer cache, the event must have been
@@ -118,27 +125,28 @@ func (ctrl *csiSnapshotSideCarController) syncGroupSnapshotContentByKey(key stri
 	groupSnapshotContentObj, found, err := ctrl.groupSnapshotContentStore.GetByKey(key)
 	if err != nil {
 		klog.V(2).Infof("error getting group snapshot content %q from cache: %v", key, err)
-		return nil
+		return false, nil
 	}
 	if !found {
 		// The controller has already processed the delete event and
 		// deleted the group snapshot content from its cache
 		klog.V(2).Infof("deletion of group snapshot content %q was already processed", key)
-		return nil
+		return false, nil
 	}
 	groupSnapshotContent, ok := groupSnapshotContentObj.(*groupsnapshotv1.VolumeGroupSnapshotContent)
 	if !ok {
 		klog.Errorf("expected group snapshot content, got %+v", groupSnapshotContent)
-		return nil
+		return false, nil
 	}
 	ctrl.deleteGroupSnapshotContentInCacheStore(groupSnapshotContent)
-	return nil
+	return false, nil
 }
 
 // updateGroupSnapshotContentInInformerCache runs in worker thread and handles
 // "group snapshot content added", "group snapshot content updated" and "periodic
-// sync" events.
-func (ctrl *csiSnapshotSideCarController) updateGroupSnapshotContentInInformerCache(groupSnapshotContent *groupsnapshotv1.VolumeGroupSnapshotContent) error {
+// sync" events. It returns a flag indicating if the group snapshot content should
+// be requeued. On error, the group snapshot content is always requeued.
+func (ctrl *csiSnapshotSideCarController) updateGroupSnapshotContentInInformerCache(groupSnapshotContent *groupsnapshotv1.VolumeGroupSnapshotContent) (requeue bool, err error) {
 	// Store the new group snapshot content version in the cache and do not process
 	// it if this is an old version.
 	new, err := ctrl.storeGroupSnapshotContentUpdate(groupSnapshotContent)
@@ -146,9 +154,9 @@ func (ctrl *csiSnapshotSideCarController) updateGroupSnapshotContentInInformerCa
 		klog.Errorf("%v", err)
 	}
 	if !new {
-		return nil
+		return false, nil
 	}
-	err = ctrl.syncGroupSnapshotContent(groupSnapshotContent)
+	requeue, err = ctrl.syncGroupSnapshotContent(groupSnapshotContent)
 	if err != nil {
 		if errors.IsConflict(err) {
 			// Version conflict error happens quite often and the controller
@@ -157,9 +165,9 @@ func (ctrl *csiSnapshotSideCarController) updateGroupSnapshotContentInInformerCa
 		} else {
 			klog.Errorf("could not sync group snapshot content %q: %+v", groupSnapshotContent.Name, err)
 		}
-		return err
+		return true, err
 	}
-	return nil
+	return requeue, nil
 }
 
 // deleteGroupSnapshotContentInCacheStore runs in worker thread and handles "group
@@ -169,8 +177,10 @@ func (ctrl *csiSnapshotSideCarController) deleteGroupSnapshotContentInCacheStore
 	klog.V(4).Infof("group snapshot content %q deleted", groupSnapshotContent.Name)
 }
 
-// syncGroupSnapshotContent deals with one key off the queue.  It returns false when it's time to quit.
-func (ctrl *csiSnapshotSideCarController) syncGroupSnapshotContent(groupSnapshotContent *groupsnapshotv1.VolumeGroupSnapshotContent) error {
+// syncGroupSnapshotContent deals with one key off the queue. It returns a flag
+// indicating if the group snapshot content should be requeued. On error, the
+// group snapshot content is always requeued.
+func (ctrl *csiSnapshotSideCarController) syncGroupSnapshotContent(groupSnapshotContent *groupsnapshotv1.VolumeGroupSnapshotContent) (requeue bool, err error) {
 	klog.V(5).Infof("synchronizing VolumeGroupSnapshotContent[%s]", groupSnapshotContent.Name)
 
 	if ctrl.shouldDeleteGroupSnapshotContent(groupSnapshotContent) {
@@ -182,13 +192,19 @@ func (ctrl *csiSnapshotSideCarController) syncGroupSnapshotContent(groupSnapshot
 			// operation will update groups snapshot content's GroupSnapshotHandle
 			// to nil upon a successful deletion. At this point, the finalizer on
 			// group snapshot content should NOT be removed to avoid leaking.
-			return ctrl.deleteCSIGroupSnapshotOperation(groupSnapshotContent)
+			if err := ctrl.deleteCSIGroupSnapshotOperation(groupSnapshotContent); err != nil {
+				return true, err
+			}
+			return false, nil
 		}
 		// otherwise, either the snapshot has been deleted from the underlying
 		// storage system, or the deletion policy is Retain, remove the finalizer
 		// if there is one so that API server could delete the object if there is
 		// no other finalizer.
-		return ctrl.removeGroupSnapshotContentFinalizer(groupSnapshotContent)
+		if err := ctrl.removeGroupSnapshotContentFinalizer(groupSnapshotContent); err != nil {
+			return true, err
+		}
+		return false, nil
 	}
 
 	if len(groupSnapshotContent.Spec.Source.VolumeHandles) != 0 && groupSnapshotContent.Status == nil {
@@ -199,11 +215,12 @@ func (ctrl *csiSnapshotSideCarController) syncGroupSnapshotContent(groupSnapshot
 	// Skip checkandUpdateGroupSnapshotContentStatus() if ReadyToUse is already
 	// true. We don't want to keep calling CreateGroupSnapshot CSI methods over
 	// and over again for performance reasons.
-	var err error
-	if groupSnapshotContent.Status != nil && groupSnapshotContent.Status.ReadyToUse != nil && *groupSnapshotContent.Status.ReadyToUse == true {
+	if groupSnapshotContentIsReady(groupSnapshotContent) {
 		// Try to remove AnnVolumeGroupSnapshotBeingCreated if it is not removed yet for some reason
-		_, err = ctrl.removeAnnVolumeGroupSnapshotBeingCreated(groupSnapshotContent)
-		return err
+		if _, err := ctrl.removeAnnVolumeGroupSnapshotBeingCreated(groupSnapshotContent); err != nil {
+			return true, err
+		}
+		return false, nil
 	}
 	return ctrl.checkandUpdateGroupSnapshotContentStatus(groupSnapshotContent)
 }
@@ -278,8 +295,14 @@ func (ctrl *csiSnapshotSideCarController) deleteCSIGroupSnapshotOperation(groupS
 		ctrl.eventRecorder.Event(groupSnapshotContent, v1.EventTypeWarning, "GroupSnapshotDeleteError", "Failed to clear content status")
 		return err
 	}
-	// trigger syncGroupSnapshotContent
-	ctrl.updateGroupSnapshotContentInInformerCache(newContent)
+	// Trigger a re-sync of the group snapshot content, which will continue
+	// cleaning up the object (e.g. removing the finalizer). The requeue flag is
+	// not propagated: the group snapshot handle has just been cleared, so the
+	// re-sync only takes the finalizer removal path and anything that needs to be
+	// retried surfaces as an error, which the caller turns into a requeue.
+	if _, err := ctrl.updateGroupSnapshotContentInInformerCache(newContent); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -367,14 +390,16 @@ func (ctrl *csiSnapshotSideCarController) shouldDeleteGroupSnapshotContent(group
 	return false
 }
 
-// createGroupSnapshot starts new asynchronous operation to create group snapshot
-func (ctrl *csiSnapshotSideCarController) createGroupSnapshot(groupSnapshotContent *groupsnapshotv1.VolumeGroupSnapshotContent) error {
+// createGroupSnapshot starts new asynchronous operation to create group snapshot.
+// It returns a flag indicating if the group snapshot content should be requeued.
+// On error, the group snapshot content is always requeued.
+func (ctrl *csiSnapshotSideCarController) createGroupSnapshot(groupSnapshotContent *groupsnapshotv1.VolumeGroupSnapshotContent) (requeue bool, err error) {
 	klog.V(5).Infof("createGroupSnapshot for group snapshot content [%s]: started", groupSnapshotContent.Name)
 	groupSnapshotContentObj, err := ctrl.createGroupSnapshotWrapper(groupSnapshotContent)
 	if err != nil {
 		ctrl.updateGroupSnapshotContentErrorStatusWithEvent(groupSnapshotContentObj, v1.EventTypeWarning, "GroupSnapshotCreationFailed", fmt.Sprintf("Failed to create group snapshot: %v", err))
 		klog.Errorf("createGroupSnapshot for groupSnapshotContent [%s]: error occurred in createGroupSnapshotWrapper: %v", groupSnapshotContent.Name, err)
-		return err
+		return true, err
 	}
 
 	_, updateErr := ctrl.storeGroupSnapshotContentUpdate(groupSnapshotContentObj)
@@ -383,7 +408,11 @@ func (ctrl *csiSnapshotSideCarController) createGroupSnapshot(groupSnapshotConte
 		klog.V(4).Infof("createGroupSnapshot for groupSnapshotContent [%s]: cannot update internal groupSnapshotContent cache: %v", groupSnapshotContent.Name, updateErr)
 	}
 
-	return nil
+	// The CSI driver may return success with ReadyToUse false while the group
+	// snapshot is still being completed on the storage system. Requeue with
+	// rate-limited backoff so readiness is picked up promptly instead of waiting
+	// for the next informer resync.
+	return !groupSnapshotContentIsReady(groupSnapshotContentObj), nil
 }
 
 // This is a wrapper function for the group snapshot creation process.
@@ -732,13 +761,24 @@ func GetSnapshotContentNameForVolumeGroupSnapshotContent(groupSnapshotContentUUI
 	return fmt.Sprintf("snapcontent-%x-%s", sha256.Sum256([]byte(groupSnapshotContentUUID+pvUUID)), time.Now().Format("2006-01-02-3.4.5"))
 }
 
-func (ctrl *csiSnapshotSideCarController) checkandUpdateGroupSnapshotContentStatus(groupSnapshotContent *groupsnapshotv1.VolumeGroupSnapshotContent) error {
+// groupSnapshotContentIsReady returns true if the group snapshot has been cut and
+// is ready to be used on the storage system.
+func groupSnapshotContentIsReady(groupSnapshotContent *groupsnapshotv1.VolumeGroupSnapshotContent) bool {
+	return groupSnapshotContent != nil && groupSnapshotContent.Status != nil &&
+		groupSnapshotContent.Status.ReadyToUse != nil && *groupSnapshotContent.Status.ReadyToUse
+}
+
+// checkandUpdateGroupSnapshotContentStatus checks the status of the group snapshot
+// in the CSI driver and updates groupSnapshotContent.Status accordingly. It returns
+// a flag indicating if the group snapshot content should be requeued. On error, the
+// group snapshot content is always requeued.
+func (ctrl *csiSnapshotSideCarController) checkandUpdateGroupSnapshotContentStatus(groupSnapshotContent *groupsnapshotv1.VolumeGroupSnapshotContent) (requeue bool, err error) {
 	klog.V(5).Infof("checkandUpdateGroupSnapshotContentStatus[%s] started", groupSnapshotContent.Name)
 	groupSnapshotContentObj, err := ctrl.checkandUpdateGroupSnapshotContentStatusOperation(groupSnapshotContent)
 	if err != nil {
 		ctrl.updateGroupSnapshotContentErrorStatusWithEvent(groupSnapshotContentObj, v1.EventTypeWarning, "GroupSnapshotContentCheckandUpdateFailed", fmt.Sprintf("Failed to check and update group snapshot content: %v", err))
 		klog.Errorf("checkandUpdateGroupSnapshotContentStatus [%s]: error occurred %v", groupSnapshotContent.Name, err)
-		return err
+		return true, err
 	}
 	_, updateErr := ctrl.storeGroupSnapshotContentUpdate(groupSnapshotContentObj)
 	if updateErr != nil {
@@ -746,7 +786,9 @@ func (ctrl *csiSnapshotSideCarController) checkandUpdateGroupSnapshotContentStat
 		klog.V(4).Infof("checkandUpdateGroupSnapshotContentStatus [%s]: cannot update internal cache: %v", groupSnapshotContent.Name, updateErr)
 	}
 
-	return nil
+	// Keep polling the storage system with rate-limited backoff until the group
+	// snapshot becomes ready to use.
+	return !groupSnapshotContentIsReady(groupSnapshotContentObj), nil
 }
 
 func (ctrl *csiSnapshotSideCarController) checkandUpdateGroupSnapshotContentStatusOperation(groupSnapshotContent *groupsnapshotv1.VolumeGroupSnapshotContent) (*groupsnapshotv1.VolumeGroupSnapshotContent, error) {

--- a/pkg/sidecar-controller/groupsnapshot_helper_test.go
+++ b/pkg/sidecar-controller/groupsnapshot_helper_test.go
@@ -17,6 +17,8 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8stesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 )
@@ -123,9 +125,12 @@ func TestCreateGroupSnapshotErrorPath(t *testing.T) {
 		eventRecorder:             record.NewFakeRecorder(10),
 	}
 
-	err := ctrl.createGroupSnapshot(content)
+	requeue, err := ctrl.createGroupSnapshot(content)
 	if err == nil {
 		t.Error("createGroupSnapshot expected error when handler returns error")
+	}
+	if !requeue {
+		t.Error("expected requeue when createGroupSnapshotWrapper returns error")
 	}
 	// Error path should call updateGroupSnapshotContentErrorStatusWithEvent
 	updated, _ := client.GroupsnapshotV1().VolumeGroupSnapshotContents().Get(context.Background(), "create-err", metav1.GetOptions{})
@@ -154,9 +159,12 @@ func TestCheckandUpdateGroupSnapshotContentStatusErrorPath(t *testing.T) {
 		eventRecorder:             record.NewFakeRecorder(10),
 	}
 
-	err := ctrl.checkandUpdateGroupSnapshotContentStatus(content)
+	requeue, err := ctrl.checkandUpdateGroupSnapshotContentStatus(content)
 	if err == nil {
 		t.Error("checkandUpdateGroupSnapshotContentStatus expected error when GetGroupSnapshotStatus fails")
+	}
+	if !requeue {
+		t.Error("expected requeue when GetGroupSnapshotStatus fails")
 	}
 	updated, _ := client.GroupsnapshotV1().VolumeGroupSnapshotContents().Get(context.Background(), "check-err", metav1.GetOptions{})
 	if updated.Status == nil || updated.Status.Error == nil {
@@ -198,6 +206,54 @@ func TestDeleteCSIGroupSnapshotOperationSuccess(t *testing.T) {
 	updated, _ := client.GroupsnapshotV1().VolumeGroupSnapshotContents().Get(context.Background(), "delete-ok", metav1.GetOptions{})
 	if updated.Status != nil && updated.Status.VolumeGroupSnapshotHandle != nil {
 		t.Error("expected VolumeGroupSnapshotHandle to be cleared after successful delete")
+	}
+}
+
+// TestDeleteCSIGroupSnapshotOperationResyncError tests that an error from the
+// re-sync triggered after the group snapshot handle is cleared is propagated to
+// the caller, so that the worker requeues and retries the remaining cleanup
+// (finalizer removal) instead of forgetting the key until the next resync.
+func TestDeleteCSIGroupSnapshotOperationResyncError(t *testing.T) {
+	content := newGroupSnapshotContent(
+		"delete-resync-err", "uid", "snap", testNamespace,
+		"group-h", "class-a", []string{"vol-1"},
+		v1.VolumeSnapshotContentDelete, nil, true, &timeNowMetav1,
+	)
+	content.Status = &groupsnapshotv1.VolumeGroupSnapshotContentStatus{
+		VolumeGroupSnapshotHandle: ptrString("group-handle-1"),
+		VolumeSnapshotInfoList: []groupsnapshotv1.VolumeSnapshotInfo{
+			{VolumeHandle: "vol-1", SnapshotHandle: "snap-1"},
+		},
+	}
+	client := fake.NewSimpleClientset(content)
+	// Let clearGroupSnapshotContentStatus (UpdateStatus) succeed, but fail the
+	// patch that removes the finalizer during the re-sync.
+	client.PrependReactor("patch", "volumegroupsnapshotcontents",
+		func(action k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, errors.NewInternalError(fmt.Errorf("patch failed"))
+		})
+	store := cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
+	_ = store.Add(content)
+	classIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	_ = classIndexer.Add(newVolumeGroupSnapshotClass("class-a", mockDriverName))
+	ctrl := &csiSnapshotSideCarController{
+		clientset:                 client,
+		groupSnapshotContentStore: store,
+		groupSnapshotClassLister:  groupsnapshotlisters.NewVolumeGroupSnapshotClassLister(classIndexer),
+		handler:                   &fakeGroupSnapshotHandler{}, // DeleteGroupSnapshot returns nil
+		eventRecorder:             record.NewFakeRecorder(10),
+	}
+
+	err := ctrl.deleteCSIGroupSnapshotOperation(content)
+	if err == nil {
+		t.Fatal("expected deleteCSIGroupSnapshotOperation to propagate the error from the triggered re-sync")
+	}
+
+	// The handle must still have been cleared: the group snapshot really is gone
+	// from the storage system, only the finalizer removal failed.
+	updated, _ := client.GroupsnapshotV1().VolumeGroupSnapshotContents().Get(context.Background(), "delete-resync-err", metav1.GetOptions{})
+	if updated.Status != nil && updated.Status.VolumeGroupSnapshotHandle != nil {
+		t.Error("expected VolumeGroupSnapshotHandle to be cleared even when the re-sync fails")
 	}
 }
 
@@ -297,13 +353,47 @@ func TestCheckandUpdateGroupSnapshotContentStatusSuccess(t *testing.T) {
 		handler:                   &fakeGroupSnapshotHandler{},
 		eventRecorder:             record.NewFakeRecorder(10),
 	}
-	err := ctrl.checkandUpdateGroupSnapshotContentStatus(content)
+	requeue, err := ctrl.checkandUpdateGroupSnapshotContentStatus(content)
 	if err != nil {
 		t.Fatalf("checkandUpdateGroupSnapshotContentStatus failed: %v", err)
+	}
+	if requeue {
+		t.Error("expected no requeue when the group snapshot became ready to use")
 	}
 	_, found, _ := store.GetByKey("check-status-ok")
 	if !found {
 		t.Error("expected content to be in store after successful checkandUpdate")
+	}
+}
+
+// TestCheckandUpdateGroupSnapshotContentStatusNotReadyRequeues verifies that a
+// successful GetGroupSnapshotStatus reporting readyToUse=false asks for a
+// rate-limited requeue instead of being forgotten until the next resync.
+func TestCheckandUpdateGroupSnapshotContentStatusNotReadyRequeues(t *testing.T) {
+	content := newGroupSnapshotContentWithHandles(
+		"check-status-not-ready", "uid", "snap", testNamespace,
+		"group-h", []string{"snap-1"}, "",
+		v1.VolumeSnapshotContentDelete, nil, false, nil,
+	)
+	content.Spec.VolumeGroupSnapshotClassName = nil
+	client := fake.NewSimpleClientset(content)
+	store := cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
+	ctrl := &csiSnapshotSideCarController{
+		clientset:                 client,
+		groupSnapshotContentStore: store,
+		handler: &fakeGroupSnapshotHandler{
+			getGroupSnapshotStatus: func() (bool, time.Time, error) {
+				return false, time.Now(), nil
+			},
+		},
+		eventRecorder: record.NewFakeRecorder(10),
+	}
+	requeue, err := ctrl.checkandUpdateGroupSnapshotContentStatus(content)
+	if err != nil {
+		t.Fatalf("checkandUpdateGroupSnapshotContentStatus failed: %v", err)
+	}
+	if !requeue {
+		t.Error("expected requeue when the group snapshot is not ready to use yet")
 	}
 }
 
@@ -396,8 +486,46 @@ func TestCreateGroupSnapshotSuccess(t *testing.T) {
 		handler:                   &fakeGroupSnapshotHandler{},
 		eventRecorder:             record.NewFakeRecorder(10),
 	}
-	err := ctrl.createGroupSnapshot(content)
+	requeue, err := ctrl.createGroupSnapshot(content)
 	if err != nil {
 		t.Fatalf("createGroupSnapshot failed: %v", err)
+	}
+	if requeue {
+		t.Error("expected no requeue when the group snapshot is created ready to use")
+	}
+}
+
+// TestCreateGroupSnapshotNotReadyRequeues verifies that a successful
+// CreateGroupSnapshot returning readyToUse=false asks for a rate-limited requeue,
+// so that readiness is not delayed until the next informer resync.
+func TestCreateGroupSnapshotNotReadyRequeues(t *testing.T) {
+	content := newGroupSnapshotContent(
+		"create-not-ready", "uid", "snap", testNamespace,
+		"", "class-a", []string{"vol-1"},
+		v1.VolumeSnapshotContentDelete, nil, false, nil,
+	)
+	class := newVolumeGroupSnapshotClass("class-a", mockDriverName)
+	class.Parameters = nil
+	classIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	_ = classIndexer.Add(class)
+	client := fake.NewSimpleClientset(content)
+	ctrl := &csiSnapshotSideCarController{
+		clientset:                 client,
+		contentStore:              cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc),
+		groupSnapshotContentStore: cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc),
+		groupSnapshotClassLister:  groupsnapshotlisters.NewVolumeGroupSnapshotClassLister(classIndexer),
+		handler: &fakeGroupSnapshotHandler{
+			createGroupSnapshotResult: func() (string, string, []*csi.Snapshot, time.Time, bool, error) {
+				return "driver", "group-id", nil, time.Now(), false, nil
+			},
+		},
+		eventRecorder: record.NewFakeRecorder(10),
+	}
+	requeue, err := ctrl.createGroupSnapshot(content)
+	if err != nil {
+		t.Fatalf("createGroupSnapshot failed: %v", err)
+	}
+	if !requeue {
+		t.Error("expected requeue when CreateGroupSnapshot succeeds with readyToUse=false")
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Requeue VolumeGroupSnapshotContent with backoff when not ready to use.

**Which issue(s) this PR fixes**:
Fixes #1457

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Requeue VolumeGroupSnapshotContent with backoff when not ready to use.
```
