### PR TITLE
test: data race in scheduleOpsInFlightMetric

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -293,11 +293,11 @@ func (opMgr *operationMetricsManager) init() {
 	// this scheduled routine will catch any leaked operations.
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	go opMgr.scheduleOpsInFlightMetric(ctx)
+	go opMgr.scheduleOpsInFlightMetric(ctx, inFlightCheckInterval)
 }
 
-func (opMgr *operationMetricsManager) scheduleOpsInFlightMetric(ctx context.Context) {
-	ticker := time.NewTicker(inFlightCheckInterval)
+func (opMgr *operationMetricsManager) scheduleOpsInFlightMetric(ctx context.Context, interval time.Duration) {
+	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	for {
 		select {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
`TestInFlightMetric` overrides the package-level `inFlightCheckInterval` variable (and restores it via `defer`) while the goroutine started in `operationMetricsManager.init()` reads the same variable in `time.NewTicker(inFlightCheckInterval)`. Under Go 1.26 the race detector flags this as a data race:

```
WARNING: DATA RACE
Write at 0x0000010c5a00 by goroutine 131:
  metrics.TestInFlightMetric.func1()
      pkg/metrics/metrics_test.go:494 +0x30
Previous read at 0x0000010c5a00 by goroutine 135:
  metrics.(*operationMetricsManager).scheduleOpsInFlightMetric()
      pkg/metrics/metrics.go:300 +0x4a
```

Fix: capture the interval into a local parameter at goroutine launch so `scheduleOpsInFlightMetric` no longer reads the package variable. Behavior is unchanged; the test still overrides the package var before `NewMetricsManager` is called, and the goroutine now snapshots the value once at start.

Seen in https://github.com/kubernetes-csi/external-snapshotter/pull/1471.

**Release note**:
```release-note
NONE
```