### PR TITLE
Enable VGS feature gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,13 +116,11 @@ Other than this, the NODE_NAME environment variable must be set where the CSI sn
 
 ### Volume Group Snapshot Support
 
-The following requisites must be met to enable the volume group snapshot feature:
+The `CSIVolumeGroupSnapshot` feature gate is General Availability (GA) and enabled by default.
 
-* the Volume Group Snapshot CRDs are installed in the cluster
-* the `--feature-gates=CSIVolumeGroupSnapshot=true` option is being passed to the snapshot controller
-* the `--feature-gates=CSIVolumeGroupSnapshot=true` option is being passed to the CSI snapshotter sidecar
+To use the volume group snapshot feature, install the Volume Group Snapshot CRDs in the cluster.
 
-Specifically, `deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml` needs to be updated with `--feature-gates=CSIVolumeGroupSnapshot=true` in order to enable this feature in the snapshot controller.
+**Note:** Because the feature gate is enabled by default, both the snapshot controller and the CSI external-snapshotter sidecar check for the Volume Group Snapshot CRDs at startup. If those CRDs are not found, they log a warning and continue running with volume group snapshot support disabled for that process, rather than failing to start. This applies whether the feature gate is left at its default or explicitly set to `true` -- a CSI driver vendor or cluster admin has no control over whether a given cluster has the Volume Group Snapshot CRDs installed, so a missing CRD is never treated as a fatal startup error. To use volume group snapshots, install the CRDs; to silence the warning when you don't intend to use the feature, pass `--feature-gates=CSIVolumeGroupSnapshot=false`.
 
 ### Snapshot controller command line options
 
@@ -159,7 +157,7 @@ Specifically, `deploy/kubernetes/snapshot-controller/setup-snapshot-controller.y
 
 #### Volume Group Snapshot support
 
-* `--feature-gates=CSIVolumeGroupSnapshot=true`: Enables support for Volume Group Snapshots. If this option is enabled, the VolumeGroupSnapshots CRD should be available on the cluster.
+* `--feature-gates=CSIVolumeGroupSnapshot=true`: Enables support for Volume Group Snapshots. This feature is GA and enabled by default. If the VolumeGroupSnapshot CRDs are not available on the cluster, this is logged as a warning and volume group snapshot support is disabled, rather than causing a startup failure.
 
 #### Other recognized arguments
 * `--kubeconfig <path>`: Path to Kubernetes client configuration that the snapshot controller uses to connect to Kubernetes API server. When omitted, default token provided by Kubernetes will be used. This option is useful only when the snapshot controller does not run as a Kubernetes pod, e.g. for debugging.
@@ -207,7 +205,7 @@ Specifically, `deploy/kubernetes/snapshot-controller/setup-snapshot-controller.y
 
 #### Volume Group Snapshot support
 
-* `--feature-gates=CSIVolumeGroupSnapshot=true`: Enables support for Volume Group Snapshots. If this option is enabled, the VolumeGroupSnapshots CRD should be available on the cluster.
+* `--feature-gates=CSIVolumeGroupSnapshot=true`: Enables support for Volume Group Snapshots. This feature is GA and enabled by default. If the VolumeGroupSnapshot CRDs are not available on the cluster, this is logged as a warning and volume group snapshot support is disabled, rather than causing a startup failure.
 
 #### Other recognized arguments
 * `--kubeconfig <path>`: Path to Kubernetes client configuration that the CSI external-snapshotter uses to connect to Kubernetes API server. When omitted, default token provided by Kubernetes will be used. This option is useful only when the external-snapshotter does not run as a Kubernetes pod, e.g. for debugging.

--- a/cmd/csi-snapshotter/main.go
+++ b/cmd/csi-snapshotter/main.go
@@ -64,6 +64,7 @@ import (
 	clientset "github.com/kubernetes-csi/external-snapshotter/client/v8/clientset/versioned"
 	snapshotscheme "github.com/kubernetes-csi/external-snapshotter/client/v8/clientset/versioned/scheme"
 	informers "github.com/kubernetes-csi/external-snapshotter/client/v8/informers/externalversions"
+	groupsnapshotinformers "github.com/kubernetes-csi/external-snapshotter/client/v8/informers/externalversions/volumegroupsnapshot/v1"
 	"github.com/kubernetes-csi/external-snapshotter/v8/pkg/group_snapshotter"
 	utils "github.com/kubernetes-csi/external-snapshotter/v8/pkg/utils"
 )
