### PR TITLE
Convert VolumeGroupSnapshotContent to and from the v1 API version

### DIFF
--- a/pkg/webhook/convert.go
+++ b/pkg/webhook/convert.go
@@ -30,7 +30,15 @@ const (
 	// that is used when converting data from the v1beta2 to the v1beta1
 	// API to make the conversion reversible.
 	volumeSnapshotInfoAnnotationName = "groupsnapshot.storage.kubernetes.io/volume-snapshot-info-list"
+
+	v1beta1Version = "groupsnapshot.storage.k8s.io/v1beta1"
+	v1beta2Version = "groupsnapshot.storage.k8s.io/v1beta2"
+	v1Version      = "groupsnapshot.storage.k8s.io/v1"
 )
+
+func sharesV1beta2Schema(version string) bool {
+	return version == v1beta2Version || version == v1Version
+}
 
 func convertGroupSnapshotCRD(obj *unstructured.Unstructured, toVersion string) (*unstructured.Unstructured, metav1.Status) {
 	klog.V(2).Info("converting crd")
@@ -47,16 +55,17 @@ func convertGroupSnapshotCRD(obj *unstructured.Unstructured, toVersion string) (
 		return nil, statusErrorWithMessage("unexpected conversion kind %q", kind)
 	}
 
-	const v1beta1Version = "groupsnapshot.storage.k8s.io/v1beta1"
-	const v1beta2Version = "groupsnapshot.storage.k8s.io/v1beta2"
-
 	switch {
-	case fromVersion == v1beta1Version && toVersion == v1beta2Version:
+	case sharesV1beta2Schema(fromVersion) && sharesV1beta2Schema(toVersion):
+		// v1 was promoted from v1beta2 without schema changes, so only the
+		// API version changes, and that is done by the caller.
+
+	case fromVersion == v1beta1Version && sharesV1beta2Schema(toVersion):
 		if err := convertVolumeGroupSnapshotContentFromV1beta1ToV1beta2(convertedObject); err != nil {
 			return nil, statusErrorWithMessage("%s", err.Error())
 		}
 
-	case fromVersion == v1beta2Version && toVersion == v1beta1Version:
+	case sharesV1beta2Schema(fromVersion) && toVersion == v1beta1Version:
 		if err := convertVolumeGroupSnapshotContentFromV1beta2ToV1beta1(convertedObject); err != nil {
 			return nil, statusErrorWithMessage("%s", err.Error())
 		}

--- a/pkg/webhook/convert_test.go
+++ b/pkg/webhook/convert_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/yaml"
 )
@@ -79,6 +80,78 @@ func TestFromBeta2ToBeta1(t *testing.T) {
 				t.Errorf("unexpected result %v vs %v", string(fromJSON), string(toJSON))
 			}
 		})
