### PR TITLE
deploy: update sidecar image versions

### DIFF
--- a/deploy/kubernetes/csi-snapshotter/setup-csi-snapshotter.yaml
+++ b/deploy/kubernetes/csi-snapshotter/setup-csi-snapshotter.yaml
@@ -97,7 +97,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: hostpath
-          image: registry.k8s.io/sig-storage/hostpathplugin:v1.17.1
+          image: registry.k8s.io/sig-storage/hostpathplugin:v1.18.0
           args:
             - "--v=5"
             - "--endpoint=$(CSI_ENDPOINT)"


### PR DESCRIPTION
Update the cross-referenced `hostpathplugin` sidecar image in `deploy/kubernetes/csi-snapshotter/setup-csi-snapshotter.yaml` to its latest stable release.

## Changes

**`deploy/kubernetes/csi-snapshotter/setup-csi-snapshotter.yaml`:**
- `hostpathplugin`: v1.17.1 → v1.18.0

`csi-provisioner` (v6.3.0) and `csi-snapshotter` (v8.6.0) are already at their latest stable releases and are unchanged. `snapshot-controller` (v8.6.0) in `deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml` is also already current.