@@ -249,7 +250,25 @@ func main() {
 
 	snapShotter := snapshotter.NewSnapshotter(csiConn)
 	var groupSnapshotter group_snapshotter.GroupSnapshotter
-	if utilfeature.DefaultFeatureGate.Enabled(features.VolumeGroupSnapshot) {
+
+	// The VolumeGroupSnapshot feature is GA and enabled by default. A CSI
+	// driver vendor has little control over whether a given cluster has the
+	// VolumeGroupSnapshot CRDs installed, so if they are missing, log a
+	// warning and continue running with volume group snapshot support
+	// disabled for this run rather than failing to start.
+	enableVolumeGroupSnapshots := utilfeature.DefaultFeatureGate.Enabled(features.VolumeGroupSnapshot)
+	if enableVolumeGroupSnapshots {
+		crdCtx, crdCancel := context.WithTimeout(ctx, *csiTimeout)
+		err := ensureVolumeGroupSnapshotCRDsExist(crdCtx, snapClient)
+		crdCancel()
+		if err != nil {
+			klog.Warningf("VolumeGroupSnapshot CRDs were not found; disabling the VolumeGroupSnapshot feature for this run. "+
+				"Install the VolumeGroupSnapshot CRDs to use this feature: %v", err)
+			enableVolumeGroupSnapshots = false
+		}
+	}
+
+	if enableVolumeGroupSnapshots {
 		tctx, cancel = context.WithTimeout(ctx, *csiTimeout)
 		defer cancel()
 		supportsCreateVolumeGroupSnapshot, err := supportsGroupControllerCreateVolumeGroupSnapshot(tctx, csiConn)
@@ -263,6 +282,13 @@ func main() {
 			klog.Error("group snapshot name prefix cannot be of length 0")
 			os.Exit(1)
 		}
+	}
+
+	var volumeGroupSnapshotContentInformer groupsnapshotinformers.VolumeGroupSnapshotContentInformer
+	var volumeGroupSnapshotClassInformer groupsnapshotinformers.VolumeGroupSnapshotClassInformer
+	if enableVolumeGroupSnapshots {
+		volumeGroupSnapshotContentInformer = snapshotContentfactory.Groupsnapshot().V1().VolumeGroupSnapshotContents()
+		volumeGroupSnapshotClassInformer = snapshotContentfactory.Groupsnapshot().V1().VolumeGroupSnapshotClasses()
 	}
 
 	ctrl := controller.NewCSISnapshotSideCarController(
@@ -281,9 +307,9 @@ func main() {
 		*groupSnapshotNameUUIDLength,
 		*extraCreateMetadata,
 		workqueue.NewTypedItemExponentialFailureRateLimiter[string](*retryIntervalStart, *retryIntervalMax),
-		utilfeature.DefaultFeatureGate.Enabled(features.VolumeGroupSnapshot),
-		snapshotContentfactory.Groupsnapshot().V1().VolumeGroupSnapshotContents(),
-		snapshotContentfactory.Groupsnapshot().V1().VolumeGroupSnapshotClasses(),
+		enableVolumeGroupSnapshots,
+		volumeGroupSnapshotContentInformer,
+		volumeGroupSnapshotClassInformer,
 		workqueue.NewTypedItemExponentialFailureRateLimiter[string](*retryIntervalStart, *retryIntervalMax),
 	)
 
@@ -373,4 +399,21 @@ func supportsGroupControllerCreateVolumeGroupSnapshot(ctx context.Context, conn 
 	}
 
 	return capabilities[csi.GroupControllerServiceCapability_RPC_CREATE_DELETE_GET_VOLUME_GROUP_SNAPSHOT], nil
+}
+
+// ensureVolumeGroupSnapshotCRDsExist checks that the VolumeGroupSnapshot v1 CRDs used by
+// this sidecar (VolumeGroupSnapshotContent and VolumeGroupSnapshotClass) exist in the cluster.
+func ensureVolumeGroupSnapshotCRDsExist(ctx context.Context, client *clientset.Clientset) error {
+	// List calls should return faster with a limit of 1.
+	// We do not care about what is returned and just want to make sure the CRDs exist.
+	listOptions := v1.ListOptions{Limit: 1}
+
+	if _, err := client.GroupsnapshotV1().VolumeGroupSnapshotContents().List(ctx, listOptions); err != nil {
+		return err
+	}
+	if _, err := client.GroupsnapshotV1().VolumeGroupSnapshotClasses().List(ctx, listOptions); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/cmd/snapshot-controller/main.go
+++ b/cmd/snapshot-controller/main.go
@@ -52,6 +52,7 @@ import (
 	clientset "github.com/kubernetes-csi/external-snapshotter/client/v8/clientset/versioned"
 	snapshotscheme "github.com/kubernetes-csi/external-snapshotter/client/v8/clientset/versioned/scheme"
 	informers "github.com/kubernetes-csi/external-snapshotter/client/v8/informers/externalversions"
+	groupsnapshotinformers "github.com/kubernetes-csi/external-snapshotter/client/v8/informers/externalversions/volumegroupsnapshot/v1"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	coreinformers "k8s.io/client-go/informers"
 	utilflag "k8s.io/component-base/cli/flag"
@@ -90,53 +91,9 @@ var (
 
 var version = "unknown"
 
-// Checks that the VolumeSnapshot v1 CRDs exist. It will wait at most the duration specified by retryCRDIntervalMax
-func ensureCustomResourceDefinitionsExist(client *clientset.Clientset, enableVolumeGroupSnapshots bool) error {
-	condition := func(ctx context.Context) (bool, error) {
-		var err error
-		// List calls should return faster with a limit of 1.
-		// We do not care about what is returned and just want to make sure the CRDs exist.
-		listOptions := metav1.ListOptions{Limit: 1}
-
-		// scoping to an empty namespace makes `List` work across all namespaces
-		_, err = client.SnapshotV1().VolumeSnapshots("").List(ctx, listOptions)
-		if err != nil {
-			klog.Errorf("Failed to list v1 volumesnapshots with error=%+v", err)
-			return false, nil
-		}
-
-		_, err = client.SnapshotV1().VolumeSnapshotClasses().List(ctx, listOptions)
-		if err != nil {
-			klog.Errorf("Failed to list v1 volumesnapshotclasses with error=%+v", err)
-			return false, nil
-		}
-		_, err = client.SnapshotV1().VolumeSnapshotContents().List(ctx, listOptions)
-		if err != nil {
-			klog.Errorf("Failed to list v1 volumesnapshotcontents with error=%+v", err)
-			return false, nil
-		}
-		if enableVolumeGroupSnapshots {
-			_, err = client.GroupsnapshotV1().VolumeGroupSnapshots("").List(ctx, listOptions)
-			if err != nil {
-				klog.Errorf("Failed to list v1 volumegroupsnapshots with error=%+v", err)
-				return false, nil
-			}
-
-			_, err = client.GroupsnapshotV1().VolumeGroupSnapshotClasses().List(ctx, listOptions)
-			if err != nil {
-				klog.Errorf("Failed to list v1 volumegroupsnapshotclasses with error=%+v", err)
-				return false, nil
-			}
-			_, err = client.GroupsnapshotV1().VolumeGroupSnapshotContents().List(ctx, listOptions)
-			if err != nil {
-				klog.Errorf("Failed to list v1 volumegroupsnapshotcontents with error=%+v", err)
-				return false, nil
-			}
-		}
-
-		return true, nil
-	}
-
+// waitForCRDCondition polls condition with an exponential backoff, waiting at
+// most the duration specified by retryCRDIntervalMax.
+func waitForCRDCondition(condition wait.ConditionWithContextFunc) error {
 	const retryFactor = 1.5
 	const initialDuration = 100 * time.Millisecond
 	backoff := wait.Backoff{
@@ -149,11 +106,56 @@ func ensureCustomResourceDefinitionsExist(client *clientset.Clientset, enableVol
 	maxBackoffDuration := max(*retryCRDIntervalMax, 1*time.Second)
 	ctx, cancel := context.WithTimeout(context.Background(), maxBackoffDuration)
 	defer cancel()
-	if err := wait.ExponentialBackoffWithContext(ctx, backoff, condition); err != nil {
-		return err
-	}
+	return wait.ExponentialBackoffWithContext(ctx, backoff, condition)
+}
 
-	return nil
+// ensureCustomResourceDefinitionsExist checks that the VolumeSnapshot v1 CRDs exist.
+// It will wait at most the duration specified by retryCRDIntervalMax.
+func ensureCustomResourceDefinitionsExist(client *clientset.Clientset) error {
+	return waitForCRDCondition(func(ctx context.Context) (bool, error) {
+		// List calls should return faster with a limit of 1.
+		// We do not care about what is returned and just want to make sure the CRDs exist.
+		listOptions := metav1.ListOptions{Limit: 1}
+
+		// scoping to an empty namespace makes `List` work across all namespaces
+		if _, err := client.SnapshotV1().VolumeSnapshots("").List(ctx, listOptions); err != nil {
+			klog.Errorf("Failed to list v1 volumesnapshots with error=%+v", err)
+			return false, nil
+		}
+		if _, err := client.SnapshotV1().VolumeSnapshotClasses().List(ctx, listOptions); err != nil {
+			klog.Errorf("Failed to list v1 volumesnapshotclasses with error=%+v", err)
+			return false, nil
+		}
+		if _, err := client.SnapshotV1().VolumeSnapshotContents().List(ctx, listOptions); err != nil {
+			klog.Errorf("Failed to list v1 volumesnapshotcontents with error=%+v", err)
+			return false, nil
+		}
+
+		return true, nil
+	})
+}
+
+// ensureVolumeGroupSnapshotCRDsExist checks that the VolumeGroupSnapshot v1 CRDs exist.
+// It will wait at most the duration specified by retryCRDIntervalMax.
+func ensureVolumeGroupSnapshotCRDsExist(client *clientset.Clientset) error {
+	return waitForCRDCondition(func(ctx context.Context) (bool, error) {
+		listOptions := metav1.ListOptions{Limit: 1}
+
+		if _, err := client.GroupsnapshotV1().VolumeGroupSnapshots("").List(ctx, listOptions); err != nil {
+			klog.Errorf("Failed to list v1 volumegroupsnapshots with error=%+v", err)
+			return false, nil
+		}
+		if _, err := client.GroupsnapshotV1().VolumeGroupSnapshotClasses().List(ctx, listOptions); err != nil {
+			klog.Errorf("Failed to list v1 volumegroupsnapshotclasses with error=%+v", err)
+			return false, nil
+		}
+		if _, err := client.GroupsnapshotV1().VolumeGroupSnapshotContents().List(ctx, listOptions); err != nil {
+			klog.Errorf("Failed to list v1 volumegroupsnapshotcontents with error=%+v", err)
+			return false, nil
+		}
+
+		return true, nil
+	})
 }
 
 func main() {
@@ -230,6 +232,36 @@ func main() {
 	// Add Snapshot types to the default Kubernetes so events can be logged for them
 	snapshotscheme.AddToScheme(scheme.Scheme)
 
+	if err := ensureCustomResourceDefinitionsExist(snapClient); err != nil {
+		klog.Errorf("Exiting due to failure to ensure CRDs exist during startup: %+v", err)
+		os.Exit(1)
+	}
+
+	// The VolumeGroupSnapshot feature is GA and enabled by default. Clusters
+	// upgrading the snapshot controller may not have the VolumeGroupSnapshot
+	// CRDs installed, and once the feature gate is removed in a future
+	// release there will be no way to opt out of this check by disabling the
+	// gate. So regardless of whether the gate is on by default or was
+	// explicitly requested, treat missing CRDs as non-fatal: log a warning
+	// and continue running with volume group snapshot support disabled.
+	enableVolumeGroupSnapshots := utilfeature.DefaultFeatureGate.Enabled(features.VolumeGroupSnapshot)
+	if enableVolumeGroupSnapshots {
+		if err := ensureVolumeGroupSnapshotCRDsExist(snapClient); err != nil {
+			klog.Warningf("VolumeGroupSnapshot CRDs were not found; disabling the VolumeGroupSnapshot feature for this run. "+
+				"Install the VolumeGroupSnapshot CRDs to use this feature: %v", err)
+			enableVolumeGroupSnapshots = false
+		}
+	}
+
+	var volumeGroupSnapshotInformer groupsnapshotinformers.VolumeGroupSnapshotInformer
+	var volumeGroupSnapshotContentInformer groupsnapshotinformers.VolumeGroupSnapshotContentInformer
+	var volumeGroupSnapshotClassInformer groupsnapshotinformers.VolumeGroupSnapshotClassInformer
+	if enableVolumeGroupSnapshots {
+		volumeGroupSnapshotInformer = factory.Groupsnapshot().V1().VolumeGroupSnapshots()
+		volumeGroupSnapshotContentInformer = factory.Groupsnapshot().V1().VolumeGroupSnapshotContents()
+		volumeGroupSnapshotClassInformer = factory.Groupsnapshot().V1().VolumeGroupSnapshotClasses()
+	}
+
 	klog.V(2).Infof("Start NewCSISnapshotController with kubeconfig [%s] resyncPeriod [%+v]", *kubeconfig, *resyncPeriod)
 
 	ctrl := controller.NewCSISnapshotCommonController(
@@ -238,9 +270,9 @@ func main() {
 		factory.Snapshot().V1().VolumeSnapshots(),
 		factory.Snapshot().V1().VolumeSnapshotContents(),
 		factory.Snapshot().V1().VolumeSnapshotClasses(),
-		factory.Groupsnapshot().V1().VolumeGroupSnapshots(),
-		factory.Groupsnapshot().V1().VolumeGroupSnapshotContents(),
-		factory.Groupsnapshot().V1().VolumeGroupSnapshotClasses(),
+		volumeGroupSnapshotInformer,
+		volumeGroupSnapshotContentInformer,
+		volumeGroupSnapshotClassInformer,
 		coreFactory.Core().V1().PersistentVolumeClaims(),
 		coreFactory.Core().V1().PersistentVolumes(),
 		nodeInformer,
@@ -252,13 +284,8 @@ func main() {
 		workqueue.NewTypedItemExponentialFailureRateLimiter[string](*retryIntervalStart, *retryIntervalMax),
 		*enableDistributedSnapshotting,
 		*preventVolumeModeConversion,
-		utilfeature.DefaultFeatureGate.Enabled(features.VolumeGroupSnapshot),
+		enableVolumeGroupSnapshots,
 	)
-
-	if err := ensureCustomResourceDefinitionsExist(snapClient, utilfeature.DefaultFeatureGate.Enabled(features.VolumeGroupSnapshot)); err != nil {
-		klog.Errorf("Exiting due to failure to ensure CRDs exist during startup: %+v", err)
-		os.Exit(1)
-	}
 
 	ctx := context.Background()
 

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -39,6 +39,6 @@ func init() {
 // defaultKubernetesFeatureGates consists of all known feature keys specific to external-snapshotter.
 // To add a new feature, define a key for it above and add it here.
 var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	VolumeGroupSnapshot:         {Default: false, PreRelease: featuregate.Beta},
+	VolumeGroupSnapshot:         {Default: true, PreRelease: featuregate.GA},
 	ReleaseLeaderElectionOnExit: {Default: false, PreRelease: featuregate.Alpha},
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR enables CSIVolumeGroupSnapshot feature gate to true by default.
(1) Made changes so if feature gate is not set all (default) and if CRD not installed, a warning message will be logged but no failure (VGS feature will be disabled).
(2) If feature gate is set to true and if CRD not installed, a warning message will be logged but no failure (same as if VGS feature is disabled).
(3) If feature gate is set to false, then CRD won’t be required and no warning msg.

- Enable feature gate but don't remove the feature gate in this release.
- In the next release, the feature gate will be deleted.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Enable CSIVolumeGroupSnapshot feature gate to true by default.
```