+	}
+}
+
+func TestConvertGroupSnapshotCRDToAndFromV1(t *testing.T) {
+	testCases := []struct {
+		name        string
+		fromFile    string
+		fromVersion string
+		toFile      string
+		toVersion   string
+	}{
+		{
+			name:        "v1 to v1beta2 leaves the object unchanged",
+			fromFile:    "testdata/v1beta2_to_v1beta1/annotation_status_v1beta2.yaml",
+			fromVersion: v1Version,
+			toFile:      "testdata/v1beta2_to_v1beta1/annotation_status_v1beta2.yaml",
+			toVersion:   v1beta2Version,
+		},
+		{
+			name:        "v1beta2 to v1 leaves the object unchanged",
+			fromFile:    "testdata/v1beta2_to_v1beta1/annotation_status_v1beta2.yaml",
+			fromVersion: v1beta2Version,
+			toFile:      "testdata/v1beta2_to_v1beta1/annotation_status_v1beta2.yaml",
+			toVersion:   v1Version,
+		},
+		{
+			name:        "v1 to v1beta1 converts as v1beta2 does",
+			fromFile:    "testdata/v1beta2_to_v1beta1/annotation_status_v1beta2.yaml",
+			fromVersion: v1Version,
+			toFile:      "testdata/v1beta2_to_v1beta1/annotation_status_v1beta1.yaml",
+			toVersion:   v1beta1Version,
+		},
+		{
+			name:        "v1beta1 to v1 converts as it does to v1beta2",
+			fromFile:    "testdata/v1beta1_to_v1beta2/annotation_status_v1beta1.yaml",
+			fromVersion: v1beta1Version,
+			toFile:      "testdata/v1beta1_to_v1beta2/annotation_status_v1beta2.yaml",
+			toVersion:   v1Version,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			from := fromFile(t, tc.fromFile)
+			from.SetAPIVersion(tc.fromVersion)
+
+			to := fromFile(t, tc.toFile)
+			to.SetAPIVersion(tc.toVersion)
+
+			converted, status := convertGroupSnapshotCRD(from, tc.toVersion)
+			if status.Status != metav1.StatusSuccess {
+				t.Fatalf("conversion from %q to %q failed: %v", tc.fromVersion, tc.toVersion, status.Message)
+			}
+
+			// The API version is changed by the framework, here we emulate it
+			converted.SetAPIVersion(tc.toVersion)
+
+			if !equality.Semantic.DeepEqual(converted, to) {
+				convertedJSON, _ := json.MarshalIndent(converted, "", "  ")
+				toJSON, _ := json.MarshalIndent(to, "", "  ")
+				t.Errorf("unexpected result %v vs %v", string(convertedJSON), string(toJSON))
+			}
+		})
+	}
+}
+
+func TestConvertGroupSnapshotCRDRejectsUnknownVersion(t *testing.T) {
+	from := fromFile(t, "testdata/v1beta2_to_v1beta1/annotation_status_v1beta2.yaml")
+
+	_, status := convertGroupSnapshotCRD(from, "groupsnapshot.storage.k8s.io/v2")
+	if status.Status != metav1.StatusFailure {
+		t.Fatalf("expected conversion to an unknown version to fail, got %q", status.Status)
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The `volumegroupsnapshotcontents` CRD serves `v1beta1`, `v1beta2`, and `v1`,
uses `v1beta2` as its storage version, and configures webhook conversion.
Consequently, accessing a `VolumeGroupSnapshotContent` through the non-storage
`v1` API requires conversion by the webhook.

`convertGroupSnapshotCRD` dispatched conversions only between `v1beta1` and
`v1beta2`. Any conversion involving `v1` reached the default case and failed:

```text
conversion webhook for groupsnapshot.storage.k8s.io/v1, Kind=VolumeGroupSnapshotContent failed:
unexpected conversion version from "groupsnapshot.storage.k8s.io/v1" to "groupsnapshot.storage.k8s.io/v1beta2"
```

This prevented `VolumeGroupSnapshotContent` from being used through the `v1`
API.

`v1` and `v1beta2` have the same schema, so this PR treats them as equivalent
for conversion dispatch:

- Conversions between `v1` and `v1beta2` require no field conversion. The
  conversion framework updates the API version in `doConversionV1`.
- Conversions between `v1` and `v1beta1` reuse the existing conversion logic
  between `v1beta2` and `v1beta1`, including the annotation used to preserve
  data during round-trip conversion.

Unrecognized API versions continue to be rejected.

**Which issue(s) this PR fixes**:

Fixes #1450

**Special notes for your reviewer**:

The existing tests called the two `convertVolumeGroupSnapshotContentFrom*`
functions directly, bypassing `convertGroupSnapshotCRD`, where version dispatch
occurs. This PR adds dispatcher-level coverage for:

- `v1` to `v1beta2`
- `v1beta2` to `v1`
- `v1` to `v1beta1`
- `v1beta1` to `v1`
- rejection of an unrecognized API version

The new `v1` cases fail against the previous dispatch logic with the error
reported in the issue and pass with this change.

`volumegroupsnapshots` and `volumegroupsnapshotclasses` also serve `v1`, but
`deploy/kubernetes/webhook-example/patch-ca-bundle.sh` configures webhook
conversion only for `volumegroupsnapshotcontents`. The other two CRDs use the
`None` conversion strategy and are unaffected.

**Does this PR introduce a user-facing change?**:

```release-note
Fixed the group snapshot conversion webhook rejecting conversions to and from `v1` for `VolumeGroupSnapshotContent`.
```
